### PR TITLE
Differentiate young generation marking.

### DIFF
--- a/src/hotspot/share/gc/shenandoah/shenandoahConcurrentMark.inline.hpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahConcurrentMark.inline.hpp
@@ -202,6 +202,7 @@ inline void ShenandoahConcurrentMark::do_chunked_array(ShenandoahObjToScanQueue*
   array->oop_iterate_range(cl, from, to);
 }
 
+template <GenerationMode GENERATION>
 class ShenandoahSATBBufferClosure : public SATBBufferClosure {
 private:
   ShenandoahObjToScanQueue* _queue;
@@ -228,12 +229,12 @@ public:
   void do_buffer_impl(void **buffer, size_t size) {
     for (size_t i = 0; i < size; ++i) {
       oop *p = (oop *) &buffer[i];
-      ShenandoahConcurrentMark::mark_through_ref<oop, NONE, STRING_DEDUP>(p, _heap, _queue, _mark_context, false);
+      ShenandoahConcurrentMark::mark_through_ref<oop, GENERATION, NONE, STRING_DEDUP>(p, _heap, _queue, _mark_context, false);
     }
   }
 };
 
-template<class T, UpdateRefsMode UPDATE_REFS, StringDedupMode STRING_DEDUP>
+template<class T, GenerationMode GENERATION, UpdateRefsMode UPDATE_REFS, StringDedupMode STRING_DEDUP>
 inline void ShenandoahConcurrentMark::mark_through_ref(T *p, ShenandoahHeap* heap, ShenandoahObjToScanQueue* q, ShenandoahMarkingContext* const mark_context, bool weak) {
   T o = RawAccess<>::oop_load(p);
   if (!CompressedOops::is_null(o)) {

--- a/src/hotspot/share/gc/shenandoah/shenandoahControlThread.hpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahControlThread.hpp
@@ -100,7 +100,7 @@ private:
   shenandoah_padding(2);
 
   bool check_cancellation_or_degen(ShenandoahHeap::ShenandoahDegenPoint point);
-  void service_concurrent_normal_cycle(GCCause::Cause cause);
+  void service_concurrent_normal_cycle(GCCause::Cause cause, ShenandoahGeneration* generation);
   void service_stw_full_cycle(GCCause::Cause cause);
   void service_stw_degenerated_cycle(GCCause::Cause cause, ShenandoahHeap::ShenandoahDegenPoint point);
   void service_uncommit(double shrink_before, size_t shrink_until);

--- a/src/hotspot/share/gc/shenandoah/shenandoahFreeSet.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahFreeSet.cpp
@@ -146,13 +146,13 @@ HeapWord* ShenandoahFreeSet::try_allocate_in(ShenandoahHeapRegion* r, Shenandoah
     return NULL;
   }
 
+  try_recycle_trashed(r);
+
   if (r->affiliation() == FREE) {
     r->set_affiliation(req.affiliation());
   } else if (r->affiliation() != req.affiliation()) {
     return NULL;
   }
-
-  try_recycle_trashed(r);
 
   in_new_region = r->is_empty();
 

--- a/src/hotspot/share/gc/shenandoah/shenandoahGlobalGeneration.hpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahGlobalGeneration.hpp
@@ -22,5 +22,16 @@
  *
  */
 
-#include "precompiled.hpp"
+#ifndef SHARE_VM_GC_SHENANDOAH_SHENANDOAHGLOBALGENERATION_HPP
+#define SHARE_VM_GC_SHENANDOAH_SHENANDOAHGLOBALGENERATION_HPP
+
 #include "gc/shenandoah/shenandoahGeneration.hpp"
+
+// A "generation" that represents the whole heap.
+class ShenandoahGlobalGeneration : public ShenandoahGeneration {
+public:
+  ShenandoahGlobalGeneration() : ShenandoahGeneration(GLOBAL) { }
+};
+
+#endif // SHARE_VM_GC_SHENANDOAH_SHENANDOAHGLOBALGENERATION_HPP
+

--- a/src/hotspot/share/gc/shenandoah/shenandoahHeap.hpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahHeap.hpp
@@ -46,6 +46,7 @@ class ShenandoahCollectorPolicy;
 class ShenandoahControlThread;
 class ShenandoahGCSession;
 class ShenandoahGCStateResetter;
+class ShenandoahGeneration;
 class ShenandoahHeuristics;
 class ShenandoahMarkingContext;
 class ShenandoahMarkCompact;
@@ -57,7 +58,6 @@ class ShenandoahHeapRegionClosure;
 class ShenandoahCollectionSet;
 class ShenandoahFreeSet;
 class ShenandoahConcurrentMark;
-class ShenandoahMarkCompact;
 class ShenandoahMonitoringSupport;
 class ShenandoahReferenceProcessor;
 class ShenandoahPacer;
@@ -370,8 +370,8 @@ public:
 public:
   // Entry points to STW GC operations, these cause a related safepoint, that then
   // call the entry method below
-  void vmop_entry_init_mark();
-  void vmop_entry_final_mark();
+  void vmop_entry_init_mark(ShenandoahGeneration* generation);
+  void vmop_entry_final_mark(ShenandoahGeneration* generation);
   void vmop_entry_init_updaterefs();
   void vmop_entry_final_updaterefs();
   void vmop_entry_full(GCCause::Cause cause);
@@ -379,8 +379,8 @@ public:
 
   // Entry methods to normally STW GC operations. These set up logging, monitoring
   // and workers for net VM operation
-  void entry_init_mark();
-  void entry_final_mark();
+  void entry_init_mark(ShenandoahGeneration* generation);
+  void entry_final_mark(ShenandoahGeneration* generation);
   void entry_init_updaterefs();
   void entry_final_updaterefs();
   void entry_full(GCCause::Cause cause);
@@ -389,7 +389,7 @@ public:
   // Entry methods to normally concurrent GC operations. These set up logging, monitoring
   // for concurrent operation.
   void entry_reset();
-  void entry_mark();
+  void entry_mark(ShenandoahGeneration* generation);
   void entry_weak_refs();
   void entry_weak_roots();
   void entry_class_unloading();
@@ -404,8 +404,8 @@ public:
 
 private:
   // Actual work for the phases
-  void op_init_mark();
-  void op_final_mark();
+  void op_init_mark(ShenandoahGeneration* generation);
+  void op_final_mark(ShenandoahGeneration* generation);
   void op_init_updaterefs();
   void op_final_updaterefs();
   void op_full(GCCause::Cause cause);
@@ -414,7 +414,7 @@ private:
   void op_degenerated_futile();
 
   void op_reset();
-  void op_mark();
+  void op_mark(ShenandoahGeneration* generation);
   void op_weak_refs();
   void op_weak_roots();
   void op_class_unloading();
@@ -440,12 +440,13 @@ private:
 // ---------- GC subsystems
 //
 private:
+  ShenandoahGeneration*      _young_generation;
+  ShenandoahGeneration*      _global_generation;
   ShenandoahControlThread*   _control_thread;
   ShenandoahCollectorPolicy* _shenandoah_policy;
   ShenandoahMode*            _gc_mode;
   ShenandoahHeuristics*      _heuristics;
   ShenandoahFreeSet*         _free_set;
-  ShenandoahConcurrentMark*  _scm;
   ShenandoahMarkCompact*     _full_gc;
   ShenandoahPacer*           _pacer;
   ShenandoahVerifier*        _verifier;
@@ -456,11 +457,12 @@ private:
   ShenandoahMarkCompact*     full_gc()                 { return _full_gc;           }
 
 public:
+  ShenandoahGeneration*      young_generation()  const { return _young_generation;  }
+  ShenandoahGeneration*      global_generation() const { return _global_generation; }
   ShenandoahCollectorPolicy* shenandoah_policy() const { return _shenandoah_policy; }
   ShenandoahMode*            mode()              const { return _gc_mode;           }
   ShenandoahHeuristics*      heuristics()        const { return _heuristics;        }
   ShenandoahFreeSet*         free_set()          const { return _free_set;          }
-  ShenandoahConcurrentMark*  concurrent_mark()         { return _scm;               }
   ShenandoahPacer*           pacer()             const { return _pacer;             }
 
   ShenandoahPhaseTimings*    phase_timings()     const { return _phase_timings;     }
@@ -518,8 +520,10 @@ private:
 
   // Prepare concurrent root processing
   void prepare_concurrent_roots();
+
   // Prepare and finish concurrent unloading
   void prepare_concurrent_unloading();
+
   void finish_concurrent_unloading();
   // Heap iteration support
   void scan_roots_for_iteration(ShenandoahScanObjectStack* oop_stack, ObjectIterateScanRootClosure* oops);
@@ -668,6 +672,7 @@ public:
 
 // ---------- Evacuation support
 //
+
 private:
   ShenandoahCollectionSet* _collection_set;
   ShenandoahEvacOOMHandler _oom_evac_handler;
@@ -722,6 +727,7 @@ private:
 
 // ---------- Testing helpers functions
 //
+
 private:
   ShenandoahSharedFlag _inject_alloc_failure;
 

--- a/src/hotspot/share/gc/shenandoah/shenandoahHeap.hpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahHeap.hpp
@@ -520,10 +520,8 @@ private:
 
   // Prepare concurrent root processing
   void prepare_concurrent_roots();
-
   // Prepare and finish concurrent unloading
   void prepare_concurrent_unloading();
-
   void finish_concurrent_unloading();
   // Heap iteration support
   void scan_roots_for_iteration(ShenandoahScanObjectStack* oop_stack, ObjectIterateScanRootClosure* oops);
@@ -672,7 +670,6 @@ public:
 
 // ---------- Evacuation support
 //
-
 private:
   ShenandoahCollectionSet* _collection_set;
   ShenandoahEvacOOMHandler _oom_evac_handler;
@@ -727,7 +724,6 @@ private:
 
 // ---------- Testing helpers functions
 //
-
 private:
   ShenandoahSharedFlag _inject_alloc_failure;
 

--- a/src/hotspot/share/gc/shenandoah/shenandoahMarkCompact.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahMarkCompact.cpp
@@ -32,6 +32,7 @@
 #include "gc/shenandoah/shenandoahConcurrentRoots.hpp"
 #include "gc/shenandoah/shenandoahCollectionSet.hpp"
 #include "gc/shenandoah/shenandoahFreeSet.hpp"
+#include "gc/shenandoah/shenandoahGeneration.hpp"
 #include "gc/shenandoah/shenandoahPhaseTimings.hpp"
 #include "gc/shenandoah/shenandoahMarkCompact.hpp"
 #include "gc/shenandoah/shenandoahHeapRegionSet.hpp"
@@ -114,14 +115,14 @@ void ShenandoahMarkCompact::do_it(GCCause::Cause gc_cause) {
 
     // b. Cancel concurrent mark, if in progress
     if (heap->is_concurrent_mark_in_progress()) {
-      heap->concurrent_mark()->cancel();
+      heap->global_generation()->concurrent_mark()->cancel();
       heap->set_concurrent_mark_in_progress(false);
     }
     assert(!heap->is_concurrent_mark_in_progress(), "sanity");
 
     // c. Update roots if this full GC is due to evac-oom, which may carry from-space pointers in roots.
     if (has_forwarded_objects) {
-      heap->concurrent_mark()->update_roots(ShenandoahPhaseTimings::full_gc_update_roots);
+      heap->global_generation()->concurrent_mark()->update_roots(ShenandoahPhaseTimings::full_gc_update_roots);
     }
 
     // d. Reset the bitmaps for new marking
@@ -238,7 +239,7 @@ void ShenandoahMarkCompact::phase1_mark_heap() {
   ShenandoahPrepareForMarkClosure cl;
   heap->heap_region_iterate(&cl);
 
-  ShenandoahConcurrentMark* cm = heap->concurrent_mark();
+  ShenandoahConcurrentMark* cm = heap->global_generation()->concurrent_mark();
 
   heap->set_unload_classes(heap->heuristics()->can_unload_classes());
 

--- a/src/hotspot/share/gc/shenandoah/shenandoahOopClosures.hpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahOopClosures.hpp
@@ -32,6 +32,11 @@
 #include "memory/iterator.hpp"
 #include "runtime/thread.hpp"
 
+enum GenerationMode {
+  YOUNG,
+  GLOBAL
+};
+
 enum UpdateRefsMode {
   NONE,       // No reference updating
   RESOLVE,    // Only a resolve (no reference updating)
@@ -52,7 +57,7 @@ private:
   bool _weak;
 
 protected:
-  template <class T, UpdateRefsMode UPDATE_MODE, StringDedupMode STRING_DEDUP>
+  template <class T, GenerationMode GENERATION, UpdateRefsMode UPDATE_MODE, StringDedupMode STRING_DEDUP>
   void work(T *p);
 
 public:
@@ -67,10 +72,11 @@ public:
   }
 };
 
+template <GenerationMode GENERATION>
 class ShenandoahMarkUpdateRefsClosure : public ShenandoahMarkRefsSuperClosure {
 private:
   template <class T>
-  inline void do_oop_work(T* p)     { work<T, CONCURRENT, NO_DEDUP>(p); }
+  inline void do_oop_work(T* p)     { work<T, GENERATION, CONCURRENT, NO_DEDUP>(p); }
 
 public:
   ShenandoahMarkUpdateRefsClosure(ShenandoahObjToScanQueue* q, ShenandoahReferenceProcessor* rp) :
@@ -81,10 +87,11 @@ public:
   virtual bool do_metadata()        { return false; }
 };
 
+template <GenerationMode GENERATION>
 class ShenandoahMarkUpdateRefsDedupClosure : public ShenandoahMarkRefsSuperClosure {
 private:
   template <class T>
-  inline void do_oop_work(T* p)     { work<T, CONCURRENT, ENQUEUE_DEDUP>(p); }
+  inline void do_oop_work(T* p)     { work<T, GENERATION, CONCURRENT, ENQUEUE_DEDUP>(p); }
 
 public:
   ShenandoahMarkUpdateRefsDedupClosure(ShenandoahObjToScanQueue* q, ShenandoahReferenceProcessor* rp) :
@@ -95,10 +102,11 @@ public:
   virtual bool do_metadata()        { return false; }
 };
 
+template <GenerationMode GENERATION>
 class ShenandoahMarkUpdateRefsMetadataClosure : public ShenandoahMarkRefsSuperClosure {
 private:
   template <class T>
-  inline void do_oop_work(T* p)     { work<T, CONCURRENT, NO_DEDUP>(p); }
+  inline void do_oop_work(T* p)     { work<T, GENERATION, CONCURRENT, NO_DEDUP>(p); }
 
 public:
   ShenandoahMarkUpdateRefsMetadataClosure(ShenandoahObjToScanQueue* q, ShenandoahReferenceProcessor* rp) :
@@ -109,10 +117,11 @@ public:
   virtual bool do_metadata()        { return true; }
 };
 
+template <GenerationMode GENERATION>
 class ShenandoahMarkUpdateRefsMetadataDedupClosure : public ShenandoahMarkRefsSuperClosure {
 private:
   template <class T>
-  inline void do_oop_work(T* p)     { work<T, CONCURRENT, ENQUEUE_DEDUP>(p); }
+  inline void do_oop_work(T* p)     { work<T, GENERATION, CONCURRENT, ENQUEUE_DEDUP>(p); }
 
 public:
   ShenandoahMarkUpdateRefsMetadataDedupClosure(ShenandoahObjToScanQueue* q, ShenandoahReferenceProcessor* rp) :
@@ -123,10 +132,11 @@ public:
   virtual bool do_metadata()        { return true; }
 };
 
+template <GenerationMode GENERATION>
 class ShenandoahMarkRefsClosure : public ShenandoahMarkRefsSuperClosure {
 private:
   template <class T>
-  inline void do_oop_work(T* p)     { work<T, NONE, NO_DEDUP>(p); }
+  inline void do_oop_work(T* p)     { work<T, GENERATION, NONE, NO_DEDUP>(p); }
 
 public:
   ShenandoahMarkRefsClosure(ShenandoahObjToScanQueue* q, ShenandoahReferenceProcessor* rp) :
@@ -137,10 +147,11 @@ public:
   virtual bool do_metadata()        { return false; }
 };
 
+template <GenerationMode GENERATION>
 class ShenandoahMarkRefsDedupClosure : public ShenandoahMarkRefsSuperClosure {
 private:
   template <class T>
-  inline void do_oop_work(T* p)     { work<T, NONE, ENQUEUE_DEDUP>(p); }
+  inline void do_oop_work(T* p)     { work<T, GENERATION, NONE, ENQUEUE_DEDUP>(p); }
 
 public:
   ShenandoahMarkRefsDedupClosure(ShenandoahObjToScanQueue* q, ShenandoahReferenceProcessor* rp) :
@@ -151,10 +162,11 @@ public:
   virtual bool do_metadata()        { return false; }
 };
 
+template <GenerationMode GENERATION>
 class ShenandoahMarkResolveRefsClosure : public ShenandoahMarkRefsSuperClosure {
 private:
   template <class T>
-  inline void do_oop_work(T* p)     { work<T, RESOLVE, NO_DEDUP>(p); }
+  inline void do_oop_work(T* p)     { work<T, GENERATION, RESOLVE, NO_DEDUP>(p); }
 
 public:
   ShenandoahMarkResolveRefsClosure(ShenandoahObjToScanQueue* q, ShenandoahReferenceProcessor* rp) :
@@ -165,10 +177,11 @@ public:
   virtual bool do_metadata()        { return false; }
 };
 
+template <GenerationMode GENERATION>
 class ShenandoahMarkRefsMetadataClosure : public ShenandoahMarkRefsSuperClosure {
 private:
   template <class T>
-  inline void do_oop_work(T* p)     { work<T, NONE, NO_DEDUP>(p); }
+  inline void do_oop_work(T* p)     { work<T, GENERATION, NONE, NO_DEDUP>(p); }
 
 public:
   ShenandoahMarkRefsMetadataClosure(ShenandoahObjToScanQueue* q, ShenandoahReferenceProcessor* rp) :
@@ -179,10 +192,11 @@ public:
   virtual bool do_metadata()        { return true; }
 };
 
+template <GenerationMode GENERATION>
 class ShenandoahMarkRefsMetadataDedupClosure : public ShenandoahMarkRefsSuperClosure {
 private:
   template <class T>
-  inline void do_oop_work(T* p)     { work<T, NONE, ENQUEUE_DEDUP>(p); }
+  inline void do_oop_work(T* p)     { work<T, GENERATION, NONE, ENQUEUE_DEDUP>(p); }
 
 public:
   ShenandoahMarkRefsMetadataDedupClosure(ShenandoahObjToScanQueue* q, ShenandoahReferenceProcessor* rp) :

--- a/src/hotspot/share/gc/shenandoah/shenandoahOopClosures.inline.hpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahOopClosures.inline.hpp
@@ -27,10 +27,11 @@
 
 #include "gc/shenandoah/shenandoahHeap.inline.hpp"
 #include "gc/shenandoah/shenandoahConcurrentMark.inline.hpp"
+#include "gc/shenandoah/shenandoahGeneration.hpp"
 
-template<class T, UpdateRefsMode UPDATE_REFS, StringDedupMode STRING_DEDUP>
+template<class T, GenerationMode GENERATION, UpdateRefsMode UPDATE_REFS, StringDedupMode STRING_DEDUP>
 inline void ShenandoahMarkRefsSuperClosure::work(T *p) {
-  ShenandoahConcurrentMark::mark_through_ref<T, UPDATE_REFS, STRING_DEDUP>(p, _heap, _queue, _mark_context, _weak);
+  ShenandoahConcurrentMark::mark_through_ref<T, GENERATION, UPDATE_REFS, STRING_DEDUP>(p, _heap, _queue, _mark_context, _weak);
 }
 
 template <class T>

--- a/src/hotspot/share/gc/shenandoah/shenandoahVMOperations.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahVMOperations.cpp
@@ -25,6 +25,7 @@
 #include "precompiled.hpp"
 
 #include "gc/shenandoah/shenandoahHeap.inline.hpp"
+#include "gc/shenandoah/shenandoahGeneration.hpp"
 #include "gc/shenandoah/shenandoahUtils.hpp"
 #include "gc/shenandoah/shenandoahVMOperations.hpp"
 #include "memory/universe.hpp"
@@ -43,12 +44,12 @@ void VM_ShenandoahReferenceOperation::doit_epilogue() {
 
 void VM_ShenandoahInitMark::doit() {
   ShenandoahGCPauseMark mark(_gc_id, SvcGCMarker::CONCURRENT);
-  ShenandoahHeap::heap()->entry_init_mark();
+  ShenandoahHeap::heap()->entry_init_mark(_generation);
 }
 
 void VM_ShenandoahFinalMarkStartEvac::doit() {
   ShenandoahGCPauseMark mark(_gc_id, SvcGCMarker::CONCURRENT);
-  ShenandoahHeap::heap()->entry_final_mark();
+  ShenandoahHeap::heap()->entry_final_mark(_generation);
 }
 
 void VM_ShenandoahFullGC::doit() {

--- a/src/hotspot/share/gc/shenandoah/shenandoahVMOperations.hpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahVMOperations.hpp
@@ -52,16 +52,20 @@ public:
 };
 
 class VM_ShenandoahInitMark: public VM_ShenandoahOperation {
+private:
+  ShenandoahGeneration* _generation;
 public:
-  VM_ShenandoahInitMark() : VM_ShenandoahOperation() {};
+  VM_ShenandoahInitMark(ShenandoahGeneration* generation) : VM_ShenandoahOperation(), _generation(generation) {};
   VM_Operation::VMOp_Type type() const { return VMOp_ShenandoahInitMark; }
   const char* name()             const { return "Shenandoah Init Marking"; }
   virtual void doit();
 };
 
 class VM_ShenandoahFinalMarkStartEvac: public VM_ShenandoahOperation {
+private:
+  ShenandoahGeneration* _generation;
 public:
-  VM_ShenandoahFinalMarkStartEvac() : VM_ShenandoahOperation() {};
+  VM_ShenandoahFinalMarkStartEvac(ShenandoahGeneration* generation) : VM_ShenandoahOperation(), _generation(generation) {};
   VM_Operation::VMOp_Type type() const { return VMOp_ShenandoahFinalMarkStartEvac; }
   const char* name()             const { return "Shenandoah Final Mark and Start Evacuation"; }
   virtual  void doit();

--- a/src/hotspot/share/gc/shenandoah/shenandoahYoungGeneration.hpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahYoungGeneration.hpp
@@ -22,25 +22,14 @@
  *
  */
 
-#ifndef SHARE_VM_GC_SHENANDOAH_SHENANDOAHGENERATION_HPP
-#define SHARE_VM_GC_SHENANDOAH_SHENANDOAHGENERATION_HPP
+#ifndef SHARE_VM_GC_SHENANDOAH_SHENANDOAHYOUNGGENERATION_HPP
+#define SHARE_VM_GC_SHENANDOAH_SHENANDOAHYOUNGGENERATION_HPP
 
-#include "memory/allocation.hpp"
-#include "gc/shenandoah/shenandoahConcurrentMark.hpp"
+#include "gc/shenandoah/shenandoahGeneration.hpp"
 
-class ShenandoahGeneration : public CHeapObj<mtGC> {
-private:
-  GenerationMode const _generation_mode;
-  ShenandoahConcurrentMark* const _scm;
+class ShenandoahYoungGeneration : public ShenandoahGeneration {
 public:
-  ShenandoahGeneration(GenerationMode generation_mode) :
-    _generation_mode(generation_mode),
-    _scm(new ShenandoahConcurrentMark(generation_mode)) {
-  }
-
-  inline GenerationMode generation_mode() const { return _generation_mode; }
-
-  inline ShenandoahConcurrentMark* concurrent_mark() const { return _scm; }
+  ShenandoahYoungGeneration() : ShenandoahGeneration(YOUNG) { }
 };
 
-#endif // SHARE_VM_GC_SHENANDOAH_SHENANDOAHGENERATION_HPP
+#endif // SHARE_VM_GC_SHENANDOAH_SHENANDOAHYOUNGGENERATION_HPP


### PR DESCRIPTION
This change is large to achieve uninterrupted functionality for single-generational Shenandoah while planting code that differentiates two distinct generations and concurrent marking for the young generation.

Where necessary we use templates to not impose runtime overhead. In code sections that are not runtime-critical we use conditions and switches over an enum that indicates which generational collection mode we are in (young or global).

We temporarily make all collections in generational mode young collections. Global and old collections will come later.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

### Reviewers
 * [Roman Kennke](https://openjdk.java.net/census#rkennke) (@rkennke - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/shenandoah pull/8/head:pull/8`
`$ git checkout pull/8`
