### PR TITLE
Fix Windows build failures

### DIFF
--- a/src/hotspot/share/gc/shenandoah/shenandoahScanRemembered.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahScanRemembered.cpp
@@ -33,7 +33,7 @@ ShenandoahDirectCardMarkRememberedSet::ShenandoahDirectCardMarkRememberedSet(Car
   _heap = ShenandoahHeap::heap();
   _card_table = card_table;
   _total_card_count = total_card_count;
-  _cluster_count = (total_card_count / ShenandoahCardCluster<ShenandoahDirectCardMarkRememberedSet>::CardsPerCluster);
+  _cluster_count = uint32_t(total_card_count / ShenandoahCardCluster<ShenandoahDirectCardMarkRememberedSet>::CardsPerCluster);
   _card_shift = CardTable::card_shift;
 
   _byte_map = _card_table->byte_for_index(0);


### PR DESCRIPTION
Current Windows builds fail with:

```
c:\buildbot\worker\build-shenandoah-jdkx-windows\build\src\hotspot\share\gc\shenandoah\shenandoahScanRemembered.cpp(36): error C2220: the following warning is treated as an error
c:\buildbot\worker\build-shenandoah-jdkx-windows\build\src\hotspot\share\gc\shenandoah\shenandoahScanRemembered.cpp(36): warning C4267: '=': conversion from 'size_t' to 'uint32_t', possible loss of data
make[3]: *** [lib/CompileJvm.gmk:143: /cygdrive/c/buildbot/worker/build-shenandoah-jdkx-windows/build/build/windows-x86_64-server-fastdebug/hotspot/variant-server/libjvm/objs/shenandoahScanRemembered.obj] Error 1
```

Additional testing:
 - [x] Windows builds

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

### Reviewers
 * [Roman Kennke](https://openjdk.java.net/census#rkennke) (@rkennke - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/shenandoah pull/17/head:pull/17`
`$ git checkout pull/17`
