### PR TITLE
Fix Zero builds

### DIFF
--- a/src/hotspot/share/gc/shenandoah/mode/shenandoahGenerationalMode.cpp
+++ b/src/hotspot/share/gc/shenandoah/mode/shenandoahGenerationalMode.cpp
@@ -28,6 +28,9 @@
 #include "gc/shenandoah/heuristics/shenandoahCompactHeuristics.hpp"
 #include "gc/shenandoah/heuristics/shenandoahStaticHeuristics.hpp"
 #include "gc/shenandoah/mode/shenandoahGenerationalMode.hpp"
+#include "logging/log.hpp"
+#include "logging/logTag.hpp"
+#include "runtime/globals_extension.hpp"
 #include "runtime/java.hpp"
 
 void ShenandoahGenerationalMode::initialize_flags() const {


### PR DESCRIPTION
Zero builds currently fail with:

```
In file included from /home/shade/trunks/shenandoah-jdk/src/hotspot/share/gc/shenandoah/heuristics/shenandoahAdaptiveHeuristics.hpp:28,
                 from /home/shade/trunks/shenandoah-jdk/src/hotspot/share/gc/shenandoah/mode/shenandoahGenerationalMode.cpp:26:
/home/shade/trunks/shenandoah-jdk/src/hotspot/share/gc/shenandoah/mode/shenandoahGenerationalMode.cpp: In member function 'virtual void ShenandoahGenerationalMode::initialize_flags() const':
/home/shade/trunks/shenandoah-jdk/src/hotspot/share/gc/shenandoah/heuristics/shenandoahHeuristics.hpp:45:16: error: 'gc' was not declared in this scope; did you mean 'StackWatermarkKind::gc'?
   45 |       log_info(gc)("Heuristics ergonomically sets -XX:+" #name);            \
      |                ^~
/home/shade/trunks/shenandoah-jdk/src/hotspot/share/gc/shenandoah/mode/shenandoahGenerationalMode.cpp:39:3: note: in expansion of macro 'SHENANDOAH_ERGO_ENABLE_FLAG'
   39 |   SHENANDOAH_ERGO_ENABLE_FLAG(ExplicitGCInvokesConcurrent);
      |   ^~~~~~~~~~~~~~~~~~~~~~~~~~~
In file included from /home/shade/trunks/shenandoah-jdk/src/hotspot/share/runtime/stackWatermarkSet.hpp:29,
                 from /home/shade/trunks/shenandoah-jdk/src/hotspot/share/runtime/thread.hpp:42,
                 from /home/shade/trunks/shenandoah-jdk/src/hotspot/share/runtime/safepoint.hpp:30,
                 from /home/shade/trunks/shenandoah-jdk/src/hotspot/share/gc/shared/collectedHeap.hpp:35,
                 from /home/shade/trunks/shenandoah-jdk/src/hotspot/share/gc/shenandoah/shenandoahHeap.hpp:30,
                 from /home/shade/trunks/shenandoah-jdk/src/hotspot/share/gc/shenandoah/heuristics/shenandoahHeuristics.hpp:28,
   ... (rest of output omitted)
```

This is because we are missing the "log" includes (look at `shenandoahSATBMode.cpp` for comparison), which are not transitively available with Zero builds.

Additional testing: 
 - [x] Linux x86_64 Zero build (now passes)

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

### Reviewers
 * [Roman Kennke](https://openjdk.java.net/census#rkennke) (@rkennke - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/shenandoah pull/18/head:pull/18`
`$ git checkout pull/18`
