### PR TITLE
Fix builds that do not have Shenandoah or other GCs

### DIFF
--- a/src/hotspot/share/gc/shared/gcConfiguration.cpp
+++ b/src/hotspot/share/gc/shared/gcConfiguration.cpp
@@ -35,60 +35,46 @@
 #include "utilities/macros.hpp"
 
 GCName GCConfiguration::young_collector() const {
-#if INCLUDE_G1GC
   if (UseG1GC) {
     return G1New;
   }
-#endif
 
-#if INCLUDE_PARALLELGC
   if (UseParallelGC) {
     return ParallelScavenge;
   }
-#endif
 
-#if INCLUDE_SHENANDOAHGC
   if (UseShenandoahGC) {
+#if INCLUDE_SHENANDOAHGC
     if (strcmp(ShenandoahGCMode, "generational") == 0) {
       return Shenandoah;
     }
+#endif
     return NA;
   }
-#endif
 
-#if INCLUDE_ZGC
   if (UseZGC) {
     return NA;
   }
-#endif
 
   return DefNew;
 }
 
 GCName GCConfiguration::old_collector() const {
-#if INCLUDE_G1GC
   if (UseG1GC) {
     return G1Old;
   }
-#endif
 
-#if INCLUDE_PARALLELGC
   if (UseParallelGC) {
     return ParallelOld;
   }
-#endif
 
-#if INCLUDE_ZGC
   if (UseZGC) {
     return Z;
   }
-#endif
 
-#if INCLUDE_SHENANDOAHGC
   if (UseShenandoahGC) {
     return Shenandoah;
   }
-#endif
 
   return SerialOld;
 }

--- a/src/hotspot/share/gc/shared/gcConfiguration.cpp
+++ b/src/hotspot/share/gc/shared/gcConfiguration.cpp
@@ -32,46 +32,63 @@
 #include "runtime/globals.hpp"
 #include "runtime/globals_extension.hpp"
 #include "utilities/debug.hpp"
+#include "utilities/macros.hpp"
 
 GCName GCConfiguration::young_collector() const {
+#if INCLUDE_G1GC
   if (UseG1GC) {
     return G1New;
   }
+#endif
 
+#if INCLUDE_PARALLELGC
   if (UseParallelGC) {
     return ParallelScavenge;
   }
+#endif
 
+#if INCLUDE_SHENANDOAHGC
   if (UseShenandoahGC) {
     if (strcmp(ShenandoahGCMode, "generational") == 0) {
       return Shenandoah;
     }
     return NA;
   }
+#endif
 
+#if INCLUDE_ZGC
   if (UseZGC) {
     return NA;
   }
+#endif
 
   return DefNew;
 }
 
 GCName GCConfiguration::old_collector() const {
+#if INCLUDE_G1GC
   if (UseG1GC) {
     return G1Old;
   }
+#endif
 
+#if INCLUDE_PARALLELGC
   if (UseParallelGC) {
     return ParallelOld;
   }
+#endif
 
+#if INCLUDE_ZGC
   if (UseZGC) {
     return Z;
   }
+#endif
 
+#if INCLUDE_SHENANDOAHGC
   if (UseShenandoahGC) {
     return Shenandoah;
   }
+#endif
 
   return SerialOld;
 }


### PR DESCRIPTION
Lots of builds are currently failing with:

```
/home/buildbot/worker/build-shenandoah-jdkX-linux/build/src/hotspot/share/gc/shared/gcConfiguration.cpp: In member function 'GCName GCConfiguration::young_collector() const':
/home/buildbot/worker/build-shenandoah-jdkX-linux/build/src/hotspot/share/gc/shared/gcConfiguration.cpp:46:16: error: 'ShenandoahGCMode' was not declared in this scope
     if (strcmp(ShenandoahGCMode, "generational") == 0) {
                ^~~~~~~~~~~~~~~~
```

The new code in `gcConfiguration.cpp` should actually sense which configurations are available.

Additional testing:
 - [x] Linux PPC64 build (as one failing example), now passing
 - [x] Linux x86_64 `gc/shenandoah/generational` tests

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

### Reviewers
 * [Roman Kennke](https://openjdk.java.net/census#rkennke) (@rkennke - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/shenandoah pull/16/head:pull/16`
`$ git checkout pull/16`
