### PR TITLE
Scan remembered

### DIFF
--- a/src/hotspot/share/gc/shenandoah/shenandoahBufferWithSATBRememberedSet.hpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahBufferWithSATBRememberedSet.hpp
@@ -1,0 +1,103 @@
+//
+// The anticipated benefits of an alternative SATB-based implementation of the remembered set are several fold:
+//
+//  1. The representation of remembered set is more concise (1 bit per card) and there is no remembered set maintenance
+//     required for ShenandoahHeapRegions that correspond to young-gen memory.  Besides requiring less memory overall,
+//     additional benefits of the more concise remembered set representation are improved cache hit rates and more efficient
+//     scanning and maintenance of remembered set information by GC threads.
+//  2. While the mutator overhead is similar between the modified SATB barrier mechanism and direct card marking, the
+//     SATB mechanism offers the potential of improved accuracy within the remembered set.  This is because direct card
+//     marking unconditionally marks every old-gen page that is overwritten with a pointer value, even when the new pointer
+//     value might refer to old-gen memory.  With the modified SATB mechanism, background GC threads process the addresses
+//     logged within the SATB buffer and mark cards as dirty only if the pointer found at an overwritten old-gen address
+//     refers to young-gen memory.  There are (at least) two options here:
+//
+//      a) Just blindly dirty each card that is overwritten with a pointer value, regardless of the written value, as with
+//         the implementation of traditional direct card marking.  When this card's memory region is eventually scanned, the
+//         the implementation of remembered set scanning will clear the page if it no longer holds references to young-gen
+//         memory.
+//      b) When the thread-local SATB becomes full, the thread examines the content of each overwritten address and only
+//         forwards the address to be marked as dirty if the address holds a young-gen reference.  Presumably, the value
+//         just recently written by this same thread will be available in the L1 cache and fetching this single reference
+//         "now" is more efficient than reading the entire card's memory at remembered set scanning time only to discover
+//         then that the card represents no references to young-gen memory.
+//
+//     Experiments with each approach may help decide between approaches.
+//
+//  3. Potentially, the incremental overhead of adding remembered set logging to the existing SATB barrier is lower than
+//     the incremental overhead of adding an independent and distinct new write barrier for card marking.  This is especially
+//     true during times that the SATB barrier is already enabled (which might represent 30-50% of execution for GC-intensive
+//     workloads).  It may even be true during times that the SATB is disabled.  This is because even when the SATB is disabled,
+//     register allocation is constrained by the reality that SATB will be enabled some of the time, so registers allocated for
+//     SATB-buffer maintenance will sit idle during times when the SATB barrier is disabled.  In tight loops that write pointer
+//     values, for example, the SATB implementation might dedicate registers to holding thread-local information associated with
+//     maintenance of the SATB buffer such as the address of the SATB buffer and the next available buffer slot within this buffer.
+//     In the traditional card-marking remembered set implementation, an additional register might be dedicated to holding a
+//     reference to the base of the card table.
+//
+// Note that a ShenandoahBufferWithSATBRememberedSet maintains the remembered set only for memory regions that correspond to
+// old-generation memory.  Anticipate that the implementation will use double indirection.
+//
+// To Do:
+//
+//  1. Figure out which region an old-gen address belongs to
+//  2. Find the cluster and card numbers that corresponds to that region
+//
+// Old-gen memory is not necessarily contiguous.  It may be comprised of multiple heap regions.
+//
+// The memory overhead for crossing map and card-table entries is given by the following analysis:
+//   For each 512-byte card-entry span, we have the following overhead:
+//    2 bytes for the object_starts map
+//    1 bit for the card-table entry
+//  =====
+//    2 bytes (rounded down) out of 512 bytes is 0.39% bookkeeping overhead
+
+
+// ShenandoahBufferWithSATBRememberedSet is not implemented correctly in its current form.
+//
+// This class is a placeholder to support a possible future implementation of remembered set that uses a generalization of the
+// existing SATB pre-write barrier to maintain remembered set information rather than using unconditional direct card marking in
+// a post-write barrier.
+class ShenandoahBufferWithSATBRememberedSet: public CHeapObj<mtGC> {
+
+  // The current implementation is simply copied from the implementation of class ShenandoahDirectCardMarkRememberedSet
+
+  // Use symbolic constants defined in cardTable.hpp
+  //  CardTable::card_shift = 9;
+  //  CardTable::card_size = 512;
+  //  CardTable::card_size_in_words = 64;
+
+  //  CardTable::clean_card_val()
+  //  CardTable::dirty_card_val()
+
+  ShenandoahHeap *_heap;
+  uint32_t _card_shift;
+  size_t _card_count;
+  uint32_t _cluster_count;
+  HeapWord *_whole_heap_base;
+  HeapWord *_whole_heap_end;
+
+public:
+  ShenandoahBufferWithSATBRememberedSet(size_t card_count);
+  ~ShenandoahBufferWithSATBRememberedSet();
+
+  uint32_t card_index_for_addr(HeapWord *p);
+  HeapWord *addr_for_card_index(uint32_t card_index);
+  bool is_card_dirty(uint32_t card_index);
+  void mark_card_as_dirty(uint32_t card_index);
+  void mark_card_as_clean(uint32_t card_index);
+  void mark_overreach_card_as_dirty(uint32_t card_index);
+  bool is_card_dirty(HeapWord *p);
+  void mark_card_as_dirty(HeapWord *p);
+  void mark_card_as_clean(HeapWord *p);
+  void mark_overreach_card_as_dirty(void *p);
+  uint32_t cluster_count();
+
+  // Called by multiple GC threads at start of concurrent mark and/ evacuation phases.  Each parallel GC thread typically
+  // initializes a different subranges of all overreach entries.
+  void initialize_overreach(uint32_t first_cluster, uint32_t count);
+
+  // Called by GC thread at end of concurrent mark or evacuation phase./ Each parallel GC thread typically merges different
+  // subranges of all overreach entries.
+  void merge_overreach(uint32_t first_cluster, uint32_t count);
+};

--- a/src/hotspot/share/gc/shenandoah/shenandoahBufferWithSATBRememberedSet.inline.hpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahBufferWithSATBRememberedSet.inline.hpp
@@ -1,0 +1,52 @@
+
+// ShenandoahBufferWithSATBRemberedSet is not currently implemented
+
+inline uint32_t
+ShenandoahBufferWithSATBRememberedSet::card_index_for_addr(HeapWord *p) {
+  return 0;
+}
+
+inline HeapWord *
+ShenandoahBufferWithSATBRememberedSet::addr_for_card_index(uint32_t card_index) {
+  return NULL;
+}
+
+inline bool
+ShenandoahBufferWithSATBRememberedSet::is_card_dirty(uint32_t card_index) {
+  return false;
+}
+
+inline void
+ShenandoahBufferWithSATBRememberedSet::mark_card_as_dirty(uint32_t card_index) {
+}
+
+inline void
+ShenandoahBufferWithSATBRememberedSet::mark_card_as_clean(uint32_t card_index) {
+}
+
+inline void
+ShenandoahBufferWithSATBRememberedSet::mark_overreach_card_as_dirty(uint32_t card_index) {
+}
+
+inline bool
+ShenandoahBufferWithSATBRememberedSet::is_card_dirty(HeapWord *p) {
+  return false;
+}
+
+
+inline void
+ShenandoahBufferWithSATBRememberedSet::mark_card_as_dirty(HeapWord *p) {
+}
+
+inline void
+ShenandoahBufferWithSATBRememberedSet::mark_card_as_clean(HeapWord *p) {
+}
+
+inline void
+ShenandoahBufferWithSATBRememberedSet::mark_overreach_card_as_dirty(void *p) {
+}
+
+inline uint32_t
+ShenandoahBufferWithSATBRememberedSet::cluster_count() {
+  return 0;
+}

--- a/src/hotspot/share/gc/shenandoah/shenandoahHeap.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahHeap.cpp
@@ -33,6 +33,7 @@
 #include "gc/shared/memAllocator.hpp"
 #include "gc/shared/plab.hpp"
 
+#include "gc/shenandoah/shenandoahScanRemembered.hpp"
 #include "gc/shenandoah/shenandoahBarrierSet.hpp"
 #include "gc/shenandoah/shenandoahCardTable.hpp"
 #include "gc/shenandoah/shenandoahClosures.inline.hpp"
@@ -72,6 +73,8 @@
 #include "gc/shenandoah/mode/shenandoahIUMode.hpp"
 #include "gc/shenandoah/mode/shenandoahPassiveMode.hpp"
 #include "gc/shenandoah/mode/shenandoahSATBMode.hpp"
+#include "gc/shenandoah/shenandoahScanRemembered.inline.hpp"
+
 #if INCLUDE_JFR
 #include "gc/shenandoah/shenandoahJfrSupport.hpp"
 #endif
@@ -211,6 +214,12 @@ jint ShenandoahHeap::initialize() {
   //
   // After reserving the Java heap, create the card table, barriers, and workers, in dependency order
   //
+  if (mode()->is_generational()) {
+    ShenandoahDirectCardMarkRememberedSet *rs;
+    size_t card_count = ShenandoahBarrierSet::barrier_set()->card_table()->cards_required(heap_rs.size() / HeapWordSize) - 1;
+    rs = new ShenandoahDirectCardMarkRememberedSet(ShenandoahBarrierSet::barrier_set()->card_table(), card_count);
+    _card_scan = new ShenandoahScanRemembered<ShenandoahDirectCardMarkRememberedSet>(rs);
+  }
   BarrierSet::set_barrier_set(new ShenandoahBarrierSet(this, _heap_region));
 
   _workers = new ShenandoahWorkGang("Shenandoah GC Threads", _max_workers,
@@ -511,7 +520,8 @@ ShenandoahHeap::ShenandoahHeap(ShenandoahCollectorPolicy* policy) :
   _bitmap_region_special(false),
   _aux_bitmap_region_special(false),
   _liveness_cache(NULL),
-  _collection_set(NULL)
+  _collection_set(NULL),
+  _card_scan(NULL)
 {
 }
 
@@ -1146,6 +1156,7 @@ public:
     ShenandoahEvacOOMScope oom_evac_scope;
     ShenandoahEvacuateUpdateRootsClosure<> cl;
     MarkingCodeBlobClosure blobsCl(&cl, CodeBlobToOopClosure::FixRelocations);
+
     _rp->roots_do(worker_id, &cl);
   }
 };
@@ -2680,21 +2691,68 @@ public:
     if (_concurrent) {
       ShenandoahConcurrentWorkerSession worker_session(worker_id);
       ShenandoahSuspendibleThreadSetJoiner stsj(ShenandoahSuspendibleWorkers);
-      do_work();
+      do_work(worker_id);
     } else {
       ShenandoahParallelWorkerSession worker_session(worker_id);
-      do_work();
+      do_work(worker_id);
     }
   }
 
 private:
-  void do_work() {
+  void do_work(uint worker_id) {
     ShenandoahHeapRegion* r = _regions->next();
     ShenandoahMarkingContext* const ctx = _heap->complete_marking_context();
+
     while (r != NULL) {
       HeapWord* update_watermark = r->get_update_watermark();
       assert (update_watermark >= r->bottom(), "sanity");
-      if (r->is_active() && !r->is_cset()) {
+
+      // Eventually, scanning of old-gen memory regions for the purpose of updating references can happen
+      // concurrently.  This can be done during concurrent evacuation of roots for example.
+      if (r->is_active() && (r->affiliation() == ShenandoahRegionAffiliation::OLD_GENERATION) && !r->is_cset()) {
+
+        // Note that we use this code even if we are doing an old-gen collection and we have a bitmap to
+        // represent marked objects within the heap region.
+        //
+        // It is necessary to process all objects rather than just the marked objects during update-refs of
+        // an old-gen region as part of an old-gen collection.  Otherwise, a subseqent update-refs scan of
+        // the same region will see stale pointers and crash.
+        //
+        // Kelvin believes (but has not confirmed) the following:
+        //   r->top() represents the upper end of memory that has been allocated within this region.
+        //       As new objects are allocated, the value of r->top() increases to accomodate each new
+        //       object.
+        //   r->get_update_watermark() represents the value that was held in r->top() at the start of
+        //       evacuation.  During evacuation, new objects may be allocated within this heap region
+        //       and this will cause r->top() to increase.  But any objects allocated during the evacuation
+        //       phase do not need to be scanned by update-refs because the to-space invariant is in force
+        //       during evacuation and this will assure that any objects residing between
+        //       r->get_update_watermark() and r->top() hold no pointers to from-space.
+
+        HeapWord *p = r->bottom();
+        ShenandoahObjectToOopBoundedClosure<T> objs(&cl, p, update_watermark);
+
+        // TODO: This code assumes every object ever allocated within this old-gen region is still live.  If we
+        // allow a sweep phase to turn garbage objects into free memory regions, we need to modify this code to
+        // skip over and/or synchronize access to these free memory regions.  There might be races, for example,
+        // if we are trying to scan one of these free memory regions while a different thread is trying to
+        // allocate from within a free region.
+        //
+        // Reality is that this code is likely to be replaced with JVM-292 code before we ever get around to
+        // sweeping up garbage objects within old-gen memory.
+
+        // Anything beyond update_watermark is not yet allocated or initialized
+        while (p < update_watermark) {
+          oop obj = oop(p);
+
+          // The invocation of do_object() is "borrowed" from the implementation of
+          // ShenandoahHeap::marked_object_iterate(), which is called by _heap->marked_object_oop_iterate().
+          objs.do_object(obj);
+          p += obj->size();
+
+        }
+      }
+      else if (r->is_active() && !r->is_cset()) {
         _heap->marked_object_oop_iterate(r, &cl, update_watermark);
       }
       if (ShenandoahPacing) {

--- a/src/hotspot/share/gc/shenandoah/shenandoahHeap.hpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahHeap.hpp
@@ -35,7 +35,9 @@
 #include "gc/shenandoah/shenandoahPadding.hpp"
 #include "gc/shenandoah/shenandoahSharedVariables.hpp"
 #include "gc/shenandoah/shenandoahUnload.hpp"
+#include "gc/shenandoah/shenandoahScanRemembered.hpp"
 #include "memory/metaspace.hpp"
+#include "gc/shenandoah/shenandoahScanRemembered.hpp"
 #include "services/memoryManager.hpp"
 #include "utilities/globalDefinitions.hpp"
 #include "utilities/stack.hpp"
@@ -44,6 +46,7 @@ class ConcurrentGCTimer;
 class ObjectIterateScanRootClosure;
 class ShenandoahCollectorPolicy;
 class ShenandoahControlThread;
+class ShenandoahDirectCardMarkRememberedSet;
 class ShenandoahGCSession;
 class ShenandoahGCStateResetter;
 class ShenandoahGeneration;
@@ -64,6 +67,7 @@ class ShenandoahPacer;
 class ShenandoahVerifier;
 class ShenandoahWorkGang;
 class VMStructs;
+
 
 // Used for buffering per-region liveness data.
 // Needed since ShenandoahHeapRegion uses atomics to update liveness.
@@ -694,6 +698,15 @@ public:
   // Call before/after evacuation.
   inline void enter_evacuation(Thread* t);
   inline void leave_evacuation(Thread* t);
+
+// ---------- Generational support
+//
+private:
+  RememberedScanner* _card_scan;
+
+public:
+  inline RememberedScanner* card_scan() { return _card_scan; }
+
 
 // ---------- Helper functions
 //

--- a/src/hotspot/share/gc/shenandoah/shenandoahHeap.inline.hpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahHeap.inline.hpp
@@ -312,7 +312,13 @@ inline oop ShenandoahHeap::evacuate_object(oop p, Thread* thread) {
     // Successfully evacuated. Our copy is now the public one!
     shenandoah_assert_correct(NULL, copy_val);
 
-    // Increment age in young copies
+    // Hey!  This code showed up in a merge conflict.  It has "nothing" to do with the patch that
+    // was merged, so kdnilsen is leaving it in place as is.  However, it looks to me like the object's
+    // age should be incremented before the copy is committed to avoid the need for synchronization here.
+    //
+    // kdnilsen believes the following code is replaced/relocated in a subsequent commit.
+
+    // Increment age in young copies.
     if (target_gen == YOUNG_GENERATION) {
       copy_val->incr_age();
     }

--- a/src/hotspot/share/gc/shenandoah/shenandoahReferenceProcessor.hpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahReferenceProcessor.hpp
@@ -27,6 +27,7 @@
 #define SHARE_VM_GC_SHENANDOAH_SHENANDOAHREFERENCEPROCESSOR_HPP
 
 #include "gc/shared/referenceDiscoverer.hpp"
+#include "gc/shared/referencePolicy.hpp"
 #include "memory/allocation.hpp"
 
 class ShenandoahMarkRefsSuperClosure;

--- a/src/hotspot/share/gc/shenandoah/shenandoahScanRemembered.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahScanRemembered.cpp
@@ -48,7 +48,7 @@ ShenandoahDirectCardMarkRememberedSet::ShenandoahDirectCardMarkRememberedSet(Car
   _overreach_map = (uint8_t *) malloc(total_card_count);
   _overreach_map_base = (_overreach_map -
                          (uintptr_t(_whole_heap_base) >> _card_shift));
-      
+
   assert(total_card_count % ShenandoahCardCluster<ShenandoahDirectCardMarkRememberedSet>::CardsPerCluster == 0, "Invalid card count.");
   assert(total_card_count > 0, "Card count cannot be zero.");
   // assert(_overreach_cards != NULL);
@@ -96,7 +96,7 @@ ShenandoahBufferWithSATBRememberedSet::ShenandoahBufferWithSATBRememberedSet(siz
   _card_shift = CardTable::card_shift;
 
   _whole_heap_base = _heap->base();
-  _whole_heap_end = _whole_heap_base + _card_count * 
+  _whole_heap_end = _whole_heap_base + _card_count *
       ShenandoahCardCluster<ShenandoahBufferWithSATBRememberedSet>::CardsPerCluster;
 }
 

--- a/src/hotspot/share/gc/shenandoah/shenandoahScanRemembered.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahScanRemembered.cpp
@@ -1,0 +1,339 @@
+/*
+ * Copyright (c) Amazon.com, Inc. or its affiliates.  All rights reserved.
+ *
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ *
+ */
+
+#include "shenandoahScanRemembered.hpp"
+
+
+ShenandoahDirectCardMarkRememberedSet::ShenandoahDirectCardMarkRememberedSet(
+    CardTable *card_table, size_t count)
+{
+  _heap = ShenandoahHeap::heap();
+  _card_table = card_table;
+  _card_count = count;
+  _cluster_count = (
+      _card_count /
+      ShenandoahCardCluster<ShenandoahDirectCardMarkRememberedSet>::CardsPerCluster);
+  _card_shift = CardTable::card_shift;
+
+  _whole_heap_base = _card_table->addr_for(_byte_map);
+  _whole_heap_end = _card_table->addr_for(_byte_map + _card_count);
+
+
+  _byte_map = _card_table->byte_for_index(0);
+  _byte_map_base = _byte_map - (uintptr_t(_whole_heap_base) >> _card_shift);
+
+  _overreach_map = (uint8_t *) malloc(_card_count);
+  _overreach_map_base = (_overreach_map -
+			 (uintptr_t(_whole_heap_base) >> _card_shift));
+      
+  assert(_card_count % ShenandoahCardCluster::CardsPerCluster == 0);
+  assert(_card_count > 0);
+  assert(_overreach_cards != NULL);
+}
+
+ShenandoahDirectCardMarkRememberedSet::~ShenandoahDirectCardMarkRememberedSet()
+{
+  free(_overreach_map);
+}
+
+void ShenandoahDirectCardMarkRememberedSet::initializeOverreach(
+    uint32_t first_cluster, uint32_t count) {
+
+  // We can make this run faster in the future by explicitly
+  // unrolling the loop and doing wide writes if the compiler
+  // doesn't do this for us.
+  uint32_t first_card_no =
+      first_cluster * ShenandoahCardCluster<ShenandoahDirectCardMarkRememberedSet>::CardsPerCluster;
+  uint8_t *omp = &_overreach_map[first_card_no];
+  uint8_t *endp = omp + count * ShenandoahCardCluster<ShenandoahDirectCardMarkRememberedSet>::CardsPerCluster;
+  while (omp < endp)
+    *omp++ = CardTable::clean_card_val();
+}
+
+void ShenandoahDirectCardMarkRememberedSet::mergeOverreach(
+    uint32_t first_cluster, uint32_t count) {
+
+  // We can make this run faster in the future by explicitly
+  // unrolling the loop and doing wide writes if the compiler
+  // doesn't do this for us.
+    uint32_t first_card_no = (
+      first_cluster *
+      ShenandoahCardCluster<ShenandoahDirectCardMarkRememberedSet>::CardsPerCluster);
+  uint8_t *bmp = &_byte_map[first_card_no];
+  uint8_t *endp = bmp + count * ShenandoahCardCluster<ShenandoahDirectCardMarkRememberedSet>::CardsPerCluster;
+  uint8_t *omp = &_overreach_map[first_card_no];
+
+  // dirty_card is 0, clean card is 0xff
+  // if either *bmp or *omp is dirty, we need to mark it as dirty
+  while (bmp < endp)
+    *bmp++ &= *omp++;
+}
+
+
+/* Implementation is not correct.  ShenandoahBufferWithSATBRememberedSet
+ * is a placeholder for future planned improvements.
+ */
+ShenandoahBufferWithSATBRememberedSet::ShenandoahBufferWithSATBRememberedSet(
+    size_t card_count)
+{
+  _heap = ShenandoahHeap::heap();
+
+  _card_count = card_count;
+  _cluster_count = _card_count /
+      ShenandoahCardCluster<ShenandoahBufferWithSATBRememberedSet>::CardsPerCluster;
+  _card_shift = CardTable::card_shift;
+
+  _whole_heap_base = _heap->base();
+  _whole_heap_end = _whole_heap_base + _card_count * 
+      ShenandoahCardCluster<ShenandoahBufferWithSATBRememberedSet>::CardsPerCluster;
+
+}
+
+/* Implementation is not correct.  ShenandoahBufferWithSATBRememberedSet
+ * is a placeholder for future planned improvements.
+ */
+ShenandoahBufferWithSATBRememberedSet::~ShenandoahBufferWithSATBRememberedSet()
+{
+}
+
+/* Implementation is not correct.  ShenandoahBufferWithSATBRememberedSet
+ * is a placeholder for future planned improvements.
+ */
+void ShenandoahBufferWithSATBRememberedSet::initializeOverreach(
+    uint32_t first_cluster, uint32_t count) {
+}
+
+/* Implementation is not correct.  ShenandoahBufferWithSATBRememberedSet
+ * is a placeholder for future planned improvements.
+ */
+void ShenandoahBufferWithSATBRememberedSet::mergeOverreach(
+    uint32_t first_cluster, uint32_t count) {
+}
+
+#ifdef IMPLEMENT_THIS_OPTIMIZATION_LATER
+
+template <class RememberedSet>
+bool ShenandoahCardCluster<RememberedSet>::hasObject(uint32_t card_no) {
+  return (object_starts[card_no] & ObjectStartsInCardRegion)? true: false;
+}
+
+template <class RememberedSet>
+uint32_t ShenandoahCardCluster<RememberedSet>::getFirstStart(uint32_t card_no)
+{
+  assert(object_starts[card_no] & ObjectStartsInCardRegion);
+  return (((object_starts[card_no] & FirstStartBits) >> FirstStartShift) *
+	  CardWordOffsetMultiplier);
+}
+
+template <class RememberedSet>
+uint32_t ShenandoahCardCluster<RememberedSet>::getLastStart(uint32_t card_no) {
+  assert(object_starts[card_no] & ObjectStartsInCardRegion);
+  return (((object_starts[card_no] & LastStartBits) >> LastStartShift) *
+	  CardWordOffsetMultiplier);
+}
+
+template <class RememberedSet>
+uint8_t ShenandoahCardCluster<RememberedSet>::getCrossingObjectStart(
+    uint32_t card_no) {
+  assert((object_starts[card_no] & ObjectStartsInCardRegion) == 0);
+  return object_starts[card_no] * CardWordOffsetMultiplier;
+}
+
+#else
+
+// This implementation of services is slow but "sure" (in theory).
+// Significant performance improvement is planned, with not a huge
+// amount of further effort.
+
+template <class RememberedSet>
+bool ShenandoahCardCluster<RememberedSet>::hasObject(uint32_t card_no) {
+  HeapWord *addr = _rs->addrForCardNo(card_no);
+  ShenandoahHeap *heap = ShenandoahHeap::heap();
+  ShenandoahHeapRegion *region = heap->heap_region_containing(addr);
+  HeapWord *obj = region->block_start(addr);
+
+  assert(obj != NULL);
+  if (obj >= addr)
+    return true;
+  else {
+    HeapWord *end_addr = addr + CardTable::card_size_in_words;
+    obj += oop(obj)->size();
+    if (obj < end_addr)
+      return true;
+    else
+      return false;
+  }
+}
+
+template <class RememberedSet>
+uint32_t ShenandoahCardCluster<RememberedSet>::getFirstStart(uint32_t card_no)
+{
+  HeapWord *addr = _rs->addrForCardNo(card_no);
+  ShenandoahHeap *heap = ShenandoahHeap::heap();
+  ShenandoahHeapRegion *region = heap->heap_region_containing(addr);
+  HeapWord *obj = region->block_start(addr);
+
+  assert(obj != NULL);
+  if (obj >= addr)
+    return obj - addr;
+  else {
+    HeapWord *end_addr = addr + CardTable::card_size_in_words;
+    obj += oop(obj)->size();
+    if (obj < end_addr)
+      return obj - addr;
+    assert(false);
+  }
+}
+
+template <class RememberedSet>
+uint32_t ShenandoahCardCluster<RememberedSet>::getLastStart(uint32_t card_no) {
+  HeapWord *addr = _rs->addrForCardNo(card_no);
+  HeapWord *end_addr = addr + CardTable::card_size_in_words;
+  ShenandoahHeap *heap = ShenandoahHeap::heap();
+  ShenandoahHeapRegion *region = heap->heap_region_containing(addr);
+  HeapWord *obj = region->block_start(addr);
+
+  assert(obj != NULL);
+
+  HeapWord *end_obj = obj + oop(obj)->size();
+  while (end_obj < end_addr) {
+    obj = end_obj;
+    end_obj = obj + oop(obj)->size();
+  }
+
+  assert(obj >= addr);
+  return obj - addr;
+}
+
+template <class RememberedSet>
+uint32_t ShenandoahCardCluster<RememberedSet>::getCrossingObjectStart(
+    uint32_t card_no) {
+  HeapWord *addr = _rs->addrForCardNo(card_no);
+  uint32_t cluster_no =
+      card_no / ShenandoahCardCluster<RememberedSet>::CardsPerCluster;
+  HeapWord *cluster_addr = _rs->addrForCardNo(cluster_no * CardsPerCluster);
+
+  HeapWord *end_addr = addr + CardTable::card_size_in_words;
+  ShenandoahHeap *heap = ShenandoahHeap::heap();
+  ShenandoahHeapRegion *region = heap->heap_region_containing(addr);
+  HeapWord *obj = region->block_start(addr);
+
+  if (obj > cluster_addr)
+    return obj - cluster_addr;
+  else
+    return 0x7fff;
+}
+#endif
+
+
+template <typename RememberedSet>
+template <typename ClosureType>
+void ShenandoahScanRemembered<RememberedSet>::processClusters(
+    uint32_t first_cluster, uint32_t count, ClosureType *oops) {
+
+  // Unlike traditional Shenandoah marking, the old-gen resident
+  // objects that are examined as part of the remembered set are not
+  // themselves marked.  Each such object will be scanned only once.
+  // Any young-gen objects referenced from the remembered set will
+  // be marked and then subsequently scanned.
+
+  while (count-- > 0) {
+
+    uint32_t card_no = first_cluster *
+	ShenandoahCardCluster<ShenandoahBufferWithSATBRememberedSet>::CardsPerCluster;
+    uint32_t end_card_no = card_no +
+	ShenandoahCardCluster<ShenandoahBufferWithSATBRememberedSet>::CardsPerCluster;
+
+    while (card_no < end_card_no) {
+      if (_scc.isCardDirty(card_no)) {
+        if (_scc.hasObject(card_no)) {
+          // Scan all objects that start within this card region.
+          uint32_t start_offset = _scc.getFirstStart(card_no);
+          HeapWord *p = _scc.getAddrForCard(card_no);
+          HeapWord *endp = p + CardTable::card_size_in_words;
+          p += start_offset;
+
+          while (p < endp) {
+            oop obj = oop(p);
+
+            // Future TODO:
+	    // For improved efficiency, we might want to give
+            // special handling of obj->is_objArray().  In
+            // particular, in that case, we might want to divide the
+            // effort for scanning of a very long object array
+            // between multiple threads.
+            if (obj->is_objArray()) {
+              objArrayOop array = objArrayOop(obj);
+	      int len = array->length();
+	      array->oop_iterate_range(oops, 0, len);
+	    } else
+	      oops->do_oop(&obj);
+	    p += obj->size();
+	  }
+	  // p either points to start of next card region, or to
+	  // the next object that needs to be scanned, which may
+	  // reside in some successor card region.
+	  card_no = _scc.cardAtAddress(p);
+	} else {
+          // otherwise, this card will have been scanned during
+          // scan of a previous cluster.
+          card_no++;
+        }
+      } else if (_scc.hasObject(card_no)) {
+        // Scan the last object that starts within this card memory if
+        // it spans at least one dirty card within this cluster or
+        // if it reaches into the next cluster. 
+        uint32_t start_offset = _scc.getFirstStart(card_no);
+        HeapWord *p = _scc.getAddrForCard(card_no) + start_offset;
+        oop obj = oop(p);
+        HeapWord *nextp = p + obj->size();
+        uint32_t last_card = _scc.cardAtAddress(nextp);
+
+        bool reaches_next_cluster = (last_card > end_card_no);
+        bool spans_dirty_within_this_cluster = false;
+        if (!reaches_next_cluster) {
+          int span_card;
+          for (span_card = card_no+1; span_card < end_card_no; span_card++)
+            if (_scc.isCardDirty(span_card)) {
+              spans_dirty_within_this_cluster = true;
+	      break;
+	    }
+	}
+	if (reaches_next_cluster || spans_dirty_within_this_cluster) {
+	  if (obj->is_objArray()) {
+	    objArrayOop array = objArrayOop(obj);
+	    int len = array->length();
+	    array->oop_iterate_range(oops, 0, len);
+          } else
+            oops->do_oop(&obj);
+	}
+	// Increment card_no to account for the spanning object,
+	// even if we didn't scan it.
+	card_no = _scc.cardAtAddress(end_card_no);
+      } else
+	card_no++;
+    }
+  }
+}

--- a/src/hotspot/share/gc/shenandoah/shenandoahScanRemembered.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahScanRemembered.cpp
@@ -23,80 +23,70 @@
  *
  */
 
-#include "shenandoahScanRemembered.hpp"
 
+#include "gc/shenandoah/shenandoahHeapRegion.hpp"
+#include "gc/shenandoah/shenandoahScanRemembered.hpp"
+#include "gc/shenandoah/shenandoahHeap.hpp"
+#include "gc/shenandoah/shenandoahHeap.inline.hpp"
+#include "gc/shenandoah/shenandoahHeapRegion.hpp"
+#include "gc/shenandoah/shenandoahHeapRegion.inline.hpp"
 
-ShenandoahDirectCardMarkRememberedSet::ShenandoahDirectCardMarkRememberedSet(
-    CardTable *card_table, size_t count)
-{
+ShenandoahDirectCardMarkRememberedSet::ShenandoahDirectCardMarkRememberedSet(CardTable *card_table, size_t total_card_count) {
   _heap = ShenandoahHeap::heap();
   _card_table = card_table;
-  _card_count = count;
-  _cluster_count = (
-      _card_count /
-      ShenandoahCardCluster<ShenandoahDirectCardMarkRememberedSet>::CardsPerCluster);
+  _total_card_count = total_card_count;
+  _cluster_count = (total_card_count / ShenandoahCardCluster<ShenandoahDirectCardMarkRememberedSet>::CardsPerCluster);
   _card_shift = CardTable::card_shift;
 
-  _whole_heap_base = _card_table->addr_for(_byte_map);
-  _whole_heap_end = _card_table->addr_for(_byte_map + _card_count);
-
-
   _byte_map = _card_table->byte_for_index(0);
+
+  _whole_heap_base = _card_table->addr_for(_byte_map);
+  _whole_heap_end = _whole_heap_base + total_card_count * CardTable::card_size;
+
   _byte_map_base = _byte_map - (uintptr_t(_whole_heap_base) >> _card_shift);
 
-  _overreach_map = (uint8_t *) malloc(_card_count);
+  _overreach_map = (uint8_t *) malloc(total_card_count);
   _overreach_map_base = (_overreach_map -
-			 (uintptr_t(_whole_heap_base) >> _card_shift));
+                         (uintptr_t(_whole_heap_base) >> _card_shift));
       
-  assert(_card_count % ShenandoahCardCluster<ShenandoahDirectCardMarkRememberedSet>::CardsPerCluster == 0, "Invalid card count.");
-  assert(_card_count > 0, "Card count cannot be zero.");
+  assert(total_card_count % ShenandoahCardCluster<ShenandoahDirectCardMarkRememberedSet>::CardsPerCluster == 0, "Invalid card count.");
+  assert(total_card_count > 0, "Card count cannot be zero.");
   // assert(_overreach_cards != NULL);
 }
 
-ShenandoahDirectCardMarkRememberedSet::~ShenandoahDirectCardMarkRememberedSet()
-{
+ShenandoahDirectCardMarkRememberedSet::~ShenandoahDirectCardMarkRememberedSet() {
   free(_overreach_map);
 }
 
-void ShenandoahDirectCardMarkRememberedSet::initializeOverreach(
-    uint32_t first_cluster, uint32_t count) {
+void ShenandoahDirectCardMarkRememberedSet::initialize_overreach(uint32_t first_cluster, uint32_t count) {
 
   // We can make this run faster in the future by explicitly
   // unrolling the loop and doing wide writes if the compiler
   // doesn't do this for us.
-  uint32_t first_card_no =
-      first_cluster * ShenandoahCardCluster<ShenandoahDirectCardMarkRememberedSet>::CardsPerCluster;
-  uint8_t *omp = &_overreach_map[first_card_no];
+  uint32_t first_card_index = first_cluster * ShenandoahCardCluster<ShenandoahDirectCardMarkRememberedSet>::CardsPerCluster;
+  uint8_t *omp = &_overreach_map[first_card_index];
   uint8_t *endp = omp + count * ShenandoahCardCluster<ShenandoahDirectCardMarkRememberedSet>::CardsPerCluster;
   while (omp < endp)
     *omp++ = CardTable::clean_card_val();
 }
 
-void ShenandoahDirectCardMarkRememberedSet::mergeOverreach(
-    uint32_t first_cluster, uint32_t count) {
+void ShenandoahDirectCardMarkRememberedSet::merge_overreach(uint32_t first_cluster, uint32_t count) {
 
-  // We can make this run faster in the future by explicitly
-  // unrolling the loop and doing wide writes if the compiler
+  // We can make this run faster in the future by explicitly unrolling the loop and doing wide writes if the compiler
   // doesn't do this for us.
-    uint32_t first_card_no = (
-      first_cluster *
-      ShenandoahCardCluster<ShenandoahDirectCardMarkRememberedSet>::CardsPerCluster);
-  uint8_t *bmp = &_byte_map[first_card_no];
+  uint32_t first_card_index = first_cluster * ShenandoahCardCluster<ShenandoahDirectCardMarkRememberedSet>::CardsPerCluster;
+  uint8_t *bmp = &_byte_map[first_card_index];
   uint8_t *endp = bmp + count * ShenandoahCardCluster<ShenandoahDirectCardMarkRememberedSet>::CardsPerCluster;
-  uint8_t *omp = &_overreach_map[first_card_no];
+  uint8_t *omp = &_overreach_map[first_card_index];
 
-  // dirty_card is 0, clean card is 0xff
-  // if either *bmp or *omp is dirty, we need to mark it as dirty
+  // dirty_card is 0, clean card is 0xff; if either *bmp or *omp is dirty, we need to mark it as dirty
   while (bmp < endp)
     *bmp++ &= *omp++;
 }
 
 
-/* Implementation is not correct.  ShenandoahBufferWithSATBRememberedSet
- * is a placeholder for future planned improvements.
- */
-ShenandoahBufferWithSATBRememberedSet::ShenandoahBufferWithSATBRememberedSet(
-    size_t card_count)
+// Implementation is not correct.  ShenandoahBufferWithSATBRememberedSet is a placeholder for future planned improvements.
+ShenandoahBufferWithSATBRememberedSet::ShenandoahBufferWithSATBRememberedSet(size_t card_count)
 {
   _heap = ShenandoahHeap::heap();
 
@@ -108,231 +98,49 @@ ShenandoahBufferWithSATBRememberedSet::ShenandoahBufferWithSATBRememberedSet(
   _whole_heap_base = _heap->base();
   _whole_heap_end = _whole_heap_base + _card_count * 
       ShenandoahCardCluster<ShenandoahBufferWithSATBRememberedSet>::CardsPerCluster;
-
 }
 
-/* Implementation is not correct.  ShenandoahBufferWithSATBRememberedSet
- * is a placeholder for future planned improvements.
- */
+// Implementation is not correct.  ShenandoahBufferWithSATBRememberedSet is a placeholder for future planned improvements.
 ShenandoahBufferWithSATBRememberedSet::~ShenandoahBufferWithSATBRememberedSet()
 {
 }
 
-/* Implementation is not correct.  ShenandoahBufferWithSATBRememberedSet
- * is a placeholder for future planned improvements.
- */
-void ShenandoahBufferWithSATBRememberedSet::initializeOverreach(
+// Implementation is not correct.  ShenandoahBufferWithSATBRememberedSet is a placeholder for future planned improvements.
+void ShenandoahBufferWithSATBRememberedSet::initialize_overreach(
     uint32_t first_cluster, uint32_t count) {
 }
 
-/* Implementation is not correct.  ShenandoahBufferWithSATBRememberedSet
- * is a placeholder for future planned improvements.
- */
-void ShenandoahBufferWithSATBRememberedSet::mergeOverreach(
+// Implementation is not correct.  ShenandoahBufferWithSATBRememberedSet is a placeholder for future planned improvements.
+void ShenandoahBufferWithSATBRememberedSet::merge_overreach(
     uint32_t first_cluster, uint32_t count) {
 }
 
 #ifdef IMPLEMENT_THIS_OPTIMIZATION_LATER
 
 template <class RememberedSet>
-bool ShenandoahCardCluster<RememberedSet>::hasObject(uint32_t card_no) {
-  return (object_starts[card_no] & ObjectStartsInCardRegion)? true: false;
+bool ShenandoahCardCluster<RememberedSet>::has_object(uint32_t card_index) {
+  return (object_starts[card_index] & ObjectStartsInCardRegion)? true: false;
 }
 
 template <class RememberedSet>
-uint32_t ShenandoahCardCluster<RememberedSet>::getFirstStart(uint32_t card_no)
+uint32_t ShenandoahCardCluster<RememberedSet>::get_first_start(uint32_t card_index)
 {
-  assert(object_starts[card_no] & ObjectStartsInCardRegion);
-  return (((object_starts[card_no] & FirstStartBits) >> FirstStartShift) *
-	  CardWordOffsetMultiplier);
+  assert(object_starts[card_index] & ObjectStartsInCardRegion);
+  return (((object_starts[card_index] & FirstStartBits) >> FirstStartShift) *
+          CardWordOffsetMultiplier);
 }
 
 template <class RememberedSet>
-uint32_t ShenandoahCardCluster<RememberedSet>::getLastStart(uint32_t card_no) {
-  assert(object_starts[card_no] & ObjectStartsInCardRegion);
-  return (((object_starts[card_no] & LastStartBits) >> LastStartShift) *
-	  CardWordOffsetMultiplier);
+uint32_t ShenandoahCardCluster<RememberedSet>::get_last_start(uint32_t card_index) {
+  assert(object_starts[card_index] & ObjectStartsInCardRegion);
+  return (((object_starts[card_index] & LastStartBits) >> LastStartShift) *
+          CardWordOffsetMultiplier);
 }
 
 template <class RememberedSet>
-uint8_t ShenandoahCardCluster<RememberedSet>::getCrossingObjectStart(
-    uint32_t card_no) {
-  assert((object_starts[card_no] & ObjectStartsInCardRegion) == 0);
-  return object_starts[card_no] * CardWordOffsetMultiplier;
+uint8_t ShenandoahCardCluster<RememberedSet>::get_crossing_object_start(uint32_t card_index) {
+  assert((object_starts[card_index] & ObjectStartsInCardRegion) == 0);
+  return object_starts[card_index] * CardWordOffsetMultiplier;
 }
 
-#else
-
-// This implementation of services is slow but "sure" (in theory).
-// Significant performance improvement is planned, with not a huge
-// amount of further effort.
-
-template <class RememberedSet>
-bool ShenandoahCardCluster<RememberedSet>::hasObject(uint32_t card_no) {
-  HeapWord *addr = _rs->addrForCardNo(card_no);
-  ShenandoahHeap *heap = ShenandoahHeap::heap();
-  ShenandoahHeapRegion *region = heap->heap_region_containing(addr);
-  HeapWord *obj = region->block_start(addr);
-
-  assert(obj != NULL, "Object cannot be null");
-  if (obj >= addr)
-    return true;
-  else {
-    HeapWord *end_addr = addr + CardTable::card_size_in_words;
-    obj += oop(obj)->size();
-    if (obj < end_addr)
-      return true;
-    else
-      return false;
-  }
-}
-
-template <class RememberedSet>
-uint32_t ShenandoahCardCluster<RememberedSet>::getFirstStart(uint32_t card_no)
-{
-  HeapWord *addr = _rs->addrForCardNo(card_no);
-  ShenandoahHeap *heap = ShenandoahHeap::heap();
-  ShenandoahHeapRegion *region = heap->heap_region_containing(addr);
-  HeapWord *obj = region->block_start(addr);
-
-  assert(obj != NULL, "Object cannot be null.");
-  if (obj >= addr)
-    return obj - addr;
-  else {
-    HeapWord *end_addr = addr + CardTable::card_size_in_words;
-    obj += oop(obj)->size();
-    if (obj < end_addr)
-      return obj - addr;
-  }
-}
-
-template <class RememberedSet>
-uint32_t ShenandoahCardCluster<RememberedSet>::getLastStart(uint32_t card_no) {
-  HeapWord *addr = _rs->addrForCardNo(card_no);
-  HeapWord *end_addr = addr + CardTable::card_size_in_words;
-  ShenandoahHeap *heap = ShenandoahHeap::heap();
-  ShenandoahHeapRegion *region = heap->heap_region_containing(addr);
-  HeapWord *obj = region->block_start(addr);
-
-  assert(obj != NULL, "Object cannot be null.");
-
-  HeapWord *end_obj = obj + oop(obj)->size();
-  while (end_obj < end_addr) {
-    obj = end_obj;
-    end_obj = obj + oop(obj)->size();
-  }
-
-  assert(obj >= addr, "Object out of range.");
-  return obj - addr;
-}
-
-template <class RememberedSet>
-uint32_t ShenandoahCardCluster<RememberedSet>::getCrossingObjectStart(
-    uint32_t card_no) {
-  HeapWord *addr = _rs->addrForCardNo(card_no);
-  uint32_t cluster_no =
-      card_no / ShenandoahCardCluster<RememberedSet>::CardsPerCluster;
-  HeapWord *cluster_addr = _rs->addrForCardNo(cluster_no * CardsPerCluster);
-
-  HeapWord *end_addr = addr + CardTable::card_size_in_words;
-  ShenandoahHeap *heap = ShenandoahHeap::heap();
-  ShenandoahHeapRegion *region = heap->heap_region_containing(addr);
-  HeapWord *obj = region->block_start(addr);
-
-  if (obj > cluster_addr)
-    return obj - cluster_addr;
-  else
-    return 0x7fff;
-}
 #endif
-
-
-template <typename RememberedSet>
-template <typename ClosureType>
-void ShenandoahScanRemembered<RememberedSet>::processClusters(
-    uint32_t first_cluster, uint32_t count, ClosureType *oops) {
-
-  // Unlike traditional Shenandoah marking, the old-gen resident
-  // objects that are examined as part of the remembered set are not
-  // themselves marked.  Each such object will be scanned only once.
-  // Any young-gen objects referenced from the remembered set will
-  // be marked and then subsequently scanned.
-
-  while (count-- > 0) {
-
-    uint32_t card_no = first_cluster *
-	ShenandoahCardCluster<ShenandoahBufferWithSATBRememberedSet>::CardsPerCluster;
-    uint32_t end_card_no = card_no +
-	ShenandoahCardCluster<ShenandoahBufferWithSATBRememberedSet>::CardsPerCluster;
-
-    while (card_no < end_card_no) {
-      if (_scc->isCardDirty(card_no)) {
-        if (_scc->hasObject(card_no)) {
-          // Scan all objects that start within this card region.
-          uint32_t start_offset = _scc->getFirstStart(card_no);
-          HeapWord *p = _scc->getAddrForCard(card_no);
-          HeapWord *endp = p + CardTable::card_size_in_words;
-          p += start_offset;
-
-          while (p < endp) {
-            oop obj = oop(p);
-
-            // Future TODO:
-	    // For improved efficiency, we might want to give
-            // special handling of obj->is_objArray().  In
-            // particular, in that case, we might want to divide the
-            // effort for scanning of a very long object array
-            // between multiple threads.
-            if (obj->is_objArray()) {
-              objArrayOop array = objArrayOop(obj);
-	      int len = array->length();
-	      array->oop_iterate_range(oops, 0, len);
-	    } else
-	      oops->do_oop(&obj);
-	    p += obj->size();
-	  }
-	  // p either points to start of next card region, or to
-	  // the next object that needs to be scanned, which may
-	  // reside in some successor card region.
-	  card_no = _scc->cardAtAddress(p);
-	} else {
-          // otherwise, this card will have been scanned during
-          // scan of a previous cluster.
-          card_no++;
-        }
-      } else if (_scc->hasObject(card_no)) {
-        // Scan the last object that starts within this card memory if
-        // it spans at least one dirty card within this cluster or
-        // if it reaches into the next cluster. 
-        uint32_t start_offset = _scc->getFirstStart(card_no);
-        HeapWord *p = _scc->getAddrForCard(card_no) + start_offset;
-        oop obj = oop(p);
-        HeapWord *nextp = p + obj->size();
-        uint32_t last_card = _scc->cardAtAddress(nextp);
-
-        bool reaches_next_cluster = (last_card > end_card_no);
-        bool spans_dirty_within_this_cluster = false;
-        if (!reaches_next_cluster) {
-          uint32_t span_card;
-          for (span_card = card_no+1; span_card < end_card_no; span_card++)
-            if (_scc->isCardDirty(span_card)) {
-              spans_dirty_within_this_cluster = true;
-	      break;
-	    }
-	}
-	if (reaches_next_cluster || spans_dirty_within_this_cluster) {
-	  if (obj->is_objArray()) {
-	    objArrayOop array = objArrayOop(obj);
-	    int len = array->length();
-	    array->oop_iterate_range(oops, 0, len);
-          } else
-            oops->do_oop(&obj);
-	}
-	// Increment card_no to account for the spanning object,
-	// even if we didn't scan it.
-	card_no = _scc->cardAtAddress(end_card_no);
-      } else
-	card_no++;
-    }
-  }
-}

--- a/src/hotspot/share/gc/shenandoah/shenandoahScanRemembered.hpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahScanRemembered.hpp
@@ -1,0 +1,1173 @@
+/*
+ * Copyright (c) Amazon.com, Inc. or its affiliates.  All rights reserved.
+ *
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ *
+ */
+
+// Terminology used within this source file:
+//
+// Card Entry:   This is the information that identifies whether a
+//               particular card-table entry is Clean or Dirty.  A clean
+//               card entry denotes that the associated memory does not
+//               hold references to young-gen memory.
+//
+// Card Region, aka
+// Card Memory:  This is the region of memory that is assocated with a
+//               particular card entry.
+//
+// Card Cluster: A card cluster represents 64 card entries.  A card
+//               cluster is the minimal amount of work performed at a
+//               time by a parallel thread.  Note that the work required
+//               to scan a card cluster is somewhat variable in that the
+//               required effort depends on how many cards are dirty, how
+//               many references are held within the objects that span a
+//               DIRTY card's memory, and on the size of the object
+//               that spans the end of a DIRTY card's memory (because
+//               that object will be scanned in its entirety). For these
+//               reasons, it is advisable for the multiple worker threads
+//               to be flexible in the number of clusters to be
+//               processed by each thread. 
+
+
+
+// A cluster represents a "natural" quantum of work to be performed by
+// a parallel GC thread's background remembered set scanning efforts.
+// The notion of cluster is similar to the notion of stripe in the
+// implementation of parallel GC card scanning.  However, a cluster is
+// typically smaller than a stripe, enabling finer grain division of
+// labor between multiple threads.
+//
+// For illustration, consider the following possible JVM configurations:
+//
+//   Scenario 1:
+//     RegionSize is 128 MB
+//     Span of a card entry is 512 B
+//     Each card table entry consumes 1 B
+//     Assume one long word of card table entries represents a cluster.
+//       This long word holds 8 card table entries, spanning a
+//       total of 4KB
+//     The number of clusters per region is 128 MB / 4 KB = 32K
+//
+//   Scenario 2:
+//     RegionSize is 128 MB
+//     Span of each card entry is 128 B
+//     Each card table entry consumes 1 bit
+//     Assume one int word of card tables represents a cluster.
+//       This int word holds 32 card table entries, spanning a
+//       total of 4KB
+//     The number of clusters per region is 128 MB / 4 KB = 32K
+//
+//   Scenario 3:
+//     RegionSize is 128 MB
+//     Span of each card entry is 512 B
+//     Each card table entry consumes 1 bit
+//     Assume one long word of card tables represents a cluster.
+//       This long word holds 64 card table entries, spanning a
+//       total of 32 KB
+//     The number of clusters per region is 128 MB / 32 KB = 4K
+//
+
+// The typical parallel remembered set scanning effort consists of the
+// following steps, all of which are performed during a JVM safetpoint:
+//
+// At the start of a new concurrent mark or concurrent evacuation
+// pass, the gang of Shenandoah worker threads collaborate in
+// performing the following actions:
+//
+//  Let old_regions = number of ShenandoahHeapRegion comprising
+//    old-gen memory
+//  Let region_size = ShenandoahHeapRegion::region_size_bytes()
+//    represent the number of bytes in each region 
+//  Let clusters_per_region = region_size / 512
+//  Let rs represent the relevant RememberedSet implementation
+//    (an instance of ShenandoahBufferWithSATBRememberedSet or
+//     ShenandoahDirectCardMarkRememberedSet)
+//
+//  for each ShenandoahHeapRegion old_region in the whole heap
+//    determine the cluster number of the first cluster belonging
+//      to that region
+//    for each cluster contained within that region
+//      Assure that exactly one worker thread initializes each
+//      cluster of overreach memory by invoking:
+//
+//        rs->initializeOverreach(cluster_no, cluster_count)
+//
+//      in separate threads.  (Divide up the clusters so that
+//      different threads are responsible for initializing different
+//      clusters.  Initialization cost is essentially identical for
+//      each cluster.)
+//
+//  Next, we repeat the process for invocations of examineCluster:
+//  for each ShenandoahHeapRegion old_region in the whole heap
+//    determine the cluster number of the first cluster belonging
+//      to that region
+//    for each cluster contained within that region
+//      Assure that exactly one worker thread processes each
+//      cluster, each thread making a series of invocations of the
+//      following: 
+//
+//        rs->processClusters(cluster_no, cluster_count,
+//		              OopClosure *oops);
+//        // Use the same approach for invocations of replaceClusters()
+//
+//      Divide up the clusters so that different threads are
+//      responsible for processing different clusters.  Processing
+//      cost may vary greatly between clusters for the following
+//      reasons:
+//        a) some clusters contain mostly dirty cards and other
+//           clusters contain mostly clean cards
+//        b) some clusters contain mostly primitive data and other
+//           clusters contain mostly reference data
+//        c) some clusters are spanned by very large objects that
+//           begin in some other cluster.  When a large object
+//           beginning in a preceding cluster spans large portions of
+//           this cluster, the processing of this cluster gets a
+//           "free ride" because the thread responsible for processing
+//           the cluster that holds the object's header does the
+//           processing. 
+//        d) in the case that the end of this cluster is spanned by a
+//           very large object, the processing of this cluster will
+//           be responsible for examining the entire object,
+//           potentially requiring this thread to process large amounts
+//           of memory pertaining to other clusters.
+//
+//      Though an initial division of labor between marking threads
+//      may assign equal numbers of clusters to be scanned by each
+//      thread, it should be expected that some threads will finish
+//      their assigned work before others.  Therefore, some amount
+//      of the full remembered set scanning effort should be held
+//      back and assigned incrementally to the threads that end up with
+//      excess capacity.  Consider the following strategy for dividing
+//      labor:
+//
+//        1. Assume there are 8 marking threads and 1024 remembered
+//           set clusters to be scanned.
+//        2. Assign each thread to scan 64 clusters.  This leaves
+//           512 (1024 - (8*64)) clusters to still be scanned.
+//        3. As the 8 server threads complete previous cluster
+//           scanning assignments, issue each of the next 8 scanning
+//           assignments as units of 32 additional cluster each.
+//           In the case that there is high variance in effort
+//           associated with previous cluster scanning assignments,
+//           multiples of these next assignments may be serviced by
+//           the server threads that were previously assigned lighter
+//           workloads. 
+//        4. Make subsequent scanning assignments as follows:
+//             a) 8 assignments of size 16 clusters
+//             b) 8 assignments of size 8 clusters
+//             c) 16 assignments of size 4 clusters
+//
+//    When there is no more remembered set processing work to be
+//    assigned to a newly idled worker threads, that thread can move
+//    on to work on other tasks associated with root scanning until such
+//    time as all clusters have been examined.
+//
+//  Once all clusters have been processed, the gang of GC worker
+//  threads collaborate to merge the overreach data.
+//
+//  for each ShenandoahHeapRegion old_region in the whole heap
+//    determine the cluster number of the first cluster belonging
+//      to that region
+//    for each cluster contained within that region
+//      Assure that exactly one worker thread initializes each
+//      cluster of overreach memory by invoking:
+//
+//        rs->mergeOverreach(cluster_no, cluster_count)
+//
+//      in separate threads.  (Divide up the clusters so that
+//      different threads are responsible for merging different
+//      clusters.  Merging cost is essentially identical for
+//      each cluster.)
+//
+//
+// To initiate concurrent scanning, insert the above code sequences
+// into strong_roots_do and roots_do methods of ShenandoahRootScanner
+// (source file shenandoahRootProcessor.cpp) following the
+// construction of tc_cl and rm and before the call to
+// _serial_roots.oops_do(). 
+//
+// To initiate concurrent evacuation, insert the above code sequences
+// into ShenandoahRootEvacuator::roots_do() before the invocation of
+// _serial_roots.oops_do(oops, worker_id).
+
+
+#ifndef SHARE_GC_SHENANDOAH_SHENANDOAHSCANREMEMBERED_HPP
+#define SHARE_GC_SHENANDOAH_SHENANDOAHSCANREMEMBERED_HPP
+
+#include "code/codeCache.hpp"
+#include "gc/shared/oopStorageSetParState.hpp"
+#include "gc/shenandoah/shenandoahCodeRoots.hpp"
+#include "gc/shenandoah/shenandoahHeap.hpp"
+#include "gc/shenandoah/shenandoahPhaseTimings.hpp"
+#include "gc/shenandoah/shenandoahSharedVariables.hpp"
+#include "gc/shenandoah/shenandoahUtils.hpp"
+#include "memory/iterator.hpp"
+
+
+
+class ShenandoahDirectCardMarkRememberedSet {
+
+private:
+
+  // Use symbolic constants defined in cardTable.hpp
+  //  CardTable::card_shift = 9;
+  //  CardTable::card_size = 512;
+  //  CardTable::card_size_in_words = 64;
+
+  //  CardTable::clean_card_val()
+  //  CardTable::dirty_card_val()
+
+  ShenandoahHeap *_heap;
+  CardTable *_card_table;
+  uint32_t _card_shift;
+  size_t _card_count;
+  uint32_t _cluster_count;
+  HeapWord *_whole_heap_base;
+  HeapWord *_whole_heap_end;
+  uint8_t *_byte_map;
+  uint8_t *_byte_map_base;
+  uint8_t *_overreach_map;
+  uint8_t *_overreach_map_base;
+
+public:
+  ShenandoahDirectCardMarkRememberedSet(CardTable *card_table, size_t count);
+
+
+  ~ShenandoahDirectCardMarkRememberedSet();
+
+  inline uint32_t cardNoForAddr(HeapWord *p) {
+    return (uintptr_t(p) >> _card_shift);
+  }
+
+  inline HeapWord *addrForCardNo(uint32_t card_no) {
+    return _whole_heap_base + CardTable::card_size_in_words * card_no;
+  }
+
+  inline bool isCardDirty(uint32_t card_no) {
+    uint8_t *bp = &_byte_map_base[card_no];
+    return (bp[0] == CardTable::dirty_card_val());
+  }
+
+  inline void markCardAsDirty(uint32_t card_no) {
+    uint8_t *bp = &_byte_map_base[card_no];
+    bp[0] = CardTable::dirty_card_val();
+  }
+
+  inline void markCardAsClean(uint32_t card_no) {
+    uint8_t *bp = &_byte_map_base[card_no];
+    bp[0] = CardTable::clean_card_val();
+  }
+
+  inline void markOverreachCardAsDirty(uint32_t card_no) {
+    uint8_t *bp = &_overreach_map_base[card_no];
+    bp[0] = CardTable::dirty_card_val();
+  }
+
+  inline bool isCardDirty(HeapWord *p) {
+    uint8_t *bp = &_byte_map_base[uintptr_t(p) >> _card_shift];
+    return (bp[0] == CardTable::dirty_card_val());
+  }
+
+  inline void markCardAsDirty(HeapWord *p) {
+    uint8_t *bp = &_byte_map_base[uintptr_t(p) >> _card_shift];
+    bp[0] = CardTable::dirty_card_val();
+  }
+
+  inline void markCardAsClean(HeapWord *p) {
+    uint8_t *bp = &_byte_map_base[uintptr_t(p) >> _card_shift];
+    bp[0] = CardTable::clean_card_val();
+  }
+
+  inline void markOverreachCardAsDirty(void *p) {
+    uint8_t *bp = &_overreach_map_base[uintptr_t(p) >> _card_shift];
+    bp[0] = CardTable::dirty_card_val();
+  }
+
+  inline uint32_t clusterCount() {
+    return _cluster_count;
+  }
+
+  // Called by multiple GC threads at start of concurrent mark and
+  // evacuation phases.  Each parallel GC thread typically initializes
+  // a different subranges of all overreach entries.
+  void initializeOverreach(uint32_t first_cluster, uint32_t count);
+
+  // Called by GC thread at end of concurrent mark or evacuation phase.
+  // Each parallel GC thread typically merges different subranges of
+  // all overreach entries.
+  void mergeOverreach(uint32_t first_cluster, uint32_t count);
+};
+
+//
+// The anticipated benefits of an alternative SATB-based
+// implementation of the remembered set are several fold:
+//
+//  1. The representation of remembered set is more concise (1 bit per
+//     card) and there is no remembered set maintenance required for
+//     ShenandoahHeapRegions that correspond to young-gen memory.  Besides
+//     requiring less memory overall, additional benefits of the more
+//     concise remembered set representation are improved cache hit rates
+//     and more efficient scanning and maintenance of remembered set
+//     information by GC threads.
+//  2. While the mutator overhead is similar between the modified SATB
+//     barrier mechanism and direct card marking, the SATB mechanism
+//     offers the potential of improved accuracy within the remembered
+//     set.  This is because direct card marking unconditionally marks
+//     every old-gen page that is overwritten with a pointer value, even
+//     when the new pointer value might refer to old-gen memory.  With
+//     the modified SATB mechanism, background GC threads process the
+//     the addresses logged within the SATB buffer and mark cards as
+//     dirty only if the pointer found at an overwritten old-gen address
+//     refers to young-gen memory.
+//  3. Potentially, the incremental overhead of adding remembered set
+//     logging to the existing SATB barrier is lower than the incremental
+//     overhead of adding an independent and distinct new write barrier
+//     for card marking.  This is especially true during times that the
+//     SATB barrier is already enabled (which might represent 30-50% of
+//     execution for GC-intensive workloads).  It may even be true during
+//     times that the SATB is disabled.  This is because even when the
+//     SATB is disabled, register allocation is constrained by the reality
+//     that SATB will be enabled some of the time, so registers
+//     allocated for the SATB maintenance will sit idle during times
+//     when the SATB barrier is disabled.  In tight loops that write
+//     pointer values, for example, the SATB implementation might dedicate
+//     registers to holding thread-local information associated with
+//     maintenance of the SATB buffer such as the address of the SATB
+//     buffer and the next available buffer slot within this buffer.  In
+//     the traditional card-marking remembered set implementation, an
+//     additional register might be dedicated to holding a reference to
+//     the base of the card table.
+
+
+// Note that a ShenandoahBufferWithSATBRememberedSet maintains the
+// remembered set only for memory regions that correspond to old-generation
+// memory.  Anticipate that the implementation will use double indirection.
+//
+// To Do:
+//
+//  1. Figure out which region an old-gen address belongs to
+//  2. Find the cluster and card numbers that corresponds to that
+//     region
+//
+// Old-gen memory is not necessarily contiguous.  It may be comprised
+// of multiple heap regions.
+//
+// The memory overhead for crossing map and card-table entries is
+// given by the following analysis:
+//   For each 512-byte card-entry span, we have the following overhead:
+//    2 bytes for the object_starts map
+//    1 bit for the card-table entry
+//  =====
+//    2 bytes (rounded down) out of 512 bytes is 0.39% bookkeeping overhead
+
+
+// ShenandoahBufferWithSATBRememberedSet is not implemented correctly
+// in its current form. 
+//
+// This class is a placeholder to support a possible future
+// implementation of remembered set that uses a generalization of the
+// existing SATB pre-write barrier to maintain remembered set
+// information rather than using unconditional direct card marking in
+// a post-write barrier.
+class ShenandoahBufferWithSATBRememberedSet {
+
+  // The current implementation is simply copied from the
+  // implementation of class ShenandoahDirectCardMarkRememberedSet
+
+  // Use symbolic constants defined in cardTable.hpp
+  //  CardTable::card_shift = 9;
+  //  CardTable::card_size = 512;
+  //  CardTable::card_size_in_words = 64;
+
+  //  CardTable::clean_card_val()
+  //  CardTable::dirty_card_val()
+
+  ShenandoahHeap *_heap;
+  uint32_t _card_shift;
+  size_t _card_count;
+  uint32_t _cluster_count;
+  HeapWord *_whole_heap_base;
+  HeapWord *_whole_heap_end;
+
+public:
+  ShenandoahBufferWithSATBRememberedSet(size_t card_count);
+
+  ~ShenandoahBufferWithSATBRememberedSet();
+
+  inline uint32_t cardNoForAddr(HeapWord *p) {
+      return 0;
+  }
+
+  inline HeapWord *addrForCardNo(uint32_t card_no) {
+      return NULL;
+  }
+
+  inline bool isCardDirty(uint32_t card_no) {
+      return false;
+  }
+
+  inline void markCardAsDirty(uint32_t card_no) {
+  }
+
+  inline void markCardAsClean(uint32_t card_no) {
+  }
+
+  inline void markOverreachCardAsDirty(uint32_t card_no) {
+  }
+
+  inline bool isCardDirty(HeapWord *p) {
+      return false;
+  }
+
+  inline void markCardAsDirty(HeapWord *p) {
+  }
+
+  inline void markCardAsClean(HeapWord *p) {
+  }
+
+  inline void markOverreachCardAsDirty(void *p) {
+  }
+
+  inline uint32_t clusterCount() {
+      return 0;
+  }
+
+  // Called by multiple GC threads at start of concurrent mark and
+  // evacuation phases.  Each parallel GC thread typically initializes
+  // a different subrance of all overreach entries.
+  void initializeOverreach(uint32_t first_cluster, uint32_t count);
+
+  // Called by GC thread at end of concurrent mark or evacuation phase.
+  // To Do: May want to parallelize this, allowing different GC
+  //        threads to merge different parts of the overreach table.
+  void mergeOverreach(uint32_t first_cluster, uint32_t count);
+};
+
+
+
+// A ShenandoahCardCluster represents the minimal unit of work
+// performed by independent parallel GC threads during scanning of
+// remembered sets.
+//
+// The GC threads that perform card-table remembered set scanning may
+// overwrite card-table entries to mark them as clean in the case that
+// the associated memory no longer holds references to young-gen
+// memory.  Rather than access the card-table entries directly, all GC
+// thread access to card-table information is made by way of the
+// ShenandoahCardCluster data abstraction.  This abstraction
+// effectively manages access to multiple possible underlying
+// remembered set implementations, including a traditional card-table
+// approach and a SATB-based approach.
+//
+// The API services represent a compromise between efficiency and
+// convenience.
+//
+// In the initial implementation, we assume that scanning of card
+// table entries occurs only while the JVM is at a safe point.  Thus,
+// there is no synchronization required between GC threads that are
+// scanning card-table entries and marking certain entries that were
+// previously dirty as clean, and mutator threads which would possibly
+// be marking certain card-table entries as dirty.
+//
+// There is however a need to implement concurrency control and memory
+// coherency between multiple GC threads that scan the remembered set
+// in parallel.  The desire is to divide the complete scanning effort
+// into multiple clusters of work that can be independently processed
+// by individual threads without need for synchronizing efforts
+// between the work performed by each task.  The term "cluster" of
+// work is similar to the term "stripe" as used in the implementation
+// of Parallel GC.
+//
+// Complexity arises when an object to be scanned crosses the boundary
+// between adjacent cluster regions.  Here is the protocol that is
+// followed:
+//
+//  1. We implement a supplemental data structure known as the overreach
+//     card table.  The thread that is responsible for scanning each
+//     cluster of card-table entries is granted exclusive access to
+//     modify the associated card-table entries.  In the case that a
+//     thread scans a very large object that reaches into one or more
+//     following clusters, that thread has exclusive access to the
+//     overreach card table for all of the entries belonging to the
+//     following clusters that are spanned by this large object.
+//     After all clusters have been scanned, the scanning threads
+//     briefly synchronize to merge the contents of the overreach
+//     entries with the traditional card table entries using logical-
+//     and operations.
+//  2. Every object is scanned in its "entirety" by the thread that is
+//     responsible for the cluster that holds its starting address.
+//     Entirety is in quotes because there are various situations in
+//     which some portions of the object will not be scanned by this
+//     thread:
+//     a) If an object spans multiple card regions, all of which are
+//        contained within the same cluster, the scanning thread 
+//        consults the existing card-table entries and does not scan
+//        portions of the object that are not currently dirty.
+//     b) For any cluster that is spanned in its entirety by a very
+//        large object, the GC thread that scans this object assumes
+//        full responsibility for maintenance of the associated
+//        card-table entries. 
+//     c) If a cluster is partially spanned by an object originating
+//        in a preceding cluster, the portion of the object that
+//        partially spans the following cluster is scanned in its
+//        entirety (because the thread that is responsible for
+//        scanning the object cannot rely upon the card-table entries
+//        associated with the following cluster).  Whenever references
+//        to young-gen memory are found within the scanned data, the
+//        associated overreach card table entries are marked as dirty
+//        by the scanning thread.
+//  3. If a cluster is spanned in its entirety by an object that
+//     originates within a preceding cluster's memory, the thread
+//     assigned to examine this cluster does absolutely nothing.  The
+//     thread assigned to scan the cluster that holds the object's
+//     starting address takes full responsibility for scanning the
+//     entire object and updating the associated card-table entries.
+//  4. If a cluster is spanned partially by an object that originates
+//     within a preceding cluster's memory, the thread assigned to
+//     examine this cluster marks the card-table entry as clean for
+//     each card table that is fully spanned by this overreaching
+//     object.  If a card-table entry's memory is partially spanned
+//     by the overreaching object, the thread sets the card-table
+//     entry to clean if it was previously dirty and if the portion
+//     of the card-table entry's memory that is not spanned by the
+//     overreaching object does not hold pointers to young-gen
+//     memory.
+//  5. While examining a particular card belonging to a particular
+//     cluster, if an object reaches beyond the end of its card
+//     memory, the thread "scans" all portions of the object that
+//     correspond to DIRTY card entries within the current cluster and
+//     all portions of the object that reach into following clustesr.
+//     After this object is scanned, continue scanning with the memory
+//     that follows this object if this memory pertains to the same
+//     cluster.  Otherwise, consider this cluster's memory to have
+//     been fully examined.
+//
+// Discussion:
+//  Though this design results from careful consideration of multiple
+//  design objectives, it is subject to various criticisms.  Some
+//  discussion of the design choices is provided here:
+//
+//  1. Note that remembered sets are a heuristic technique to avoid
+//     the need to scan all of old-gen memory with each young-gen
+//     collection.  If we sometimes scan a bit more memory than is
+//     absolutely necessary, that should be considered a reasonable
+//     compromise.  This compromise is already present in the sizing
+//     of card table memory areas.  Note that a single dirty pointer
+//     within a 512-byte card region forces the "unnecessary" scanning
+//     of 63 = ((512 - 8 = 504) / 8) pointers.
+//  2. One undesirable aspect of this design is that we sometimes have
+//     to scan large amounts of memory belonging to very large
+//     objects, even for parts of the very large object that do not
+//     correspond to dirty card table entries.  Note that this design
+//     limits the amount of non-dirty scanning that might have to
+//     be performed for these very large objects.  In particular, only
+//     the last part of the very large object that extends into but
+//     does not completely span a particular cluster is unnecessarily
+//     scanned.  Thus, for each very large object, the maximum
+//     over-scan is the size of memory spanned by a single cluster.
+//  3. The representation of pointer location descriptive information
+//     within Klass representations is not designed for efficient
+//     "random access".  An alternative approach to this design would
+//     be to scan very large objects multiple times, once for each
+//     cluster that is spanned by the object's range.  This reduces
+//     unnecessary overscan, but it introduces different sorts of
+//     overhead effort:
+//       i) For each spanned cluster, we have to look up the start of
+//          the crossing object. 
+//      ii) Each time we scan the very large object, we have to
+//          sequentially walk through its pointer location
+//          descriptors, skipping over all of the pointers that
+//          precede the start of the range of addresses that we
+//          consider relevant.
+
+
+// Because old-gen heap memory is not necessarily contiguous, and
+// because cards are not necessarily maintained for young-gen memory, 
+// consecutive card numbers do not necessarily correspond to consecutive
+// address ranges.  For the traditional direct-card-marking
+// implementation of this interface, consecutive card numbers are
+// likely to correspond to contiguous regions of memory, but this
+// should not be assumed.  Instead, rely only upon the following:
+//
+//  1. All card numbers for cards pertaining to the same
+//     ShenandoahHeapRegion are consecutively numbered.
+//  2. In the case that neighboring ShenandoahHeapRegions both
+//     represent old-gen memory, the card regions that span the
+//     boundary between these neighboring heap regions will be
+//     consecutively numbered.
+//  3. (A corollary) In the case that an old-gen object spans the
+//     boundary between two heap regions, the card regions that
+//     correspond to the span of this object will be consecutively
+//     numbered. 
+
+
+// ShenandoahCardCluster abstracts access to the remembered set
+// and also keeps track of crossing map information to allow efficient
+// resolution of object start addresses.
+//
+// ShenandoahCardClusters supports all of the services of
+// RememberedSet, plus it supports registerObject() and lookupObject().
+//
+// There are two situations under which we need to know the location
+// at which the object spanning the start of a particular card-table
+// memory region begins:
+//
+// 1. When we begin to scan dirty card memory that is not the
+//    first card region within a cluster, and the object that
+//    crosses into this card memory was not previously scanned,
+//    we need to find where that object starts so we can scan it.
+//    (Asides: if the objects starts within a previous cluster, it
+//     has already been scanned.  If the object starts within this
+//     cluster and it spans at least one card region that is dirty
+//     and precedes this card region within the cluster, then it has
+//     already been scanned.)
+// 2. When we are otherwise done scanning a complete cluster, if the
+//    last object within the cluster reaches into the following
+//    cluster, we need to scan this object.  Thus, we need to find
+//    its starting location.
+//
+// The RememberedSet template parameter is intended to represent either
+//     ShenandoahDirectCardMarkRememberedSet, or
+//     ShenandoahBufferWithSATBRememberedSet.
+template<typename RememberedSet>
+class ShenandoahCardCluster {
+
+private:
+  RememberedSet *_rs;
+
+public:
+  static const uint32_t CardsPerCluster = 64;
+
+
+  ShenandoahCardCluster(RememberedSet *rs) {
+    _rs = rs;
+  }
+
+  ~ShenandoahCardCluster() {
+  }
+
+  // There is one entry within the object_starts array for each
+  // card entry.  The interpretation of the data contained within each
+  // object_starts entry is described below:
+  //
+  // Bits 0x003f: Value ranges from 0-63, which is multiplied by 8
+  //              to obtain the offset at which the first object
+  //              beginning within this card region begins.
+  // Bits 0x0fc0: Value ranges from 0-63, which is multiplied by 8 to
+  //              obtain the offset at which the last object beginning
+  //              within this card region begins.
+  // Bits 0x8000: This bit is on if an object starts within this card
+  //              region.
+  //
+  // In the most recent implementation of
+  //   ShenandoahScanRemembered::processClusters(),
+  // there is no need for the getCrossingObjectStart() method
+  // function, so there is no need to maintain the following
+  // information.  The comment is left in place for now in case we
+  // find it necessary to add support for this service at a later time.
+  //
+  // Bits 0x7fff: If no object starts within this card region, the
+  //              remaining bits of the object_starts array represent
+  //              the absolute word offset within the enclosing
+  //              cluster's memory of the starting address for the
+  //              object that spans the start of this card region's
+  //              memory.  If the spanning object begins in memory
+  //              that precedes this card region's cluster, the value
+  //              stored in these bits is the special value 0x7fff.
+  //              (Note that the maximum value required to represent a
+  //              spanning object from within the current cluster is
+  //              ((63 * 64) - 8), which equals 0x0fbf. 
+  //
+  // In the absence of the need to support getCrossingObjectStart(),
+  // here is discussion of performance:
+  //
+  //  Suppose multiple garbage objects are coalesced during GC sweep
+  //  into a single larger "free segment".  As each two objects are
+  //  coalesced together, the start information pertaining to the second
+  //  object must be removed from the objects_starts array.  If the
+  //  second object had been been the first object within card memory,
+  //  the new first object is the object that follows that object if
+  //  that starts within the same card memory, or NoObject if the
+  //  following object starts within the following cluster.  If the
+  //  second object had been the last object in the card memory,
+  //  replace this entry with the newly coalesced object if it starts
+  //  within the same card memory, or with NoObject if it starts in a
+  //  preceding card's memory.
+  //
+  //  Suppose a large free segment is divided into a smaller free
+  //  segment and a new object.  The second part of the newly divided
+  //  memory must be registered as a new object, overwriting at most
+  //  one first_start and one last_start entry.  Note that one of the
+  //  newly divided two objects might be a new GCLAB.
+  //
+  //  Suppose postprocessing of a GCLAB finds that the original GCLAB
+  //  has been divided into N objects.  Each of the N newly allocated
+  //  objects will be registered, overwriting at most one first_start
+  //  and one last_start entries.
+  //
+  //  No object registration operations are linear in the length of
+  //  the registered objects.
+  //
+  // Consider further the following observations regarding object
+  // registration costs:
+  // 
+  //   1. The cost is paid once for each old-gen object (Except when
+  //      an object is demoted and repromoted, in which case we would
+  //      pay the cost again).
+  //   2. The cost can be deferred so that there is no urgency during
+  //      mutator copy-on-first-access promotion.  Background GC
+  //      threads will update the object_starts array by post-
+  //      processing the contents of retired GCLAB buffers.
+  //   3. The bet is that these costs are paid relatively rarely
+  //      because:
+  //      a) Most objects die young and objects that die in young-gen
+  //         memory never need to be registered with the object_starts
+  //         array. 
+  //      b) Most objects that are promoted into old-gen memory live
+  //         there without further relocation for a relatively long
+  //         time, so we get a lot of benefit from each investment
+  //         in registering an object.
+
+private:
+  const uint32_t CardByteOffsetMultiplier = 8;
+  const uint32_t CardWordOffsetMultiplier = 1;
+
+#ifdef IMPLEMENT_THIS_OPTIMIZATION_LATER
+
+  // This bit is set iff at least one object starts within a
+  // particular card region.
+  const uint_16 ObjectStartsInCardRegion = 0x8000;
+  const uint_16 FirstStartBits = 0x003f;
+  const uint_16 LastStartBits = 0x0fc0;
+  const uint_16 FirstStartShift = 0;
+  const uint_16 LastStartShift = 6;
+  const uint_16 CrossingObjectOverflow = 0x7fff;
+
+  uint_16 *object_starts;
+
+public:
+  inline void setFirstStart(uint32_t card_no, uint8_t value) {
+    object_starts[card_no] &= ~FirstStartBits;
+    object_starts[card_no] |= (FirstStartBits & (value << FirstStartShift));
+  }
+
+  inline void setLastStart(uint32_t card_no, uint8_t value) {
+    object_starts[card_no] &= ~LastStartBits;
+    object_starts[card_no] |= (LastStartBits & (value << LastStartShift));
+  }
+
+  inline void setHasObjectBit(uint32_t card_no) {
+    object_starts[card_no] |= ObjectStartsInCardRegion;
+  }
+
+  // This has side effect of clearing ObjectStartsInCardRegion bit.
+  inline void setCrossingObjectStart(uint32_t card_no,
+				     uint_16 crossing_offset) {
+    object_starts[card_no] = crossing_offset;
+  }
+#endif  // IMPLEMENT_THIS_OPTIMIZATION_LATER
+
+public:
+
+  // The starting locations of objects contained within old-gen memory
+  // are registered as part of the remembered set implementation.  This
+  // information is required when scanning dirty card regions that are
+  // spanned by objects beginning within preceding card regions.  It
+  // is necessary to find the first and last objects that begin within
+  // this card region.  Starting addresses of objects are required to
+  // find the object headers, and object headers provide information
+  // about which fields within the object hold addresses.
+  //
+  // The old-gen memory allocator invokes registerObject() for any
+  // object that is allocated within old-gen memory.  This identifies
+  // the starting addresses of objects that span boundaries between
+  // card regions.
+  //
+  // It is not necessary to invoke registerObject at the very instant
+  // an object is allocated.  It is only necessary to invoke it
+  // prior to the next start of a garbage collection concurrent mark
+  // or concurrent evacuation phase.  An "ideal" time to register
+  // objects is during post-processing of a GCLAB after the GCLAB is
+  // retired due to depletion of its memory.
+  //
+  // registerObject() does not perform synchronization.  In the case
+  // that multiple threads are registering objects whose starting
+  // addresses are within the same cluster, races between these
+  // threads may result in corruption of the object-start data
+  // structures.  Parallel GC threads should avoid registering objects
+  // residing within the same cluster by adhering to the following
+  // coordination protocols:
+  //
+  //  1. Align thread-local GCLAB buffers with some TBD multiple of
+  //     card clusters.  The card cluster size is 32 KB.  If the
+  //     desired GCLAB size is 128 KB, align the buffer on a multiple
+  //     of 4 card clusters.
+  //  2. Post-process the contents of GCLAB buffers to register the
+  //     objects allocated therein.  Allow one GC thread at a
+  //     time to do the post-processing of each GCLAB.
+  //  3. Since only one GC thread at a time is registering objects
+  //     belonging to a particular allocation buffer, no locking
+  //     is performed when registering these objects.  
+  //  4. Any remnant of unallocated memory within an expended GC
+  //     allocation buffer is not returned to the old-gen allocation
+  //     pool until after the GC allocation buffer has been post
+  //     processed.  Before any remnant memory is returned to the
+  //     old-gen allocation pool, the GC thread that scanned this GC
+  //     allocation buffer performs a write-commit memory barrier.
+  //  5. Background GC threads that perform tenuring of young-gen
+  //     objects without a GCLAB use a CAS lock before registering
+  //     each tenured object.  The CAS lock assures both mutual
+  //     exclusion and memory coherency/visibility.  Note that an
+  //     object tenured by a background GC thread will not overlap
+  //     with any of the clusters that are receiving tenured objects
+  //     by way of GCLAB buffers.  Multiple independent GC threads may
+  //     attempt to tenure objects into a shared cluster.  This is why
+  //     sychronization may be necessary.  Consider the following
+  //     scenarios: 
+  //
+  //     a) If two objects are tenured into the same card region, each
+  //        registration may attempt to modify the first-start or
+  //        last-start information associated with that card region.
+  //        Furthermore, because the representations of first-start
+  //        and last-start information within the object_starts array
+  //        entry uses different bits of a shared uint_16 to represent
+  //        each, it is necessary to lock the entire card entry
+  //        before modifying either the first-start or last-start
+  //        information within the entry.
+  //     b) Suppose GC thread X promotes a tenured object into
+  //        card region A and this tenured object spans into
+  //        neighboring card region B.  Suppose GC thread Y (not equal
+  //        to X) promotes a tenured object into cluster B.  GC thread X
+  //        will update the object_starts information for card A.  No
+  //        synchronization is required.
+  //     c) In summary, when background GC threads register objects
+  //        newly tenured into old-gen memory, they must acquire a
+  //        mutual exclusion lock on the card that holds the starting
+  //        address of the newly tenured object.  This can be achieved
+  //        by using a CAS instruction to assure that the previous
+  //        values of first-offset and last-offset have not been
+  //        changed since the same thread inquired as to their most
+  //        current values.
+  //
+  //     One way to minimize the need for synchronization between
+  //     background tenuring GC threads is for each tenuring GC thread
+  //     to promote young-gen objects into distinct dedicated cluster
+  //     ranges.
+  //  6. The object_starts information is only required during the
+  //     starting of concurrent marking and concurrent evacuation
+  //     phases of GC.  Before we start either of these GC phases, the
+  //     JVM enters a safe point and all GC threads perform
+  //     commit-write barriers to assure that access to the
+  //     object_starts information is coherent.
+
+  static void registerObject(void *address, uint32_t length_in_bytes) {
+
+#ifdef IMPLEMENT_THIS_OPTIMIZATION_LATER
+    uint32_t card_at_start = cardAtAddress(address);
+    // The end of this object is contained within this card
+    uint32_t card_at_end = cardAtAddress(address + length_in_bytes);
+
+    uint32_t cluster_at_start = clusterAtCard(card_at_start);
+    uint32_t cluster_at_end = clusterAtCard(card_at_end);
+
+    void *card_start_address = addressAtCard(card_at_start);
+    void *cluster_start_address = addressAtCluster(cluster_at_start);
+
+    uint8_t offset_in_card =
+      (address - card_start_address) / CardOffsetMultiplier;
+
+    if (!getHashObjectBit(card_at_start)) {
+      setHasObjectBit(card_at_start);
+      setFirstStart(card_at_start, offset_in_card);
+      setLastStart(card_at_start, offset_in_card);
+    } else {
+      if (offset_in_card < getFirstStart(card_at_start))
+	setFirstStart(card_at_start, offset_in_card);
+      if (offset_in_card > getLastStart(card_at_start))
+	setLastStart(card_at_last, offset_in_card);
+    }
+
+#ifdef SUPPORT_FOR_GET_CROSSING_OBJECT_START_NO_LONGER_REQUIRED
+
+    // What is the last card within the current cluster?
+    uint32_t next_cluster = cluster_at_start + 1;
+    uint32_t card_at_next_cluster = cardAtCluster(next_cluster);
+    uint32_t last_card_of_this_cluster = card_at_next_cluster - 1;
+    uint32_t last_card_in_cluster = ((card_at_end < last_card_of_this_cluster)
+				    ? card_at_end: last_card_of_this_cluster);
+
+    uint_16 crossing_map_within_cluster = address - cluster_at_start;
+
+    for (uint32_t card_to_update = card_at_start + 1;
+	 card_to_update < last_card_in_cluster; card_to_update++)
+      setCrossingObjectStart(card_to_update, crossing_map_within_cluster);
+
+    // If the last card region of this cluster is completely spanned
+    // by this new object,  set its crossing object start as well.
+    if (cluster_at_end > cluster_at_start) {
+      setCrossingObjectStart(card_to_update++, crossing_map_within_cluster);
+
+      // Now, we have to update all spanned cards that reside within the
+      // following clusters.
+      while (card_to_update < card_at_end)
+	setCrossingObjectStart(card_to_update++, CrossingObjectOverflow);
+
+      // Cases:
+      //
+      // 1. The region for card_at_end is not spanned at all because the
+      //    end of the new object aligns with the start of the last
+      //    card region.  In this case, we do nothing with the
+      //    card_at_end entry of the object_starts array.
+      //
+      // 2. The region for card_at_end is spanned partially.  In this
+      //    case, we do nothing with the card_at_end entry of the
+      //    object_starts array.
+      //
+      // 3. Do not need to consider the case that the region for
+      //    card_at_end is spanned entirely.  If the last region
+      //    spanned by a newly registered object is spanned in its
+      //    entirety, then card_at_end will identify the card region
+      //    that follows the object rather than the last region spanned
+      //    by the object.
+      
+      // Bottom line: no further work to be done in any of these cases.
+    }
+    // Otherwise, the last card region of this cluster is not
+    // completely spanned by this new object.  Leave the object_starts
+    // array entry alone.  Two cases: 
+    //
+    //  a) This newly registered object represents a consolidation of
+    //     multiple smaller objects, not including the object that
+    //     follows the consolidation.
+    //  b) This newly registered object is created by splitting a
+    //     previously existing object.  In this case, the other
+    //     objects resulting from the split will be registered
+    //     separately before it is necessary to lookup any information
+    //     within the object_starts array.
+    //
+
+#endif  // SUPPORT_FOR_GET_CROSSING_OBJECT_START_NO_LONGER_REQUIRED
+
+#else   // IMPLEMENT_THIS_OPTIMIZATION_LATER
+
+    // Do nothing for now as we have a brute-force implementation
+    // of findSpanningObject().
+
+#endif  // IMPLEMENT_THIS_OPTIMIZATION_LATER
+  }
+
+  // The typical use case is going to look something like this:
+  //   for each heapregion that comprises olg-gen memory
+  //     for each card number that corresponds to this heap region
+  //       scan the objects contained therein if the card is dirty
+  // To avoid excessive lookups in a sparse array, the API queries
+  // the card numbero pertaining to a particular address and then uses the
+  // card noumber for subsequent information lookups and stores.
+
+  // TO DO:
+  //   After correctness of implementation is proven, many of the following
+  //   services should be implemented as in-lines for improved performance.
+
+  // What card number corresponds to old-gen heap addresss p.  (If p
+  // does not refer to old-gen memory, the returned value is undefined.)
+  uint32_t cardNoForAddr(HeapWord *p);
+
+  // Returns true iff an object is known to start within the card memory
+  // associated with addr p.
+  // Returns true iff an object is known to start within the card memory
+  // associated with addr p.
+  bool hasObject(uint32_t card_no);
+
+  // If hasObject(card_no), this returns the word offset within this card
+  // memory at which the first object begins.
+  uint32_t getFirstStart(uint32_t card_no);
+
+  // If hasObject(card_no), this returns the word offset within this card
+  // memory at which the last object begins.
+  uint32_t getLastStart(uint32_t card_no);
+
+  // If !hasObject(card_no), this returns the offset within the
+  // enclosing cluster at which the object spanning the start of this
+  // card memory begins, or returns 0x7fff if the spanning object
+  // starts before the enclosing cluster.
+  uint32_t getCrossingObjectStart(uint32_t card_no);
+
+
+  inline HeapWord *addrForCardNo(uint32_t card_no) {
+    return _rs->addrForCardNo(card_no);
+  }
+
+  inline bool isCardDirty(uint32_t card_no) {
+    return _rs->isCardDirty(card_no);
+  }
+
+  inline void markCardAsDirty(uint32_t card_no) {
+    return _rs->markCardAsDirty(card_no);
+  }
+
+  inline void markCardAsClean(uint32_t card_no) {
+    return _rs->markCardAsClean(card_no);
+  }
+
+  inline void markOverreachCardAsDirty(uint32_t card_no) {
+    return _rs->markOverreachCardAsDirty(card_no);
+  }
+
+  inline bool isCardDirty(HeapWord *p) {
+    return _rs->isCardDirty(p);
+  }
+
+  inline void markCardAsDirty(HeapWord *p) {
+    return _rs->markCardAsDirty(p);
+  }
+
+  inline void markCardAsClean(HeapWord *p) {
+    return _rs->markCardAsClean(p);
+  }
+
+  inline void markOverreachCardAsDirty(void *p) {
+    return _rs->markOverreachCardAsDirty(p);
+  }
+
+  inline uint32_t clusterCount() {
+    return _rs->clusterCount();
+  }
+
+  inline void initializeOverreach(uint32_t first_cluster, uint32_t count) {
+    return _rs->initializeOverreach(first_cluster, count);
+  }
+
+  inline void mergeOverreach(uint32_t first_cluster, uint32_t count) {
+    return _rs->mergeOverreach(first_cluster, count);
+  }
+};
+
+// ShenandoahScanRemembered is a concrete class representing the
+// ability to scan the old-gen remembered set for references to
+// objects residing in young-gen memory.
+//
+// In an initial implementation, remembered set scanning happens
+// during a HotSpot safepoint.  This greatly simplifies the
+// implementation and improves efficiency of remembered set scanning,
+// but this design choice increases pause times experienced at the
+// start of concurrent marking and concurrent evacuation.  Pause times
+// will be especially long if old-gen memory holds many pointers to
+// young-gen memory.
+//
+// Scanning normally begins with an invocation of numRegions and ends
+// after all clusters of all regions have been scanned.
+//
+// Throughout the scanning effort, the number of regions does not
+// change.
+//
+// Even though the regions that comprise old-gen memory are not
+// necessarily contiguous, the abstraction represented by this class
+// identifies each of the old-gen regions with an integer value
+// in the range from 0 to (numRegions() - 1) inclusive.
+//
+
+template<typename RememberedSet>
+class ShenandoahScanRemembered {
+
+private:
+
+  ShenandoahCardCluster<RememberedSet> *_scc;
+
+public:
+  // How to instantiate this object?
+  //   ShenandoahDirectCardMarkRememberedSet *rs =
+  //       new ShenandoahDirectCardMarkRememberedSet();
+  //   scr = new
+  //     ShenandoahScanRememberd<ShenandoahDirectCardMarkRememberedSet>(rs);
+  //
+  // or, when fully implemented:
+  // 
+  //   ShenandoahBufferWithSATBRememberedSet *rs =
+  //       new ShenandoahBufferWithSATBRememberedSet();
+  //   scr = new
+  //     ShenandoahScanRememberd<ShenandoahBufferWithSATBRememberedSet>(rs);
+
+
+  ShenandoahScanRemembered(RememberedSet rs) {
+    _scc = new ShenandoahCardCluster<RememberedSet>(rs);
+  }
+  
+  ~ShenandoahScanRemembered() {
+    delete _scc;
+  }
+
+  // processClusters() scans a portion of the remembered set during a JVM
+  // safepoint as part of the root scanning activities that serve to
+  // initiate concurrent scanning and concurrent evacuation.  Multiple
+  // threads may scan different portions of the remembered set by
+  // making parallel invocations of processClusters() with each
+  // invocation scanning different clusters of the remembered set.
+  //
+  // An invocation of processClusters() examines all of the
+  // intergenerational references spanned by count clusters starting
+  // with first_cluster.  The oops argument is assumed to represent a
+  // thread-local OopClosure into which addresses of intergenerational
+  // pointer values will be accumulated for the purposes of root scanning.
+  //
+  // A side effect of executing processClusters() is to update the card
+  // table entries, marking dirty cards as clean if they no longer
+  // hold references to young-gen memory.  (THIS IS NOT YET IMPLEMENTED.)
+  //
+  // The implementation of processClusters() is designed to efficiently
+  // minimize work in the large majority of cases for which the
+  // associated cluster has very few dirty card-table entries.
+  //
+  // At initialization of concurrent marking, invoke processClusters with
+  // ClosureType equal to ShenandoahInitMarkRootsClosure.
+  //
+  // At initialization of concurrent evacuation, invoke processClusters with
+  // ClosureType equal to ShenandoahEvacuateUpdateRootsClosure.
+
+  template <typename ClosureType>
+  void processClusters(uint32_t first_cluster,
+		       uint32_t count, ClosureType *oops);
+
+  // To Do:
+  //  Create subclasses of ShenandoahInitMarkRootsClosure and
+  //  ShenandoahEvacuateUpdateRoootsClosure and any other closures
+  //  that need to participate in remembered set scanning.  Within the
+  //  subclasses, add a (probably templated) instance variable that
+  //  refers to the associated ShenandoahCardCluster object.  Use this
+  //  ShenandoahCardCluster instance to "enhance" the do_oops
+  //  processing so that we can:
+  //
+  //   1. Avoid processing references that correspond to clean card
+  //      regions, and
+  //   2. Set card status to CLEAN when the associated card region no
+  //      longer holds inter-generatioanal references.
+  //
+  //  To enable efficient implementation of these behaviors, we
+  //  probably also want to add a few fields into the
+  //  ShenandoahCardCluster object that allow us to precompute and
+  //  remember the addresses at which card status is going to change
+  //  from dirty to clean and clean to dirty.  The do_oops
+  //  implementations will want to update this value each time they
+  //  cross one of these boundaries.
+
+};
+
+#endif // SHARE_GC_SHENANDOAH_SHENANDOAHSCANREMEMBERED_HPP

--- a/src/hotspot/share/gc/shenandoah/shenandoahScanRemembered.hpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahScanRemembered.hpp
@@ -45,7 +45,7 @@
 //               that object will be scanned in its entirety). For these
 //               reasons, it is advisable for the multiple worker threads
 //               to be flexible in the number of clusters to be
-//               processed by each thread. 
+//               processed by each thread.
 
 
 
@@ -96,7 +96,7 @@
 //  Let old_regions = number of ShenandoahHeapRegion comprising
 //    old-gen memory
 //  Let region_size = ShenandoahHeapRegion::region_size_bytes()
-//    represent the number of bytes in each region 
+//    represent the number of bytes in each region
 //  Let clusters_per_region = region_size / 512
 //  Let rs represent the relevant RememberedSet implementation
 //    (an instance of ShenandoahBufferWithSATBRememberedSet or
@@ -123,7 +123,7 @@
 //    for each cluster contained within that region
 //      Assure that exactly one worker thread processes each
 //      cluster, each thread making a series of invocations of the
-//      following: 
+//      following:
 //
 //        rs->process_clusters(worker_id, ReferenceProcessor *,
 //                            ShenandoahConcurrentMark *, cluster_no, cluster_count,
@@ -144,7 +144,7 @@
 //           this cluster, the processing of this cluster gets a
 //           "free ride" because the thread responsible for processing
 //           the cluster that holds the object's header does the
-//           processing. 
+//           processing.
 //        d) in the case that the end of this cluster is spanned by a
 //           very large object, the processing of this cluster will
 //           be responsible for examining the entire object,
@@ -171,7 +171,7 @@
 //           associated with previous cluster scanning assignments,
 //           multiples of these next assignments may be serviced by
 //           the server threads that were previously assigned lighter
-//           workloads. 
+//           workloads.
 //        4. Make subsequent scanning assignments as follows:
 //             a) 8 assignments of size 16 clusters
 //             b) 8 assignments of size 8 clusters
@@ -204,7 +204,7 @@
 // into strong_roots_do and roots_do methods of ShenandoahRootScanner
 // (source file shenandoahRootProcessor.cpp) following the
 // construction of tc_cl and rm and before the call to
-// _serial_roots.oops_do(). 
+// _serial_roots.oops_do().
 //
 // To initiate concurrent evacuation, insert the above code sequences
 // into ShenandoahRootEvacuator::roots_do() before the invocation of
@@ -332,13 +332,13 @@ public:
 //     which some portions of the object will not be scanned by this
 //     thread:
 //     a) If an object spans multiple card regions, all of which are
-//        contained within the same cluster, the scanning thread 
+//        contained within the same cluster, the scanning thread
 //        consults the existing card-table entries and does not scan
 //        portions of the object that are not currently dirty.
 //     b) For any cluster that is spanned in its entirety by a very
 //        large object, the GC thread that scans this object assumes
 //        full responsibility for maintenance of the associated
-//        card-table entries. 
+//        card-table entries.
 //     c) If a cluster is partially spanned by an object originating
 //        in a preceding cluster, the portion of the object that
 //        partially spans the following cluster is scanned in its
@@ -405,7 +405,7 @@ public:
 //     unnecessary overscan, but it introduces different sorts of
 //     overhead effort:
 //       i) For each spanned cluster, we have to look up the start of
-//          the crossing object. 
+//          the crossing object.
 //      ii) Each time we scan the very large object, we have to
 //          sequentially walk through its pointer location
 //          descriptors, skipping over all of the pointers that
@@ -414,7 +414,7 @@ public:
 
 
 // Because old-gen heap memory is not necessarily contiguous, and
-// because cards are not necessarily maintained for young-gen memory, 
+// because cards are not necessarily maintained for young-gen memory,
 // consecutive card numbers do not necessarily correspond to consecutive
 // address ranges.  For the traditional direct-card-marking
 // implementation of this interface, consecutive card numbers are
@@ -430,7 +430,7 @@ public:
 //  3. (A corollary) In the case that an old-gen object spans the
 //     boundary between two heap regions, the card regions that
 //     correspond to the span of this object will be consecutively
-//     numbered. 
+//     numbered.
 
 
 // ShenandoahCardCluster abstracts access to the remembered set
@@ -505,7 +505,7 @@ public:
   //              stored in these bits is the special value 0x7fff.
   //              (Note that the maximum value required to represent a
   //              spanning object from within the current cluster is
-  //              ((63 * 64) - 8), which equals 0x0fbf. 
+  //              ((63 * 64) - 8), which equals 0x0fbf.
   //
   // In the absence of the need to support get_crossing_object_start(),
   // here is discussion of performance:
@@ -539,7 +539,7 @@ public:
   //
   // Consider further the following observations regarding object
   // registration costs:
-  // 
+  //
   //   1. The cost is paid once for each old-gen object (Except when
   //      an object is demoted and repromoted, in which case we would
   //      pay the cost again).
@@ -551,7 +551,7 @@ public:
   //      because:
   //      a) Most objects die young and objects that die in young-gen
   //         memory never need to be registered with the object_starts
-  //         array. 
+  //         array.
   //      b) Most objects that are promoted into old-gen memory live
   //         there without further relocation for a relatively long
   //         time, so we get a lot of benefit from each investment
@@ -635,7 +635,7 @@ public:
   //     time to do the post-processing of each GCLAB.
   //  3. Since only one GC thread at a time is registering objects
   //     belonging to a particular allocation buffer, no locking
-  //     is performed when registering these objects.  
+  //     is performed when registering these objects.
   //  4. Any remnant of unallocated memory within an expended GC
   //     allocation buffer is not returned to the old-gen allocation
   //     pool until after the GC allocation buffer has been post
@@ -651,7 +651,7 @@ public:
   //     by way of GCLAB buffers.  Multiple independent GC threads may
   //     attempt to tenure objects into a shared cluster.  This is why
   //     sychronization may be necessary.  Consider the following
-  //     scenarios: 
+  //     scenarios:
   //
   //     a) If two objects are tenured into the same card region, each
   //        registration may attempt to modify the first-start or
@@ -755,12 +755,12 @@ public:
       //    entirety, then card_at_end will identify the card region
       //    that follows the object rather than the last region spanned
       //    by the object.
-      
+
       // Bottom line: no further work to be done in any of these cases.
     }
     // Otherwise, the last card region of this cluster is not
     // completely spanned by this new object.  Leave the object_starts
-    // array entry alone.  Two cases: 
+    // array entry alone.  Two cases:
     //
     //  a) This newly registered object represents a consolidation of
     //     multiple smaller objects, not including the object that
@@ -869,7 +869,7 @@ public:
   //     ShenandoahScanRememberd<ShenandoahDirectCardMarkRememberedSet>(rs);
   //
   // or, when fully implemented:
-  // 
+  //
   //   ShenandoahBufferWithSATBRememberedSet *rs =
   //       new ShenandoahBufferWithSATBRememberedSet();
   //   scr = new

--- a/src/hotspot/share/gc/shenandoah/shenandoahScanRemembered.inline.hpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahScanRemembered.inline.hpp
@@ -1,0 +1,401 @@
+/*
+ * Copyright (c) Amazon.com, Inc. or its affiliates.  All rights reserved.
+ *
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ *
+ */
+
+#ifndef SHARE_GC_SHENANDOAH_SHENANDOAHSCANREMEMBEREDINLINE_HPP
+#define SHARE_GC_SHENANDOAH_SHENANDOAHSCANREMEMBEREDINLINE_HPP
+
+#include "memory/iterator.hpp"
+#include "oops/oop.hpp"
+#include "oops/objArrayOop.hpp"
+#include "gc/shenandoah/shenandoahCardTable.hpp"
+#include "gc/shenandoah/shenandoahHeap.hpp"
+#include "gc/shenandoah/shenandoahHeapRegion.hpp"
+#include "gc/shenandoah/shenandoahScanRemembered.hpp"
+
+#include "gc/shenandoah/shenandoahBufferWithSATBRememberedSet.inline.hpp"
+
+inline uint32_t
+ShenandoahDirectCardMarkRememberedSet::card_index_for_addr(HeapWord *p) {
+  return (uint32_t) _card_table->index_for(p);
+}
+
+inline HeapWord *
+ShenandoahDirectCardMarkRememberedSet::addr_for_card_index(uint32_t card_index) {
+  return _whole_heap_base + CardTable::card_size_in_words * card_index;
+}
+
+inline bool
+ShenandoahDirectCardMarkRememberedSet::is_card_dirty(uint32_t card_index) {
+  uint8_t *bp = &_byte_map[card_index];
+  return (bp[0] == CardTable::dirty_card_val());
+}
+
+inline void
+ShenandoahDirectCardMarkRememberedSet::mark_card_as_dirty(uint32_t card_index) {
+  uint8_t *bp = &_byte_map[card_index];
+  bp[0] = CardTable::dirty_card_val();
+}
+
+inline void
+ShenandoahDirectCardMarkRememberedSet::mark_card_as_clean(uint32_t card_index) {
+  uint8_t *bp = &_byte_map[card_index];
+  bp[0] = CardTable::clean_card_val();
+}
+
+inline void
+ShenandoahDirectCardMarkRememberedSet::mark_overreach_card_as_dirty(
+    uint32_t card_index) {
+  uint8_t *bp = &_overreach_map[card_index];
+  bp[0] = CardTable::dirty_card_val();
+}
+
+inline bool
+ShenandoahDirectCardMarkRememberedSet::is_card_dirty(HeapWord *p) {
+  uint8_t *bp = &_byte_map_base[uintptr_t(p) >> _card_shift];
+  return (bp[0] == CardTable::dirty_card_val());
+}
+
+inline void
+ShenandoahDirectCardMarkRememberedSet::mark_card_as_dirty(HeapWord *p) {
+  uint8_t *bp = &_byte_map_base[uintptr_t(p) >> _card_shift];
+  bp[0] = CardTable::dirty_card_val();
+}
+
+inline void
+ShenandoahDirectCardMarkRememberedSet::mark_card_as_clean(HeapWord *p) {
+  uint8_t *bp = &_byte_map_base[uintptr_t(p) >> _card_shift];
+  bp[0] = CardTable::clean_card_val();
+}
+
+inline void
+ShenandoahDirectCardMarkRememberedSet::mark_overreach_card_as_dirty(void *p) {
+  uint8_t *bp = &_overreach_map_base[uintptr_t(p) >> _card_shift];
+  bp[0] = CardTable::dirty_card_val();
+}
+
+inline uint32_t
+ShenandoahDirectCardMarkRememberedSet::cluster_count() {
+  return _cluster_count;
+}
+
+
+template<typename RememberedSet>
+inline uint32_t
+ShenandoahCardCluster<RememberedSet>::card_index_for_addr(HeapWord *p) {
+  return _rs->card_index_for_addr(p);
+}
+
+template<typename RememberedSet>
+inline bool
+ShenandoahCardCluster<RememberedSet>::has_object(uint32_t card_index) {
+
+  HeapWord *addr = _rs->addr_for_card_index(card_index);
+
+  ShenandoahHeap *heap = ShenandoahHeap::heap();
+  ShenandoahHeapRegion *region = heap->heap_region_containing(addr);
+
+  // Apparently, region->block_start(addr) is not robust to inquiries beyond top() and it crashes.
+  if (region->top() <= addr)
+    return false;
+
+  HeapWord *obj = region->block_start(addr);
+
+  // addr is the first address of the card region.
+  // obj is the object that spans addr (or starts at addr).
+  assert(obj != NULL, "Object cannot be null");
+  if (obj >= addr)
+    return true;
+  else {
+    HeapWord *end_addr = addr + CardTable::card_size_in_words;
+
+    // end_addr needs to be adjusted downward if top address of the enclosing region is less than end_addr.  this is intended
+    // to be slow and reliable alternative to the planned production quality replacement, so go ahead and spend some extra
+    // cycles here in order to make this code reliable.
+    if (region->top() < end_addr) {
+      end_addr = region->top();
+    }
+
+    obj += oop(obj)->size();
+    if (obj < end_addr)
+      return true;
+    else
+      return false;
+  }
+}
+
+template<typename RememberedSet>
+inline uint32_t
+ShenandoahCardCluster<RememberedSet>::get_first_start(uint32_t card_index) {
+  HeapWord *addr = _rs->addr_for_card_index(card_index);
+  ShenandoahHeap *heap = ShenandoahHeap::heap();
+  ShenandoahHeapRegion *region = heap->heap_region_containing(addr);
+
+  HeapWord *obj = region->block_start(addr);
+
+  assert(obj != NULL, "Object cannot be null.");
+  if (obj >= addr)
+    return obj - addr;
+  else {
+    HeapWord *end_addr = addr + CardTable::card_size_in_words;
+    obj += oop(obj)->size();
+
+    // If obj > end_addr, offset will reach beyond end of this card
+    // region.  But clients should not invoke this service unless
+    // they first confirm that this card has an object.
+    assert(obj < end_addr, "Object out of range");
+    return obj - addr;
+  }
+}
+
+template<typename RememberedSet>
+inline uint32_t
+ShenandoahCardCluster<RememberedSet>::get_last_start(uint32_t card_index) {
+  HeapWord *addr = _rs->addr_for_card_index(card_index);
+  HeapWord *end_addr = addr + CardTable::card_size_in_words;
+  ShenandoahHeap *heap = ShenandoahHeap::heap();
+  ShenandoahHeapRegion *region = heap->heap_region_containing(addr);
+  HeapWord *obj = region->block_start(addr);
+  assert(obj != NULL, "Object cannot be null.");
+
+  if (region->top() <= end_addr) {
+    end_addr = region->top();
+  }
+
+  HeapWord *end_obj = obj + oop(obj)->size();
+  while (end_obj < end_addr) {
+    obj = end_obj;
+    end_obj = obj + oop(obj)->size();
+  }
+  assert(obj >= addr, "Object out of range.");
+  return obj - addr;
+}
+
+template<typename RememberedSet>
+inline uint32_t
+ShenandoahCardCluster<RememberedSet>::get_crossing_object_start(uint32_t card_index) {
+  HeapWord *addr = _rs->addr_for_card_index(card_index);
+  uint32_t cluster_no = card_index / ShenandoahCardCluster<RememberedSet>::CardsPerCluster;
+  HeapWord *cluster_addr = _rs->addr_for_card_index(cluster_no * CardsPerCluster);
+
+  ShenandoahHeap *heap = ShenandoahHeap::heap();
+  ShenandoahHeapRegion *region = heap->heap_region_containing(addr);
+  HeapWord *obj = region->block_start(addr);
+
+  if (obj > cluster_addr)
+    return obj - cluster_addr;
+  else
+    return 0x7fff;
+}
+
+template<typename RememberedSet>
+inline HeapWord *
+ShenandoahCardCluster<RememberedSet>::addr_for_card_index(uint32_t card_index) {
+  return _rs->addr_for_card_index(card_index);
+}
+
+template<typename RememberedSet>
+inline bool
+ShenandoahCardCluster<RememberedSet>::is_card_dirty(uint32_t card_index) {
+  return _rs->is_card_dirty(card_index);
+}
+
+template<typename RememberedSet>
+inline void
+ShenandoahCardCluster<RememberedSet>::mark_card_as_dirty(uint32_t card_index) {
+  return _rs->mark_card_as_dirty(card_index);
+}
+
+template<typename RememberedSet>
+inline void
+ShenandoahCardCluster<RememberedSet>::mark_card_as_clean(uint32_t card_index) {
+  return _rs->mark_card_as_clean(card_index);
+}
+
+template<typename RememberedSet>
+inline void
+ShenandoahCardCluster<RememberedSet>::mark_overreach_card_as_dirty(uint32_t card_index) {
+  return _rs->mark_overreach_card_as_dirty(card_index);
+}
+
+template<typename RememberedSet>
+inline bool
+ShenandoahCardCluster<RememberedSet>::is_card_dirty(HeapWord *p) {
+  return _rs->is_card_dirty(p);
+}
+
+template<typename RememberedSet>
+inline void
+ShenandoahCardCluster<RememberedSet>::mark_card_as_dirty(HeapWord *p) {
+  return _rs->mark_card_as_dirty(p);
+}
+
+template<typename RememberedSet>
+inline void
+ShenandoahCardCluster<RememberedSet>::mark_card_as_clean(HeapWord *p) {
+  return _rs->mark_card_as_clean(p);
+}
+
+template<typename RememberedSet>
+inline void
+ShenandoahCardCluster<RememberedSet>::mark_overreach_card_as_dirty(void *p) {
+  return _rs->mark_overreach_card_as_dirty(p);
+}
+
+template<typename RememberedSet>
+inline uint32_t
+ShenandoahCardCluster<RememberedSet>::cluster_count() {
+  return _rs->cluster_count();
+}
+
+template<typename RememberedSet>
+inline void
+ShenandoahCardCluster<RememberedSet>::initialize_overreach(uint32_t first_cluster, uint32_t count) {
+  return _rs->initialize_overreach(first_cluster, count);
+}
+
+template<typename RememberedSet>
+inline void
+ShenandoahCardCluster<RememberedSet>::merge_overreach(uint32_t first_cluster, uint32_t count) {
+  return _rs->merge_overreach(first_cluster, count);
+}
+
+template<typename RememberedSet>
+ShenandoahScanRemembered<RememberedSet>::ShenandoahScanRemembered(RememberedSet *rs) {
+  _scc = new ShenandoahCardCluster<RememberedSet>(rs);
+}
+
+template<typename RememberedSet>
+ShenandoahScanRemembered<RememberedSet>::~ShenandoahScanRemembered() {
+  delete _scc;
+}
+
+template<typename RememberedSet>
+template <typename ClosureType>
+inline void
+ShenandoahScanRemembered<RememberedSet>::process_clusters(uint worker_id, ShenandoahReferenceProcessor* rp, ShenandoahConcurrentMark* cm,
+                                                          uint32_t first_cluster, uint32_t count, HeapWord *end_of_range,
+                                                          ClosureType *oops) {
+
+  // Unlike traditional Shenandoah marking, the old-gen resident objects that are examined as part of the remembered set are not
+  // themselves marked.  Each such object will be scanned only once.  Any young-gen objects referenced from the remembered set will
+  // be marked and then subsequently scanned.
+
+  while (count-- > 0) {
+    uint32_t card_index = first_cluster * ShenandoahCardCluster<RememberedSet>::CardsPerCluster;
+    uint32_t end_card_index = card_index + ShenandoahCardCluster<RememberedSet>::CardsPerCluster;
+
+    first_cluster++;
+    int next_card_index = 0;
+    while (card_index < end_card_index) {
+      int is_dirty = _scc->is_card_dirty(card_index);
+      int has_object = _scc->has_object(card_index);
+
+      if (is_dirty) {
+        if (has_object) {
+          // Scan all objects that start within this card region.
+          uint32_t start_offset = _scc->get_first_start(card_index);
+          HeapWord *p = _scc->addr_for_card_index(card_index);
+          HeapWord *endp = p + CardTable::card_size_in_words;
+          if (endp > end_of_range) {
+            endp = end_of_range;
+            next_card_index = end_card_index;
+          } else {
+            // endp either points to start of next card region, or to the next object that needs to be scanned, which may
+            // reside in some successor card region.
+            next_card_index = _scc->card_index_for_addr(endp);
+          }
+
+          p += start_offset;
+          while (p < endp) {
+            oop obj = oop(p);
+            // Future TODO:
+            // For improved efficiency, we might want to give special handling of obj->is_objArray().  In
+            // particular, in that case, we might want to divide the effort for scanning of a very long object array
+            // between multiple threads.
+            if (obj->is_objArray()) {
+              ShenandoahObjToScanQueue* q = cm->get_queue(worker_id);
+              ShenandoahMarkRefsClosure<YOUNG> cl(q, rp);
+              objArrayOop array = objArrayOop(obj);
+              int len = array->length();
+              array->oop_iterate_range(&cl, 0, len);
+            } else {
+              oops->do_oop(&obj);
+            }
+            p += obj->size();
+          }
+          card_index = next_card_index;
+        } else {
+          // otherwise, this card will have been scanned during scan of a previous cluster.
+          card_index++;
+        }
+      } else if (_scc->has_object(card_index)) {
+        // Scan the last object that starts within this card memory if it spans at least one dirty card within this cluster
+        // or if it reaches into the next cluster.
+        uint32_t start_offset = _scc->get_last_start(card_index);
+        HeapWord *p = _scc->addr_for_card_index(card_index) + start_offset;
+        oop obj = oop(p);
+        HeapWord *nextp = p + obj->size();
+        uint32_t last_card = _scc->card_index_for_addr(nextp);
+
+        bool reaches_next_cluster = (last_card > end_card_index);
+        bool spans_dirty_within_this_cluster = false;
+
+        if (!reaches_next_cluster) {
+          uint32_t span_card;
+          for (span_card = card_index+1; span_card < end_card_index; span_card++)
+            if (_scc->is_card_dirty(span_card)) {
+              spans_dirty_within_this_cluster = true;
+              break;
+            }
+        }
+        if (reaches_next_cluster || spans_dirty_within_this_cluster) {
+          if (obj->is_objArray()) {
+            ShenandoahObjToScanQueue* q = cm->get_queue(worker_id); // kelvin to confirm: get_queue wants worker_id
+            ShenandoahMarkRefsClosure<YOUNG> cl(q, rp);
+            objArrayOop array = objArrayOop(obj);
+            int len = array->length();
+            array->oop_iterate_range(&cl, 0, len);
+          } else {
+            oops->do_oop(&obj);
+          }
+        }
+        // Increment card_index to account for the spanning object, even if we didn't scan it.
+        card_index = (last_card > card_index)? last_card: card_index + 1;
+      } else {
+        card_index++;
+      }
+    }
+  }
+}
+
+template<typename RememberedSet>
+inline uint32_t
+ShenandoahScanRemembered<RememberedSet>::cluster_for_addr(HeapWordImpl **addr) {
+  uint32_t card_index = _scc->card_index_for_addr(addr);
+  uint32_t result = card_index / ShenandoahCardCluster<RememberedSet>::CardsPerCluster;
+  return result;
+}
+
+#endif   // SHARE_GC_SHENANDOAH_SHENANDOAHSCANREMEMBEREDINLINE_HPP

--- a/src/hotspot/share/oops/constantPool.cpp
+++ b/src/hotspot/share/oops/constantPool.cpp
@@ -1183,15 +1183,35 @@ void ConstantPool::copy_bootstrap_arguments_at_impl(const constantPoolHandle& th
   }
 }
 
+#undef TRACE_STRING_AT_IMPL
+
 oop ConstantPool::string_at_impl(const constantPoolHandle& this_cp, int which, int obj_index, TRAPS) {
   // If the string has already been interned, this entry will be non-null
+#ifdef TRACE_STRING_AT_IMPL
+  printf("ConstantPool::string_at_impl(which: %d, obj_index: %d)\n", which, obj_index);
+#endif
   oop str = this_cp->resolved_references()->obj_at(obj_index);
+#ifdef TRACE_STRING_AT_IMPL
+  printf(" str is %llx\n", (unsigned long long) cast_from_oop<HeapWord *>(str));
+#endif
   assert(str != Universe::the_null_sentinel(), "");
   if (str != NULL) return str;
   Symbol* sym = this_cp->unresolved_string_at(which);
+#ifdef TRACE_STRING_AT_IMPL
+  printf(" sym is %llx\n", (unsigned long long) sym);
+#endif
   str = StringTable::intern(sym, CHECK_(NULL));
+#ifdef TRACE_STRING_AT_IMPL
+  printf(" Interned str is %llx\n", (unsigned long long) cast_from_oop<HeapWord *>(str));
+#endif
   this_cp->string_at_put(which, obj_index, str);
+#ifdef TRACE_STRING_AT_IMPL
+  printf(" put string at which: %d, obj_index: %d\n", which, obj_index);
+#endif
   assert(java_lang_String::is_instance(str), "must be string");
+#ifdef TRACE_STRING_AT_IMPL
+  printf(" returning string %llx\n", (unsigned long long) cast_from_oop<HeapWord *>(str));
+#endif
   return str;
 }
 


### PR DESCRIPTION
Add support for scanning remembered set
    
The code has support for two alternative implementations of the remembered set.  The current remembered set implementation uses traditional card marking, where the post writer barrier for pointer write operations sets the mark for every overwritten card.
    
A contemplated future remembered set implementation is represented in skeleton form within the shenandoahBufferWithSATBRememberedSet.hpp and shenandoahBufferWithSATBRememberedSet.inline.hpp files.  The idea of this alternative remembered set implementation is that the existing SATB buffers will be augmented to additionally remember the address of each overwritten reference field.  Subsequent processing of the SATB buffer contents by background GC threads will update the TBD remembered set representation.
    
There are known bugs and performance improvements in the remembered set scanning implementation that have been addressed in certain Amazon-internal commits.  These commits will be upstreamed at a later time after other commits not directly related to remembered set scanning are upstreamed.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [ ] Change must be properly reviewed

### Error
&nbsp;⚠️ OCA signatory status must be verified

### Download
`$ git fetch https://git.openjdk.java.net/shenandoah pull/11/head:pull/11`
`$ git checkout pull/11`
