### PR TITLE
Mark concurrent roots as global when requested to do so, instead of young

### DIFF
--- a/src/hotspot/share/gc/shenandoah/shenandoahConcurrentMark.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahConcurrentMark.cpp
@@ -233,7 +233,7 @@ void ShenandoahConcurrentMark::mark_concurrent_roots(ShenandoahGeneration* gener
       break;
     }
     case GLOBAL: {
-      ShenandoahMarkConcurrentRootsTask<YOUNG> task(this, task_queues(), rp, ShenandoahPhaseTimings::conc_mark_roots, workers->active_workers());
+      ShenandoahMarkConcurrentRootsTask<GLOBAL> task(this, task_queues(), rp, ShenandoahPhaseTimings::conc_mark_roots, workers->active_workers());
       workers->run_task(&task);
       break;
     }


### PR DESCRIPTION
This is probably a merge error from the last big merge that brought in concurrent roots marking.

Testing:
 - [x] hotspot_gc_shenandoah
 - [x] tier1 (+UseShenandoahGC)

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

### Reviewers
 * [Aleksey Shipilev](https://openjdk.java.net/census#shade) (@shipilev - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/shenandoah pull/15/head:pull/15`
`$ git checkout pull/15`
