### PR TITLE
Fix ShenandoahPurgeSATBTask

### DIFF
--- a/src/hotspot/share/gc/shenandoah/shenandoahOldGeneration.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahOldGeneration.cpp
@@ -32,24 +32,21 @@
 #include "gc/shenandoah/shenandoahMark.inline.hpp"
 #include "gc/shenandoah/shenandoahOldGeneration.hpp"
 #include "gc/shenandoah/shenandoahOopClosures.inline.hpp"
+#include "gc/shenandoah/shenandoanRootProcessor.hpp"
 #include "gc/shenandoah/shenandoahStringDedup.hpp"
 #include "gc/shenandoah/shenandoahUtils.hpp"
 
 class ShenandoahFlushAllSATB : public ThreadClosure {
  private:
   SATBMarkQueueSet& _satb_qset;
-  uintx _claim_token;
 
  public:
   explicit ShenandoahFlushAllSATB(SATBMarkQueueSet& satb_qset) :
-    _satb_qset(satb_qset),
-    _claim_token(Threads::thread_claim_token()) {}
+    _satb_qset(satb_qset) { }
 
   void do_thread(Thread* thread) {
-    if (thread->claim_threads_do(true, _claim_token)) {
-      // Transfer any partial buffer to the qset for completed buffer processing.
-      _satb_qset.flush_queue(ShenandoahThreadLocalData::satb_mark_queue(thread));
-    }
+    // Transfer any partial buffer to the qset for completed buffer processing.
+    _satb_qset.flush_queue(ShenandoahThreadLocalData::satb_mark_queue(thread));
   }
 };
 
@@ -92,13 +89,18 @@ class ShenandoahProcessOldSATB : public SATBBufferClosure {
 };
 
 class ShenandoahPurgeSATBTask : public AbstractGangTask {
- private:
+private:
   ShenandoahObjToScanQueueSet* _mark_queues;
- public:
+  uintx _claim_token;
+
+public:
   size_t _trashed_oops;
 
   explicit ShenandoahPurgeSATBTask(ShenandoahObjToScanQueueSet* queues) :
-    AbstractGangTask("Purge SATB"), _mark_queues(queues), _trashed_oops(0) {}
+    AbstractGangTask("Purge SATB"),
+    _mark_queues(queues),
+    _claim_token(Threads::thread_claim_token()),
+    _trashed_oops(0) {}
 
   ~ShenandoahPurgeSATBTask() {
     if (_trashed_oops > 0) {
@@ -110,7 +112,7 @@ class ShenandoahPurgeSATBTask : public AbstractGangTask {
     ShenandoahParallelWorkerSession worker_session(worker_id);
     ShenandoahSATBMarkQueueSet &satb_queues = ShenandoahBarrierSet::satb_mark_queue_set();
     ShenandoahFlushAllSATB flusher(satb_queues);
-    Threads::threads_do(&flusher);
+    Threads::possibly_parallel_threads_do(true /*par*/, &flusher);
 
     ShenandoahObjToScanQueue* mark_queue = _mark_queues->queue(worker_id);
     ShenandoahProcessOldSATB processor(mark_queue);

--- a/src/hotspot/share/gc/shenandoah/shenandoahOldGeneration.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahOldGeneration.cpp
@@ -32,7 +32,6 @@
 #include "gc/shenandoah/shenandoahMark.inline.hpp"
 #include "gc/shenandoah/shenandoahOldGeneration.hpp"
 #include "gc/shenandoah/shenandoahOopClosures.inline.hpp"
-#include "gc/shenandoah/shenandoanRootProcessor.hpp"
 #include "gc/shenandoah/shenandoahStringDedup.hpp"
 #include "gc/shenandoah/shenandoahUtils.hpp"
 

--- a/src/hotspot/share/gc/shenandoah/shenandoahOldGeneration.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahOldGeneration.cpp
@@ -90,7 +90,6 @@ class ShenandoahProcessOldSATB : public SATBBufferClosure {
 class ShenandoahPurgeSATBTask : public AbstractGangTask {
 private:
   ShenandoahObjToScanQueueSet* _mark_queues;
-  uintx _claim_token;
 
 public:
   size_t _trashed_oops;
@@ -98,7 +97,6 @@ public:
   explicit ShenandoahPurgeSATBTask(ShenandoahObjToScanQueueSet* queues) :
     AbstractGangTask("Purge SATB"),
     _mark_queues(queues),
-    _claim_token(Threads::thread_claim_token()),
     _trashed_oops(0) {}
 
   ~ShenandoahPurgeSATBTask() {


### PR DESCRIPTION
ShenandoahPurgeSATBTask looks wrong.

1) Thread's token should be claimed by task, not by closure
2) Threads::threads_do() is single thread version.

Note: It can be improved by only iterating JavaThread with ShenandoahJavaThreadsIterator, but it needs phase time ...

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

### Reviewers
 * [Roman Kennke](https://openjdk.java.net/census#rkennke) (@rkennke - **Reviewer**) ⚠️ Review applies to b9c27ee8bd7ccbc989ad1c864ccbbd20e69079d8


### Download
To checkout this PR locally:
`$ git fetch https://git.openjdk.java.net/shenandoah pull/23/head:pull/23`
`$ git checkout pull/23`

To update a local copy of the PR:
`$ git checkout pull/23`
`$ git pull https://git.openjdk.java.net/shenandoah pull/23/head`
