### PR TITLE
Only scan dirty cards, not entire regions, in update refs remset scan.

### DIFF
--- a/src/hotspot/share/gc/shenandoah/shenandoahScanRemembered.hpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahScanRemembered.hpp
@@ -213,6 +213,7 @@
 #include "memory/iterator.hpp"
 #include "gc/shared/workgroup.hpp"
 #include "gc/shenandoah/shenandoahCardTable.hpp"
+#include "gc/shenandoah/shenandoahHeapRegion.hpp"
 #include "gc/shenandoah/shenandoahTaskqueue.hpp"
 
 class ShenandoahReferenceProcessor;
@@ -929,6 +930,8 @@ public:
   template <typename ClosureType>
   inline void process_clusters(size_t first_cluster, size_t count, HeapWord *end_of_range, ClosureType *oops);
 
+  template <typename ClosureType>
+  inline void process_region(ShenandoahHeapRegion* region, ClosureType *cl);
 
   // To Do:
   //  Create subclasses of ShenandoahInitMarkRootsClosure and


### PR DESCRIPTION
So far in update refs, when iterating over regions to process the remset, we scan an entire region for references into young gen if we find any dirty card in it. With this update, we only process dirty cards in each region and leave out clean ones. To do so, we refactor the scan code from the marking phase into a method that is then reused for update refs, passing down a different closure. The JVM switch `ShenandoahUseSimpleCardScanning` provides a means to fall back on the previous code.

(In the future, we may want to replace region stealing with card stealing.)

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

### Reviewers
 * [Roman Kennke](https://openjdk.java.net/census#rkennke) (@rkennke - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/shenandoah pull/22/head:pull/22`
`$ git checkout pull/22`
