### PR TITLE
Marking and evacuation constrained to young gen in generational mode.

### DIFF
--- a/src/hotspot/share/gc/shenandoah/heuristics/shenandoahHeuristics.cpp
+++ b/src/hotspot/share/gc/shenandoah/heuristics/shenandoahHeuristics.cpp
@@ -96,6 +96,9 @@ void ShenandoahHeuristics::choose_collection_set(ShenandoahCollectionSet* collec
 
   for (size_t i = 0; i < num_regions; i++) {
     ShenandoahHeapRegion* region = heap->get_region(i);
+    if (heap->mode()->is_generational() && region->affiliation() != ShenandoahRegionAffiliation::YOUNG_GENERATION) {
+      continue;
+    }
 
     size_t garbage = region->garbage();
     total_garbage += garbage;

--- a/src/hotspot/share/gc/shenandoah/shenandoahFreeSet.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahFreeSet.cpp
@@ -311,6 +311,7 @@ HeapWord* ShenandoahFreeSet::allocate_contiguous(ShenandoahAllocRequest& req) {
     }
 
     r->set_top(r->bottom() + used_words);
+    r->set_affiliation(req.affiliation());
 
     _mutator_free_bitmap.clear_bit(r->index());
   }


### PR DESCRIPTION
These restrictions will change when we have multiple generations at work. For GenShen milestone 1 we want to operate entirely in the young generation, to prove our changes function thus far.

The second commit adds the missing generation affiliation for contiguous allocations, i.e. humongous object regions.

This step still runs normally when in any non-generational mode, and it runs at reduced heap capacity in generational mode. Only the young generation is populated in the latter case.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

### Reviewers
 * [Roman Kennke](https://openjdk.java.net/census#rkennke) (@rkennke - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/shenandoah pull/9/head:pull/9`
`$ git checkout pull/9`
