### PR TITLE
Clean up CondCardMark code: remove excess barriers, enable it by default

### DIFF
--- a/src/hotspot/cpu/aarch64/gc/shenandoah/shenandoahBarrierSetAssembler_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/gc/shenandoah/shenandoahBarrierSetAssembler_aarch64.cpp
@@ -643,9 +643,6 @@ void ShenandoahBarrierSetAssembler::gen_write_ref_array_post_barrier(MacroAssemb
 
   __ load_byte_map_base(scratch);
   __ add(start, start, scratch);
-  // if (ct->scanned_concurrently()) {
-  //   __ membar(__ StoreStore);
-  // }
   __ bind(L_loop);
   __ strb(zr, Address(start, count));
   __ subs(count, count, 1);

--- a/src/hotspot/cpu/aarch64/gc/shenandoah/shenandoahBarrierSetAssembler_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/gc/shenandoah/shenandoahBarrierSetAssembler_aarch64.cpp
@@ -390,15 +390,11 @@ void ShenandoahBarrierSetAssembler::store_check(MacroAssembler* masm, Register o
 
   if (UseCondCardMark) {
     Label L_already_dirty;
-    __ membar(Assembler::StoreLoad);
     __ ldrb(rscratch2,  Address(obj, rscratch1));
     __ cbz(rscratch2, L_already_dirty);
     __ strb(zr, Address(obj, rscratch1));
     __ bind(L_already_dirty);
   } else {
-    // if (ct->scanned_concurrently()) {
-    //  __ membar(Assembler::StoreStore);
-    // }
     __ strb(zr, Address(obj, rscratch1));
   }
 }

--- a/src/hotspot/cpu/x86/gc/shenandoah/shenandoahBarrierSetAssembler_x86.cpp
+++ b/src/hotspot/cpu/x86/gc/shenandoah/shenandoahBarrierSetAssembler_x86.cpp
@@ -656,9 +656,6 @@ void ShenandoahBarrierSetAssembler::store_check(MacroAssembler* masm, Register o
   int dirty = CardTable::dirty_card_val();
   if (UseCondCardMark) {
     Label L_already_dirty;
-//    if (ct->scanned_concurrently()) {
-//      __ membar(Assembler::StoreLoad);
-//    }
     __ cmpb(card_addr, dirty);
     __ jcc(Assembler::equal, L_already_dirty);
     __ movb(card_addr, dirty);

--- a/src/hotspot/share/gc/shenandoah/c1/shenandoahBarrierSetC1.cpp
+++ b/src/hotspot/share/gc/shenandoah/c1/shenandoahBarrierSetC1.cpp
@@ -353,9 +353,6 @@ void ShenandoahBarrierSetC1::post_barrier(LIRAccess& access, LIR_OprDesc* addr, 
   LIR_Opr dirty = LIR_OprFact::intConst(CardTable::dirty_card_val());
   if (UseCondCardMark) {
     LIR_Opr cur_value = gen->new_register(T_INT);
-//    if (ct->scanned_concurrently()) {
-//      __ membar_storeload();
-//    }
     __ move(card_addr, cur_value);
 
     LabelObj* L_already_dirty = new LabelObj();
@@ -364,9 +361,6 @@ void ShenandoahBarrierSetC1::post_barrier(LIRAccess& access, LIR_OprDesc* addr, 
     __ move(dirty, card_addr);
     __ branch_destination(L_already_dirty->label());
   } else {
-//    if (ct->scanned_concurrently()) {
-//      __ membar_storestore();
-//    }
     __ move(dirty, card_addr);
   }
 }

--- a/src/hotspot/share/gc/shenandoah/c2/shenandoahBarrierSetC2.cpp
+++ b/src/hotspot/share/gc/shenandoah/c2/shenandoahBarrierSetC2.cpp
@@ -522,10 +522,6 @@ void ShenandoahBarrierSetC2::post_barrier(GraphKit* kit,
   Node*   zero = __ ConI(0); // Dirty card value
 
   if (UseCondCardMark) {
-//    if (ct->scanned_concurrently()) {
-//      kit->insert_mem_bar(Op_MemBarVolatile, oop_store);
-//      __ sync_kit(kit);
-//    }
     // The classic GC reference write barrier is typically implemented
     // as a store into the global card mark table.  Unfortunately
     // unconditional stores can result in false sharing and excessive
@@ -538,12 +534,7 @@ void ShenandoahBarrierSetC2::post_barrier(GraphKit* kit,
   }
 
   // Smash zero into card
-//  if(!ct->scanned_concurrently()) {
-    __ store(__ ctrl(), card_adr, zero, T_BYTE, adr_type, MemNode::unordered);
-//  } else {
-//    // Specialized path for CM store barrier
-//    __ storeCM(__ ctrl(), card_adr, zero, oop_store, adr_idx, T_BYTE, adr_type);
-//  }
+  __ store(__ ctrl(), card_adr, zero, T_BYTE, adr_type, MemNode::unordered);
 
   if (UseCondCardMark) {
     __ end_if();

--- a/src/hotspot/share/gc/shenandoah/mode/shenandoahGenerationalMode.cpp
+++ b/src/hotspot/share/gc/shenandoah/mode/shenandoahGenerationalMode.cpp
@@ -47,6 +47,9 @@ void ShenandoahGenerationalMode::initialize_flags() const {
   SHENANDOAH_ERGO_ENABLE_FLAG(ExplicitGCInvokesConcurrent);
   SHENANDOAH_ERGO_ENABLE_FLAG(ShenandoahImplicitGCInvokesConcurrent);
 
+  // This helps most multi-core hardware hosts, enable by default
+  SHENANDOAH_ERGO_ENABLE_FLAG(UseCondCardMark);
+
   // Final configuration checks
   SHENANDOAH_CHECK_FLAG_SET(ShenandoahLoadRefBarrier);
   SHENANDOAH_CHECK_FLAG_UNSET(ShenandoahIUBarrier);

--- a/src/hotspot/share/gc/shenandoah/shenandoahBarrierSet.inline.hpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahBarrierSet.inline.hpp
@@ -196,12 +196,7 @@ template <DecoratorSet decorators, typename T>
 inline void ShenandoahBarrierSet::write_ref_field_post(T* field, oop newVal) {
   if (ShenandoahHeap::heap()->mode()->is_generational()) {
     volatile CardTable::CardValue* byte = card_table()->byte_for(field);
-    // if (card_table()->scanned_concurrently()) {
-    //   // Perform a releasing store if the card table is scanned concurrently
-    //   Atomic::release_store(byte, CardTable::dirty_card_val());
-    // } else {
-      *byte = CardTable::dirty_card_val();
-    // }
+    *byte = CardTable::dirty_card_val();
   }
 }
 


### PR DESCRIPTION
The `StoreLoad`, `StoreStore` barriers in that code are only needed for CMS, and does not relate to Shenandoah. Also, `UseCondCardMark` is a recommended option for most machines today, and therefore we better just enable it ergonomically.

Additional testing:
 - [x] hotspot_gc_shenandoah, x86_64, {fastdebug,release}

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

### Reviewers
 * [Zhengyu Gu](https://openjdk.java.net/census#zgu) (@zhengyu123 - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/shenandoah pull/26/head:pull/26` \
`$ git checkout pull/26`

Update a local copy of the PR: \
`$ git checkout pull/26` \
`$ git pull https://git.openjdk.java.net/shenandoah pull/26/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 26`

View PR using the GUI difftool: \
`$ git pr show -t 26`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/shenandoah/pull/26.diff">https://git.openjdk.java.net/shenandoah/pull/26.diff</a>

</details>
