### PR TITLE
Update periodic gc test for changed heuristic log message

### DIFF
--- a/src/hotspot/share/gc/shenandoah/shenandoahRegulatorThread.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahRegulatorThread.cpp
@@ -91,10 +91,12 @@ void ShenandoahRegulatorThread::regulate_interleaved_cycles() {
   assert(_global_heuristics != NULL, "Need global heuristics.");
 
   while (!should_terminate()) {
-    if (start_global_cycle()) {
-      log_info(gc)("Heuristics request for global collection accepted.");
-    } else if (start_young_cycle()) {
-      log_info(gc)("Heuristics request for young collection accepted.");
+    if (_control_thread->gc_mode() == ShenandoahControlThread::none) {
+      if (start_global_cycle()) {
+        log_info(gc)("Heuristics request for global collection accepted.");
+      } else if (start_young_cycle()) {
+        log_info(gc)("Heuristics request for young collection accepted.");
+      }
     }
 
     regulator_sleep();
@@ -105,8 +107,10 @@ void ShenandoahRegulatorThread::regulate_heap() {
   assert(_global_heuristics != NULL, "Need global heuristics.");
 
   while (!should_terminate()) {
-    if (start_global_cycle()) {
-      log_info(gc)("Heuristics request for global collection accepted.");
+    if (_control_thread->gc_mode() == ShenandoahControlThread::none) {
+      if (start_global_cycle()) {
+        log_info(gc)("Heuristics request for global collection accepted.");
+      }
     }
 
     regulator_sleep();

--- a/test/hotspot/jtreg/gc/shenandoah/TestPeriodicGC.java
+++ b/test/hotspot/jtreg/gc/shenandoah/TestPeriodicGC.java
@@ -46,10 +46,10 @@ public class TestPeriodicGC {
 
         OutputAnalyzer output = new OutputAnalyzer(pb.start());
         output.shouldHaveExitValue(0);
-        if (periodic && !output.getOutput().contains("Trigger: Time since last GC")) {
+        if (periodic && !output.getOutput().contains("Trigger (GLOBAL): Time since last GC")) {
             throw new AssertionError(msg + ": Should have periodic GC in logs");
         }
-        if (!periodic && output.getOutput().contains("Trigger: Time since last GC")) {
+        if (!periodic && output.getOutput().contains("Trigger (GLOBAL): Time since last GC")) {
             throw new AssertionError(msg + ": Should not have periodic GC in logs");
         }
     }


### PR DESCRIPTION
This also includes a change to hold down regulator requests when the GC is already running in non-generational modes.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

### Reviewers
 * [Roman Kennke](https://openjdk.java.net/census#rkennke) (@rkennke - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/shenandoah pull/21/head:pull/21`
`$ git checkout pull/21`
