### PR TITLE
Restore ShenandoahVerify functionality for generational mode

### DIFF
--- a/src/hotspot/share/gc/shenandoah/shenandoahFreeSet.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahFreeSet.cpp
@@ -364,9 +364,9 @@ HeapWord* ShenandoahFreeSet::allocate_contiguous(ShenandoahAllocRequest& req) {
   increase_used(ShenandoahHeapRegion::region_size_bytes() * num);
 
   if (req.affiliation() == ShenandoahRegionAffiliation::YOUNG_GENERATION) {
-    _heap->young_generation()->increase_used(ShenandoahHeapRegion::region_size_bytes() * num);
+    _heap->young_generation()->increase_used(words_size * HeapWordSize);
   } else if (req.affiliation() == ShenandoahRegionAffiliation::OLD_GENERATION) {
-    _heap->old_generation()->increase_used(ShenandoahHeapRegion::region_size_bytes() * num);
+    _heap->old_generation()->increase_used(words_size * HeapWordSize);
   }
 
   if (remainder != 0) {

--- a/src/hotspot/share/gc/shenandoah/shenandoahGeneration.hpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahGeneration.hpp
@@ -92,6 +92,9 @@ public:
   // Apply closure to all regions affiliated with this generation.
   virtual void parallel_heap_region_iterate(ShenandoahHeapRegionClosure* cl) = 0;
 
+  // Apply closure to all regions affiliated with this generation (single threaded).
+  virtual void heap_region_iterate(ShenandoahHeapRegionClosure* cl) = 0;
+
   // This is public to support cancellation of marking when a Full cycle is started.
   virtual void set_concurrent_mark_in_progress(bool in_progress) = 0;
 

--- a/src/hotspot/share/gc/shenandoah/shenandoahGlobalGeneration.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahGlobalGeneration.cpp
@@ -78,7 +78,7 @@ void ShenandoahGlobalGeneration::parallel_heap_region_iterate(ShenandoahHeapRegi
   ShenandoahHeap::heap()->parallel_heap_region_iterate(cl);
 }
 
-void ShenandoahGlobalGeneration::heap_region_iterate(ShenandoahHeapRegionClosure *cl) {
+void ShenandoahGlobalGeneration::heap_region_iterate(ShenandoahHeapRegionClosure* cl) {
   ShenandoahHeap::heap()->heap_region_iterate(cl);
 }
 

--- a/src/hotspot/share/gc/shenandoah/shenandoahGlobalGeneration.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahGlobalGeneration.cpp
@@ -78,6 +78,10 @@ void ShenandoahGlobalGeneration::parallel_heap_region_iterate(ShenandoahHeapRegi
   ShenandoahHeap::heap()->parallel_heap_region_iterate(cl);
 }
 
+void ShenandoahGlobalGeneration::heap_region_iterate(ShenandoahHeapRegionClosure *cl) {
+  ShenandoahHeap::heap()->heap_region_iterate(cl);
+}
+
 bool ShenandoahGlobalGeneration::is_concurrent_mark_in_progress() {
   ShenandoahHeap* heap = ShenandoahHeap::heap();
   return heap->is_concurrent_mark_in_progress();

--- a/src/hotspot/share/gc/shenandoah/shenandoahGlobalGeneration.hpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahGlobalGeneration.hpp
@@ -48,6 +48,8 @@ public:
 
   void parallel_heap_region_iterate(ShenandoahHeapRegionClosure* cl);
 
+  void heap_region_iterate(ShenandoahHeapRegionClosure *cl) override;
+
  protected:
   bool is_concurrent_mark_in_progress();
 };

--- a/src/hotspot/share/gc/shenandoah/shenandoahGlobalGeneration.hpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahGlobalGeneration.hpp
@@ -48,7 +48,7 @@ public:
 
   void parallel_heap_region_iterate(ShenandoahHeapRegionClosure* cl);
 
-  void heap_region_iterate(ShenandoahHeapRegionClosure *cl) override;
+  void heap_region_iterate(ShenandoahHeapRegionClosure* cl);
 
  protected:
   bool is_concurrent_mark_in_progress();

--- a/src/hotspot/share/gc/shenandoah/shenandoahHeapRegion.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahHeapRegion.cpp
@@ -816,7 +816,7 @@ public:
   }
 };
 
-void ShenandoahHeapRegion::promote() {
+size_t ShenandoahHeapRegion::promote() {
   assert(SafepointSynchronize::is_at_safepoint(), "must be at a safepoint");
 
   ShenandoahHeap* heap = ShenandoahHeap::heap();
@@ -825,6 +825,9 @@ void ShenandoahHeapRegion::promote() {
   assert(affiliation() == YOUNG_GENERATION, "Only young regions can be promoted");
 
   UpdateCardValuesClosure update_card_values;
+  ShenandoahGeneration *old_generation = heap->old_generation();
+  ShenandoahGeneration *young_generation = heap->young_generation();
+
   if (is_humongous_start()) {
     oop obj = oop(bottom());
     assert(marking_context->is_marked(obj), "promoted humongous object should be alive");
@@ -838,7 +841,8 @@ void ShenandoahHeapRegion::promote() {
 
       ShenandoahBarrierSet::barrier_set()->card_table()->clear_MemRegion(MemRegion(r->bottom(), r->end()));
       r->set_affiliation(OLD_GENERATION);
-      heap->old_generation()->increase_used(r->used());
+      old_generation->increase_used(r->used());
+      young_generation->decrease_used(r->used());
     }
     // HEY!  Better to call ShenandoahHeap::heap()->card_scan()->mark_range_as_clean(r->bottom(), obj->size())
     //  and skip the calls to clear_MemRegion() above.
@@ -846,6 +850,7 @@ void ShenandoahHeapRegion::promote() {
     // Iterate over all humongous regions that are spanned by the humongous object obj.  The remnant
     // of memory in the last humongous region that is not spanned by obj is currently not used.
     obj->oop_iterate(&update_card_values);
+    return index_limit - index();
   } else {
     log_debug(gc)("promoting region " SIZE_FORMAT ", clear cards from " SIZE_FORMAT " to " SIZE_FORMAT,
       index(), (size_t) bottom(), (size_t) top());
@@ -862,7 +867,9 @@ void ShenandoahHeapRegion::promote() {
     // HEY!  Better to call ShenandoahHeap::heap()->card_scan()->mark_range_as_dirty(r->bottom(), obj->size());
     ShenandoahBarrierSet::barrier_set()->card_table()->dirty_MemRegion(MemRegion(bottom(), end()));
     set_affiliation(OLD_GENERATION);
-    heap->old_generation()->increase_used(used());
+    old_generation->increase_used(used());
+    young_generation->decrease_used(used());
     oop_iterate_objects(&update_card_values, /*fill_dead_objects*/ true, /* reregister_coalesced_objects */ false);
+    return 1;
   }
 }

--- a/src/hotspot/share/gc/shenandoah/shenandoahHeapRegion.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahHeapRegion.cpp
@@ -825,8 +825,8 @@ size_t ShenandoahHeapRegion::promote() {
   assert(affiliation() == YOUNG_GENERATION, "Only young regions can be promoted");
 
   UpdateCardValuesClosure update_card_values;
-  ShenandoahGeneration *old_generation = heap->old_generation();
-  ShenandoahGeneration *young_generation = heap->young_generation();
+  ShenandoahGeneration* old_generation = heap->old_generation();
+  ShenandoahGeneration* young_generation = heap->young_generation();
 
   if (is_humongous_start()) {
     oop obj = oop(bottom());

--- a/src/hotspot/share/gc/shenandoah/shenandoahHeapRegion.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahHeapRegion.cpp
@@ -838,7 +838,7 @@ void ShenandoahHeapRegion::promote() {
 
       ShenandoahBarrierSet::barrier_set()->card_table()->clear_MemRegion(MemRegion(r->bottom(), r->end()));
       r->set_affiliation(OLD_GENERATION);
-      heap->old_generation()->increase_used(used());
+      heap->old_generation()->increase_used(r->used());
     }
     // HEY!  Better to call ShenandoahHeap::heap()->card_scan()->mark_range_as_clean(r->bottom(), obj->size())
     //  and skip the calls to clear_MemRegion() above.

--- a/src/hotspot/share/gc/shenandoah/shenandoahHeapRegion.hpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahHeapRegion.hpp
@@ -403,7 +403,8 @@ public:
   void increment_age() { if (_age < markWord::max_age) { _age++; } }
   void reset_age()     { _age = 0; }
 
-  void promote();
+  // If this is a humongous start, returns the number of regions in the object.
+  size_t promote();
 
 private:
   void do_commit();

--- a/src/hotspot/share/gc/shenandoah/shenandoahOldGeneration.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahOldGeneration.cpp
@@ -136,6 +136,11 @@ void ShenandoahOldGeneration::parallel_heap_region_iterate(ShenandoahHeapRegionC
   ShenandoahHeap::heap()->parallel_heap_region_iterate(&old_regions);
 }
 
+void ShenandoahOldGeneration::heap_region_iterate(ShenandoahHeapRegionClosure *cl) {
+  ShenandoahGenerationRegionClosure<OLD> old_regions(cl);
+  ShenandoahHeap::heap()->heap_region_iterate(&old_regions);
+}
+
 void ShenandoahOldGeneration::set_concurrent_mark_in_progress(bool in_progress) {
   ShenandoahHeap::heap()->set_concurrent_old_mark_in_progress(in_progress);
 }

--- a/src/hotspot/share/gc/shenandoah/shenandoahOldGeneration.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahOldGeneration.cpp
@@ -136,7 +136,7 @@ void ShenandoahOldGeneration::parallel_heap_region_iterate(ShenandoahHeapRegionC
   ShenandoahHeap::heap()->parallel_heap_region_iterate(&old_regions);
 }
 
-void ShenandoahOldGeneration::heap_region_iterate(ShenandoahHeapRegionClosure *cl) {
+void ShenandoahOldGeneration::heap_region_iterate(ShenandoahHeapRegionClosure* cl) {
   ShenandoahGenerationRegionClosure<OLD> old_regions(cl);
   ShenandoahHeap::heap()->heap_region_iterate(&old_regions);
 }

--- a/src/hotspot/share/gc/shenandoah/shenandoahOldGeneration.hpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahOldGeneration.hpp
@@ -38,6 +38,9 @@ class ShenandoahOldGeneration : public ShenandoahGeneration {
 
   bool contains(ShenandoahHeapRegion* region) const;
   void parallel_heap_region_iterate(ShenandoahHeapRegionClosure* cl);
+
+  void heap_region_iterate(ShenandoahHeapRegionClosure *cl) override;
+
   void set_concurrent_mark_in_progress(bool in_progress);
 
   // We leave the SATB barrier on for the entirety of the old generation

--- a/src/hotspot/share/gc/shenandoah/shenandoahOldGeneration.hpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahOldGeneration.hpp
@@ -39,7 +39,7 @@ class ShenandoahOldGeneration : public ShenandoahGeneration {
   bool contains(ShenandoahHeapRegion* region) const;
   void parallel_heap_region_iterate(ShenandoahHeapRegionClosure* cl);
 
-  void heap_region_iterate(ShenandoahHeapRegionClosure *cl) override;
+  void heap_region_iterate(ShenandoahHeapRegionClosure* cl);
 
   void set_concurrent_mark_in_progress(bool in_progress);
 

--- a/src/hotspot/share/gc/shenandoah/shenandoahRootVerifier.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahRootVerifier.cpp
@@ -110,7 +110,7 @@ void ShenandoahRootVerifier::oops_do(OopClosure* oops) {
     ShenandoahStringDedup::oops_do_slow(oops);
   }
 
-  ShenandoahHeap *heap = ShenandoahHeap::heap();
+  ShenandoahHeap* heap = ShenandoahHeap::heap();
   if (heap->mode()->is_generational() && heap->is_gc_generation_young() && verify(RememberedSetRoots)) {
     shenandoah_assert_safepoint();
     heap->card_scan()->oops_do(oops);
@@ -138,7 +138,7 @@ void ShenandoahRootVerifier::roots_do(OopClosure* oops) {
   JNIHandles::oops_do(oops);
   Universe::vm_global()->oops_do(oops);
 
-  ShenandoahHeap *heap = ShenandoahHeap::heap();
+  ShenandoahHeap* heap = ShenandoahHeap::heap();
   if (heap->mode()->is_generational() && heap->is_gc_generation_young()) {
     heap->card_scan()->oops_do(oops);
   }
@@ -161,7 +161,7 @@ void ShenandoahRootVerifier::strong_roots_do(OopClosure* oops) {
   JNIHandles::oops_do(oops);
   Universe::vm_global()->oops_do(oops);
 
-  ShenandoahHeap *heap = ShenandoahHeap::heap();
+  ShenandoahHeap* heap = ShenandoahHeap::heap();
   if (heap->mode()->is_generational() && heap->is_gc_generation_young()) {
     heap->card_scan()->oops_do(oops);
   }

--- a/src/hotspot/share/gc/shenandoah/shenandoahRootVerifier.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahRootVerifier.cpp
@@ -110,9 +110,10 @@ void ShenandoahRootVerifier::oops_do(OopClosure* oops) {
     ShenandoahStringDedup::oops_do_slow(oops);
   }
 
-  if (ShenandoahHeap::heap()->mode()->is_generational() && verify(RememberedSetRoots)) {
+  ShenandoahHeap *heap = ShenandoahHeap::heap();
+  if (heap->mode()->is_generational() && heap->is_gc_generation_young() && verify(RememberedSetRoots)) {
     shenandoah_assert_safepoint();
-    ShenandoahHeap::heap()->card_scan()->oops_do(oops);
+    heap->card_scan()->oops_do(oops);
   }
 
   if (verify(ThreadRoots)) {
@@ -137,8 +138,9 @@ void ShenandoahRootVerifier::roots_do(OopClosure* oops) {
   JNIHandles::oops_do(oops);
   Universe::vm_global()->oops_do(oops);
 
-  if (ShenandoahHeap::heap()->mode()->is_generational() && verify(RememberedSetRoots)) {
-    ShenandoahHeap::heap()->card_scan()->oops_do(oops);
+  ShenandoahHeap *heap = ShenandoahHeap::heap();
+  if (heap->mode()->is_generational() && heap->is_gc_generation_young()) {
+    heap->card_scan()->oops_do(oops);
   }
 
   // Do thread roots the last. This allows verification code to find
@@ -159,8 +161,9 @@ void ShenandoahRootVerifier::strong_roots_do(OopClosure* oops) {
   JNIHandles::oops_do(oops);
   Universe::vm_global()->oops_do(oops);
 
-  if (ShenandoahHeap::heap()->mode()->is_generational() && verify(RememberedSetRoots)) {
-    ShenandoahHeap::heap()->card_scan()->oops_do(oops);
+  ShenandoahHeap *heap = ShenandoahHeap::heap();
+  if (heap->mode()->is_generational() && heap->is_gc_generation_young()) {
+    heap->card_scan()->oops_do(oops);
   }
 
   // Do thread roots the last. This allows verification code to find

--- a/src/hotspot/share/gc/shenandoah/shenandoahRootVerifier.hpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahRootVerifier.hpp
@@ -50,7 +50,8 @@ public:
     WeakRoots           = 1 << 4,
     StringDedupRoots    = 1 << 5,
     JNIHandleRoots      = 1 << 6,
-    AllRoots            = (SerialRoots | ThreadRoots | CodeRoots | CLDGRoots | WeakRoots | StringDedupRoots | JNIHandleRoots)
+    RememberedSetRoots  = 1 << 7,
+    AllRoots            = (SerialRoots | ThreadRoots | CodeRoots | CLDGRoots | WeakRoots | StringDedupRoots | JNIHandleRoots | RememberedSetRoots)
   };
 
 private:

--- a/src/hotspot/share/gc/shenandoah/shenandoahScanRemembered.hpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahScanRemembered.hpp
@@ -955,6 +955,7 @@ public:
   //  implementations will want to update this value each time they
   //  cross one of these boundaries.
 
+  void oops_do(OopClosure* cl);
 };
 
 typedef ShenandoahScanRemembered<ShenandoahDirectCardMarkRememberedSet> RememberedScanner;

--- a/src/hotspot/share/gc/shenandoah/shenandoahScanRemembered.inline.hpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahScanRemembered.inline.hpp
@@ -573,4 +573,40 @@ ShenandoahScanRemembered<RememberedSet>::cluster_for_addr(HeapWordImpl **addr) {
   return result;
 }
 
+class ShenandoahOopIterateAdapter : public BasicOopIterateClosure {
+ private:
+  OopClosure* _cl;
+ public:
+  explicit ShenandoahOopIterateAdapter(OopClosure *cl) : _cl(cl) {}
+
+  void do_oop(oop *o) override {
+    _cl->do_oop(o);
+  }
+
+  void do_oop(narrowOop *o) override {
+    _cl->do_oop(o);
+  }
+};
+
+template<typename RememberedSet>
+inline void ShenandoahScanRemembered<RememberedSet>::oops_do(OopClosure *cl) {
+  ShenandoahOopIterateAdapter adapter(cl);
+  ShenandoahHeap* heap = ShenandoahHeap::heap();
+  for (size_t i = 0, n = heap->num_regions(); i < n; ++i) {
+    ShenandoahHeapRegion* region = heap->get_region(i);
+    if (region->affiliation() == OLD_GENERATION) {
+      HeapWord *start_of_range = region->bottom();
+      HeapWord *end_of_range = region->top();
+      size_t start_cluster_no = cluster_for_addr(start_of_range);
+      size_t num_heapwords = end_of_range - start_of_range;
+      unsigned int cluster_size = CardTable::card_size_in_words *
+                                  ShenandoahCardCluster<ShenandoahDirectCardMarkRememberedSet>::CardsPerCluster;
+      size_t num_clusters = (size_t) ((num_heapwords - 1 + cluster_size) / cluster_size);
+
+      // Remembered set scanner
+      process_clusters(start_cluster_no, num_clusters, end_of_range, &adapter);
+    }
+  }
+}
+
 #endif   // SHARE_GC_SHENANDOAH_SHENANDOAHSCANREMEMBEREDINLINE_HPP

--- a/src/hotspot/share/gc/shenandoah/shenandoahScanRemembered.inline.hpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahScanRemembered.inline.hpp
@@ -577,26 +577,26 @@ class ShenandoahOopIterateAdapter : public BasicOopIterateClosure {
  private:
   OopClosure* _cl;
  public:
-  explicit ShenandoahOopIterateAdapter(OopClosure *cl) : _cl(cl) {}
+  explicit ShenandoahOopIterateAdapter(OopClosure* cl) : _cl(cl) {}
 
-  void do_oop(oop *o) override {
+  void do_oop(oop* o) {
     _cl->do_oop(o);
   }
 
-  void do_oop(narrowOop *o) override {
+  void do_oop(narrowOop* o) {
     _cl->do_oop(o);
   }
 };
 
 template<typename RememberedSet>
-inline void ShenandoahScanRemembered<RememberedSet>::oops_do(OopClosure *cl) {
+inline void ShenandoahScanRemembered<RememberedSet>::oops_do(OopClosure* cl) {
   ShenandoahOopIterateAdapter adapter(cl);
   ShenandoahHeap* heap = ShenandoahHeap::heap();
   for (size_t i = 0, n = heap->num_regions(); i < n; ++i) {
     ShenandoahHeapRegion* region = heap->get_region(i);
     if (region->affiliation() == OLD_GENERATION) {
-      HeapWord *start_of_range = region->bottom();
-      HeapWord *end_of_range = region->top();
+      HeapWord* start_of_range = region->bottom();
+      HeapWord* end_of_range = region->top();
       size_t start_cluster_no = cluster_for_addr(start_of_range);
       size_t num_heapwords = end_of_range - start_of_range;
       unsigned int cluster_size = CardTable::card_size_in_words *

--- a/src/hotspot/share/gc/shenandoah/shenandoahVerifier.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahVerifier.cpp
@@ -140,7 +140,7 @@ private:
     check(ShenandoahAsserts::_safe_unknown, obj, is_object_aligned(obj),
               "oop must be aligned");
 
-    ShenandoahHeapRegion *obj_reg = _heap->heap_region_containing(obj);
+    ShenandoahHeapRegion* obj_reg = _heap->heap_region_containing(obj);
     Klass* obj_klass = obj->klass_or_null();
 
     // Verify that obj is not in dead space:
@@ -151,7 +151,7 @@ private:
       check(ShenandoahAsserts::_safe_unknown, obj, Metaspace::contains(obj_klass),
              "Object klass pointer must go to metaspace");
 
-      HeapWord *obj_addr = cast_from_oop<HeapWord*>(obj);
+      HeapWord* obj_addr = cast_from_oop<HeapWord*>(obj);
       check(ShenandoahAsserts::_safe_unknown, obj, obj_addr < obj_reg->top(),
              "Object start should be within the region");
 
@@ -216,7 +216,7 @@ private:
       check(ShenandoahAsserts::_safe_oop, obj, !fwd_reg->is_humongous(),
              "Should have no humongous forwardees");
 
-      HeapWord *fwd_addr = cast_from_oop<HeapWord *>(fwd);
+      HeapWord* fwd_addr = cast_from_oop<HeapWord* >(fwd);
       check(ShenandoahAsserts::_safe_oop, obj, fwd_addr < fwd_reg->top(),
              "Forwardee start should be within the region");
       check(ShenandoahAsserts::_safe_oop, obj, (fwd_addr + fwd->size()) <= fwd_reg->top(),
@@ -516,7 +516,7 @@ class ShenandoahVerifierMarkedRegionTask : public AbstractGangTask {
 private:
   const char* _label;
   ShenandoahVerifier::VerifyOptions _options;
-  ShenandoahHeap *_heap;
+  ShenandoahHeap* _heap;
   MarkBitMap* _bitmap;
   ShenandoahLivenessData* _ld;
   volatile size_t _claimed;
@@ -576,7 +576,7 @@ public:
     return _generation == NULL || _generation->contains(r);
   }
 
-  virtual void work_humongous(ShenandoahHeapRegion *r, ShenandoahVerifierStack& stack, ShenandoahVerifyOopClosure& cl) {
+  virtual void work_humongous(ShenandoahHeapRegion* r, ShenandoahVerifierStack& stack, ShenandoahVerifyOopClosure& cl) {
     size_t processed = 0;
     HeapWord* obj = r->bottom();
     if (_heap->complete_marking_context()->is_marked((oop)obj)) {
@@ -585,7 +585,7 @@ public:
     Atomic::add(&_processed, processed, memory_order_relaxed);
   }
 
-  virtual void work_regular(ShenandoahHeapRegion *r, ShenandoahVerifierStack &stack, ShenandoahVerifyOopClosure &cl) {
+  virtual void work_regular(ShenandoahHeapRegion* r, ShenandoahVerifierStack &stack, ShenandoahVerifyOopClosure &cl) {
     size_t processed = 0;
     ShenandoahMarkingContext* ctx = _heap->complete_marking_context();
     HeapWord* tams = ctx->top_at_mark_start(r);
@@ -618,7 +618,7 @@ public:
     Atomic::add(&_processed, processed, memory_order_relaxed);
   }
 
-  void verify_and_follow(HeapWord *addr, ShenandoahVerifierStack &stack, ShenandoahVerifyOopClosure &cl, size_t *processed) {
+  void verify_and_follow(HeapWord* addr, ShenandoahVerifierStack &stack, ShenandoahVerifyOopClosure &cl, size_t* processed) {
     if (!_bitmap->par_mark(addr)) return;
 
     // Verify the object itself:
@@ -654,7 +654,7 @@ public:
   }
 };
 
-void ShenandoahVerifier::verify_at_safepoint(const char *label,
+void ShenandoahVerifier::verify_at_safepoint(const char* label,
                                              VerifyForwarded forwarded, VerifyMarked marked,
                                              VerifyCollectionSet cset,
                                              VerifyLiveness liveness, VerifyRegions regions,
@@ -729,7 +729,7 @@ void ShenandoahVerifier::verify_at_safepoint(const char *label,
               byte_size_in_proper_unit(cl.committed()), proper_unit_for_byte_size(cl.committed()));
   }
 
-  ShenandoahGeneration *generation;
+  ShenandoahGeneration* generation;
   if (_heap->mode()->is_generational()) {
     generation = _heap->active_generation();
     guarantee(generation != NULL, "Need to know which generation to verify.");

--- a/src/hotspot/share/gc/shenandoah/shenandoahVerifier.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahVerifier.cpp
@@ -230,7 +230,14 @@ private:
     }
 
     // ------------ obj and fwd are safe at this point --------------
-
+    // We allow for marked or old here for two reasons:
+    //  1. If this is a young collect, old objects wouldn't be marked. We've
+    //     recently change the verifier traversal to only follow young objects
+    //     during a young collect so this _shouldn't_ be necessary.
+    //  2. At present, we do not clear dead objects from the remembered set.
+    //     Everything in the remembered set is old (ipso facto), so allowing for
+    //     'marked_or_old' covers the case of stale objects in rset.
+    // TODO: Just use 'is_marked' here.
     switch (_options._verify_marked) {
       case ShenandoahVerifier::_verify_marked_disable:
         // skip
@@ -244,7 +251,7 @@ private:
                "Must be marked in complete bitmap");
         break;
       case ShenandoahVerifier::_verify_marked_complete_except_references:
-        check(ShenandoahAsserts::_safe_all, obj, _heap->complete_marking_context()->is_marked(obj),
+        check(ShenandoahAsserts::_safe_all, obj, _heap->complete_marking_context()->is_marked_or_old(obj),
               "Must be marked in complete bitmap, except j.l.r.Reference referents");
         break;
       default:

--- a/src/hotspot/share/gc/shenandoah/shenandoahVerifier.hpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahVerifier.hpp
@@ -166,7 +166,7 @@ public:
   };
 
 private:
-  void verify_at_safepoint(const char *label,
+  void verify_at_safepoint(const char* label,
                            VerifyForwarded forwarded,
                            VerifyMarked marked,
                            VerifyCollectionSet cset,

--- a/src/hotspot/share/gc/shenandoah/shenandoahYoungGeneration.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahYoungGeneration.cpp
@@ -125,7 +125,7 @@ void ShenandoahYoungGeneration::parallel_heap_region_iterate(ShenandoahHeapRegio
   }
 }
 
-void ShenandoahYoungGeneration::heap_region_iterate(ShenandoahHeapRegionClosure *cl) {
+void ShenandoahYoungGeneration::heap_region_iterate(ShenandoahHeapRegionClosure* cl) {
   ShenandoahGenerationRegionClosure<YOUNG> young_regions(cl);
   ShenandoahHeap::heap()->heap_region_iterate(&young_regions);
 }

--- a/src/hotspot/share/gc/shenandoah/shenandoahYoungGeneration.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahYoungGeneration.cpp
@@ -127,6 +127,11 @@ void ShenandoahYoungGeneration::parallel_heap_region_iterate(ShenandoahHeapRegio
   }
 }
 
+void ShenandoahYoungGeneration::heap_region_iterate(ShenandoahHeapRegionClosure *cl) {
+  ShenandoahGenerationRegionClosure<YOUNG> young_regions(cl);
+  ShenandoahHeap::heap()->heap_region_iterate(&young_regions);
+}
+
 bool ShenandoahYoungGeneration::is_concurrent_mark_in_progress() {
   return ShenandoahHeap::heap()->is_concurrent_young_mark_in_progress();
 }

--- a/src/hotspot/share/gc/shenandoah/shenandoahYoungGeneration.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahYoungGeneration.cpp
@@ -56,13 +56,11 @@ class ShenandoahPromoteTenuredRegionsTask : public AbstractGangTask {
 private:
   ShenandoahRegionIterator* _regions;
 public:
-  volatile size_t _used;
   volatile size_t _promoted;
 
   ShenandoahPromoteTenuredRegionsTask(ShenandoahRegionIterator* regions) :
     AbstractGangTask("Shenandoah Promote Tenured Regions"),
     _regions(regions),
-    _used(0),
     _promoted(0) {
   }
 
@@ -71,11 +69,12 @@ public:
     ShenandoahHeapRegion* r = _regions->next();
     while (r != NULL) {
       if (r->is_young()) {
+        // The thread that first encounters a humongous start region is responsible
+        // for promoting the continuation regions so we need this guard here to
+        // keep other worker threads from trying to promote the continuations.
         if (r->age() >= InitialTenuringThreshold && !r->is_humongous_continuation()) {
-          r->promote();
-          Atomic::inc(&_promoted);
-        } else {
-          Atomic::add(&_used, r->used());
+          size_t promoted = r->promote();
+          Atomic::add(&_promoted, promoted);
         }
       }
       r = _regions->next();
@@ -87,7 +86,6 @@ void ShenandoahYoungGeneration::promote_tenured_regions() {
   ShenandoahRegionIterator regions;
   ShenandoahPromoteTenuredRegionsTask task(&regions);
   ShenandoahHeap::heap()->workers()->run_task(&task);
-  _used = task._used;
   log_info(gc)("Promoted " SIZE_FORMAT " regions.", task._promoted);
 }
 

--- a/src/hotspot/share/gc/shenandoah/shenandoahYoungGeneration.hpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahYoungGeneration.hpp
@@ -39,7 +39,7 @@ public:
   virtual void set_concurrent_mark_in_progress(bool in_progress);
   virtual void parallel_heap_region_iterate(ShenandoahHeapRegionClosure* cl);
 
-  void heap_region_iterate(ShenandoahHeapRegionClosure *cl) override;
+  void heap_region_iterate(ShenandoahHeapRegionClosure* cl);
 
   bool contains(ShenandoahHeapRegion* region) const;
 

--- a/src/hotspot/share/gc/shenandoah/shenandoahYoungGeneration.hpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahYoungGeneration.hpp
@@ -39,6 +39,8 @@ public:
   virtual void set_concurrent_mark_in_progress(bool in_progress);
   virtual void parallel_heap_region_iterate(ShenandoahHeapRegionClosure* cl);
 
+  void heap_region_iterate(ShenandoahHeapRegionClosure *cl) override;
+
   bool contains(ShenandoahHeapRegion* region) const;
 
   void promote_tenured_regions();


### PR DESCRIPTION
### Summary
1. Add remembered set to verifier roots for young generation collections
2. Don't follow pointers outside the generation during verify traversals
3. Verify generation's `used` value
4. Correct errors in computing a generation's `used` values

### Testing
1. Dacapo suite completes without verification errors
2. hotspot_gc_shenandoah completes without verification errors

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

### Reviewers
 * [Roman Kennke](https://openjdk.java.net/census#rkennke) (@rkennke - **Reviewer**) ⚠️ Review applies to b4d1ea782a46d96b955fec7e6ea698224d102dc3


### Download
To checkout this PR locally:
`$ git fetch https://git.openjdk.java.net/shenandoah pull/24/head:pull/24`
`$ git checkout pull/24`

To update a local copy of the PR:
`$ git checkout pull/24`
`$ git pull https://git.openjdk.java.net/shenandoah pull/24/head`
