### PR TITLE
Use timed wait to sleep control thread

### DIFF
--- a/src/hotspot/share/gc/shenandoah/shenandoahControlThread.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahControlThread.cpp
@@ -52,6 +52,7 @@ ShenandoahControlThread::ShenandoahControlThread() :
   ConcurrentGCThread(),
   _alloc_failure_waiters_lock(Mutex::leaf, "ShenandoahAllocFailureGC_lock", true, Monitor::_safepoint_check_always),
   _gc_waiters_lock(Mutex::leaf, "ShenandoahRequestedGC_lock", true, Monitor::_safepoint_check_always),
+  _control_lock(Mutex::leaf, "ShenandoahControlGC_lock", true, Monitor::_safepoint_check_never),
   _periodic_task(this),
   _requested_gc_cause(GCCause::_no_cause_specified),
   _requested_generation(GenerationMode::GLOBAL),
@@ -367,11 +368,12 @@ void ShenandoahControlThread::run_service() {
       last_shrink_time = current;
     }
 
-    // HEY! kemperw would like to have this thread sleep on a timed wait so it
-    // could be explicitly woken when there is something to do. The timed wait
-    // is necessary because this thread has a responsibility to send
-    // 'alloc_words' to the pacer when it does not perform a GC.
-    os::naked_short_sleep(ShenandoahControlIntervalMin);
+    {
+      // The timed wait is necessary because this thread has a responsibility to send
+      // 'alloc_words' to the pacer when it does not perform a GC.
+      MonitorLocker lock(&_control_lock, Mutex::SafepointCheckFlag::_no_safepoint_check_flag);
+      lock.wait(ShenandoahControlIntervalMax);
+    }
   }
 
   // Wait for the actual stop(), can't leave run_service() earlier.
@@ -721,6 +723,7 @@ bool ShenandoahControlThread::request_concurrent_gc(GenerationMode generation) {
   if (_mode == none) {
     _requested_gc_cause = GCCause::_shenandoah_concurrent_gc;
     _requested_generation = generation;
+    notify_control_thread();
     return true;
   }
 
@@ -730,10 +733,16 @@ bool ShenandoahControlThread::request_concurrent_gc(GenerationMode generation) {
     _requested_generation = generation;
     _preemption_requested.set();
     ShenandoahHeap::heap()->cancel_gc(GCCause::_shenandoah_concurrent_gc);
+    notify_control_thread();
     return true;
   }
 
   return false;
+}
+
+void ShenandoahControlThread::notify_control_thread() {
+  MonitorLocker locker(&_control_lock, Mutex::SafepointCheckFlag::_no_safepoint_check_flag);
+  _control_lock.notify();
 }
 
 bool ShenandoahControlThread::preempt_old_marking(GenerationMode generation) {
@@ -756,6 +765,7 @@ void ShenandoahControlThread::handle_requested_gc(GCCause::Cause cause) {
   while (current_gc_id < required_gc_id) {
     _gc_requested.set();
     _requested_gc_cause = cause;
+    notify_control_thread();
     ml.wait();
     current_gc_id = get_gc_id();
   }

--- a/src/hotspot/share/gc/shenandoah/shenandoahControlThread.hpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahControlThread.hpp
@@ -62,6 +62,7 @@ private:
   // to make complete explicit cycle for for demanding customers.
   Monitor _alloc_failure_waiters_lock;
   Monitor _gc_waiters_lock;
+  Monitor _control_lock;
   ShenandoahPeriodicTask _periodic_task;
   ShenandoahPeriodicPacerNotify _periodic_pacer_notify_task;
 
@@ -175,6 +176,7 @@ public:
 
  private:
   static const char* gc_mode_name(GCMode mode);
+  void notify_control_thread();
 };
 
 #endif // SHARE_GC_SHENANDOAH_SHENANDOAHCONTROLTHREAD_HPP


### PR DESCRIPTION
Using a timed `wait` rather than a naked sleep allows the control thread to be more responsive to requests from mutators and the regulator thread to start GC cycles. The sleep time is also changed from `ShenandoahControlIntervalMin` to `ShenandoahControlIntervalMax` to reduce unnecessary polling cycles. We could use a plain `wait`, but the control thread is responsible for periodically sending allocation metrics to the `pacer`.