### PR TITLE
Update remembered set during old generation mark

### DIFF
--- a/src/hotspot/share/gc/shenandoah/shenandoahHeap.hpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahHeap.hpp
@@ -669,6 +669,7 @@ private:
 public:
   inline RememberedScanner* card_scan() { return _card_scan; }
   void clear_cards_for(ShenandoahHeapRegion* region);
+  void mark_card_as_dirty(HeapWord* location);
 
 // ---------- Helper functions
 //

--- a/src/hotspot/share/gc/shenandoah/shenandoahHeap.inline.hpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahHeap.inline.hpp
@@ -40,6 +40,7 @@
 #include "gc/shenandoah/shenandoahHeapRegion.inline.hpp"
 #include "gc/shenandoah/shenandoahControlThread.hpp"
 #include "gc/shenandoah/shenandoahMarkingContext.inline.hpp"
+#include "gc/shenandoah/shenandoahScanRemembered.inline.hpp"
 #include "gc/shenandoah/shenandoahThreadLocalData.hpp"
 #include "gc/shenandoah/mode/shenandoahMode.hpp"
 #include "oops/compressedOops.inline.hpp"
@@ -578,5 +579,12 @@ inline void ShenandoahHeap::clear_cards_for(ShenandoahHeapRegion* region) {
     _card_scan->mark_range_as_empty(region->bottom(), (uint32_t) (region->end() - region->bottom()));
   }
 }
+
+inline void ShenandoahHeap::mark_card_as_dirty(HeapWord* location) {
+  if (mode()->is_generational()) {
+    _card_scan->mark_card_as_dirty(location);
+  }
+}
+
 
 #endif // SHARE_GC_SHENANDOAH_SHENANDOAHHEAP_INLINE_HPP

--- a/src/hotspot/share/gc/shenandoah/shenandoahMark.inline.hpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahMark.inline.hpp
@@ -269,8 +269,13 @@ inline void ShenandoahMark::mark_through_ref(T *p, ShenandoahObjToScanQueue* q, 
       mark_ref<STRING_DEDUP>(q, mark_context, weak, obj);
       shenandoah_assert_marked(p, obj);
     } else if (old != nullptr) {
+      // Young mark, bootstrapping old.
       mark_ref<STRING_DEDUP>(old, mark_context, weak, obj);
       shenandoah_assert_marked(p, obj);
+    } else if (GENERATION == OLD) {
+      // Old mark, found a young pointer.
+      assert(ShenandoahHeap::heap()->is_in_young(obj), "Expected young object.");
+      ShenandoahHeap::heap()->mark_card_as_dirty((HeapWord*)p);
     }
   }
 }


### PR DESCRIPTION
This change is to support the concurrent remembered set scanning work which is in progress.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

### Reviewers
 * [Roman Kennke](https://openjdk.java.net/census#rkennke) (@rkennke - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/shenandoah pull/31/head:pull/31` \
`$ git checkout pull/31`

Update a local copy of the PR: \
`$ git checkout pull/31` \
`$ git pull https://git.openjdk.java.net/shenandoah pull/31/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 31`

View PR using the GUI difftool: \
`$ git pr show -t 31`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/shenandoah/pull/31.diff">https://git.openjdk.java.net/shenandoah/pull/31.diff</a>

</details>
