### PR TITLE
Add parallel worker timings for remembered set scan

### DIFF
--- a/src/hotspot/share/gc/shenandoah/shenandoahGeneration.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahGeneration.cpp
@@ -242,6 +242,7 @@ void ShenandoahGeneration::scan_remembered_set() {
   uint nworkers = heap->workers()->active_workers();
   reserve_task_queues(nworkers);
 
+  ShenandoahGCPhase phase(ShenandoahPhaseTimings::init_scan_rset);
   ShenandoahReferenceProcessor* rp = heap->ref_processor();
   ShenandoahRegionIterator regions;
   ShenandoahScanRememberedTask task(task_queues(), old_gen_task_queues(), rp, &regions);

--- a/src/hotspot/share/gc/shenandoah/shenandoahPhaseTimings.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahPhaseTimings.cpp
@@ -97,6 +97,7 @@ bool ShenandoahPhaseTimings::is_worker_phase(Phase phase) {
   assert(phase >= 0 && phase < _num_phases, "Out of bounds");
   switch (phase) {
     case init_evac:
+    case init_scan_rset:
     case finish_mark:
     case purge_weak_par:
     case full_gc_mark:

--- a/src/hotspot/share/gc/shenandoah/shenandoahPhaseTimings.hpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahPhaseTimings.hpp
@@ -102,8 +102,8 @@ class outputStream;
   f(conc_rendezvous_roots,                          "Rendezvous")                      \
   f(conc_evac,                                      "Concurrent Evacuation")           \
                                                                                        \
-  f(init_update_refs_gross,                         "Pause Init Update Refs (G)")      \
-  f(init_update_refs,                               "Pause Init Update Refs (N)")      \
+  f(init_update_refs_gross,                         "Pause Init  Update Refs (G)")      \
+  f(init_update_refs,                               "Pause Init  Update Refs (N)")      \
   f(init_update_refs_manage_gclabs,                 "  Manage GCLABs")                 \
                                                                                        \
   f(conc_update_refs,                               "Concurrent Update Refs")          \

--- a/src/hotspot/share/gc/shenandoah/shenandoahPhaseTimings.hpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahPhaseTimings.hpp
@@ -46,6 +46,7 @@ class outputStream;
   f(CNT_PREFIX ## StringDedupQueueRoots,    DESC_PREFIX "Dedup Queue Roots")           \
   f(CNT_PREFIX ## WeakRefProc,              DESC_PREFIX "Weak References")             \
   f(CNT_PREFIX ## ParallelMark,             DESC_PREFIX "Parallel Mark")               \
+  f(CNT_PREFIX ## ScanClusters,             DESC_PREFIX "Scan Clusters")
   // end
 
 #define SHENANDOAH_PHASE_DO(f)                                                         \
@@ -54,6 +55,8 @@ class outputStream;
   f(init_mark_gross,                                "Pause Init Mark (G)")             \
   f(init_mark,                                      "Pause Init Mark (N)")             \
   f(init_manage_tlabs,                              "  Manage TLABs")                  \
+  f(init_scan_rset,                                 "  Scan Remembered Set")           \
+  SHENANDOAH_PAR_PHASE_DO(init_scan_rset_,          "    RS: ", f)                     \
   f(init_update_region_states,                      "  Update Region States")          \
                                                                                        \
   f(conc_mark_roots,                                "Concurrent Mark Roots ")          \
@@ -99,8 +102,8 @@ class outputStream;
   f(conc_rendezvous_roots,                          "Rendezvous")                      \
   f(conc_evac,                                      "Concurrent Evacuation")           \
                                                                                        \
-  f(init_update_refs_gross,                         "Pause Init  Update Refs (G)")      \
-  f(init_update_refs,                               "Pause Init  Update Refs (N)")      \
+  f(init_update_refs_gross,                         "Pause Init Update Refs (G)")      \
+  f(init_update_refs,                               "Pause Init Update Refs (N)")      \
   f(init_update_refs_manage_gclabs,                 "  Manage GCLABs")                 \
                                                                                        \
   f(conc_update_refs,                               "Concurrent Update Refs")          \

--- a/src/hotspot/share/gc/shenandoah/shenandoahScanRemembered.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahScanRemembered.cpp
@@ -95,11 +95,12 @@ void ShenandoahScanRememberedTask::work(uint worker_id) {
   // This sets up a thread local reference to the worker_id which is necessary
   // the weak reference processor.
   ShenandoahParallelWorkerSession worker_session(worker_id);
+  ShenandoahWorkerTimingsTracker x(ShenandoahPhaseTimings::init_scan_rset, ShenandoahPhaseTimings::ScanClusters, worker_id);
 
   ShenandoahObjToScanQueue* q = _queue_set->queue(worker_id);
   ShenandoahObjToScanQueue* old = _old_queue_set == NULL ? NULL : _old_queue_set->queue(worker_id);
   ShenandoahMarkRefsClosure<YOUNG> cl(q, _rp, old);
-  RememberedScanner *rs = ShenandoahHeap::heap()->card_scan();
+  RememberedScanner *scanner = ShenandoahHeap::heap()->card_scan();
 
   // set up thread local closure for shen ref processor
   _rp->set_mark_closure(worker_id, &cl);
@@ -107,7 +108,7 @@ void ShenandoahScanRememberedTask::work(uint worker_id) {
   ShenandoahHeapRegion* region = _regions->next();
   while (region != NULL) {
     if (region->affiliation() == OLD_GENERATION) {
-      rs->process_region(region, &cl);
+      scanner->process_region(region, &cl);
     }
     region = _regions->next();
   }

--- a/src/hotspot/share/gc/shenandoah/shenandoahScanRemembered.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahScanRemembered.cpp
@@ -31,7 +31,7 @@
 #include "gc/shenandoah/shenandoahReferenceProcessor.hpp"
 #include "gc/shenandoah/shenandoahScanRemembered.inline.hpp"
 
-ShenandoahDirectCardMarkRememberedSet::ShenandoahDirectCardMarkRememberedSet(CardTable *card_table, size_t total_card_count) {
+ShenandoahDirectCardMarkRememberedSet::ShenandoahDirectCardMarkRememberedSet(CardTable* card_table, size_t total_card_count) {
   _heap = ShenandoahHeap::heap();
   _card_table = card_table;
   _total_card_count = total_card_count;
@@ -64,8 +64,8 @@ void ShenandoahDirectCardMarkRememberedSet::initialize_overreach(size_t first_cl
   // unrolling the loop and doing wide writes if the compiler
   // doesn't do this for us.
   size_t first_card_index = first_cluster * ShenandoahCardCluster<ShenandoahDirectCardMarkRememberedSet>::CardsPerCluster;
-  uint8_t *omp = &_overreach_map[first_card_index];
-  uint8_t *endp = omp + count * ShenandoahCardCluster<ShenandoahDirectCardMarkRememberedSet>::CardsPerCluster;
+  uint8_t* omp = &_overreach_map[first_card_index];
+  uint8_t* endp = omp + count * ShenandoahCardCluster<ShenandoahDirectCardMarkRememberedSet>::CardsPerCluster;
   while (omp < endp)
     *omp++ = CardTable::clean_card_val();
 }
@@ -75,9 +75,9 @@ void ShenandoahDirectCardMarkRememberedSet::merge_overreach(size_t first_cluster
   // We can make this run faster in the future by explicitly unrolling the loop and doing wide writes if the compiler
   // doesn't do this for us.
   size_t first_card_index = first_cluster * ShenandoahCardCluster<ShenandoahDirectCardMarkRememberedSet>::CardsPerCluster;
-  uint8_t *bmp = &_byte_map[first_card_index];
-  uint8_t *endp = bmp + count * ShenandoahCardCluster<ShenandoahDirectCardMarkRememberedSet>::CardsPerCluster;
-  uint8_t *omp = &_overreach_map[first_card_index];
+  uint8_t* bmp = &_byte_map[first_card_index];
+  uint8_t* endp = bmp + count * ShenandoahCardCluster<ShenandoahDirectCardMarkRememberedSet>::CardsPerCluster;
+  uint8_t* omp = &_overreach_map[first_card_index];
 
   // dirty_card is 0, clean card is 0xff; if either *bmp or *omp is dirty, we need to mark it as dirty
   while (bmp < endp)
@@ -100,7 +100,7 @@ void ShenandoahScanRememberedTask::work(uint worker_id) {
   ShenandoahObjToScanQueue* q = _queue_set->queue(worker_id);
   ShenandoahObjToScanQueue* old = _old_queue_set == NULL ? NULL : _old_queue_set->queue(worker_id);
   ShenandoahMarkRefsClosure<YOUNG> cl(q, _rp, old);
-  RememberedScanner *scanner = ShenandoahHeap::heap()->card_scan();
+  RememberedScanner* scanner = ShenandoahHeap::heap()->card_scan();
 
   // set up thread local closure for shen ref processor
   _rp->set_mark_closure(worker_id, &cl);


### PR DESCRIPTION
### Description
Followed the existing pattern to add parallel working timings for remembered set scan.

### Testing
Ran Dacapo, looks like this in the logs:
```
[157.867s][202297][info] Concurrent Reset                  94013 us
[157.867s][202297][info] Pause Init Mark (G)              579650 us
[157.867s][202297][info] Pause Init Mark (N)              579456 us
[157.867s][202297][info]   Scan Remembered Set            483166 us, parallelism: 3.91x
[157.867s][202297][info]     RS: <total>                 1891580 us
[157.867s][202297][info]     RS: Scan Clusters           1891580 us, workers (us): 481972, 468615, 457912, 483081, 
[157.867s][202297][info]   Update Region States               78 us
[157.867s][202297][info] Concurrent Mark Roots             18932 us, parallelism: 1.98x

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

### Reviewers
 * [Aleksey Shipilev](https://openjdk.java.net/census#shade) (@shipilev - **Reviewer**) ⚠️ Review applies to 9cc042c8e3c05a45deb8e28b63613f273d995c29


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/shenandoah pull/27/head:pull/27` \
`$ git checkout pull/27`

Update a local copy of the PR: \
`$ git checkout pull/27` \
`$ git pull https://git.openjdk.java.net/shenandoah pull/27/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 27`

View PR using the GUI difftool: \
`$ git pr show -t 27`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/shenandoah/pull/27.diff">https://git.openjdk.java.net/shenandoah/pull/27.diff</a>

</details>
