### PR TITLE
Fix build failures due to undeclared ShenandoahOldHeuristics

### DIFF
--- a/src/hotspot/share/gc/shenandoah/heuristics/shenandoahHeuristics.hpp
+++ b/src/hotspot/share/gc/shenandoah/heuristics/shenandoahHeuristics.hpp
@@ -57,6 +57,7 @@
 class ShenandoahCollectionSet;
 class ShenandoahHeapRegion;
 class ShenandoahGeneration;
+class ShenandoahOldHeuristics;
 
 class ShenandoahHeuristics : public CHeapObj<mtGC> {
   static const intx Concurrent_Adjust   = -1; // recover from penalties


### PR DESCRIPTION
Some configs, notably Zero, does not build due to:

```
* For target hotspot_variant-zero_libjvm_objs_shenandoahAdaptiveHeuristics.o:
In file included from /home/buildbot/worker/build-shenandoah-jdkX-linux/build/src/hotspot/share/gc/shenandoah/heuristics/shenandoahAdaptiveHeuristics.hpp:28:0,
                 from /home/buildbot/worker/build-shenandoah-jdkX-linux/build/src/hotspot/share/gc/shenandoah/heuristics/shenandoahAdaptiveHeuristics.cpp:27:
/home/buildbot/worker/build-shenandoah-jdkX-linux/build/src/hotspot/share/gc/shenandoah/heuristics/shenandoahHeuristics.hpp:142:79: error: 'ShenandoahOldHeuristics' has not been declared
   virtual void choose_collection_set(ShenandoahCollectionSet* collection_set, ShenandoahOldHeuristics* old_heuristics);
                                                                               ^~~~~~~~~~~~~~~~~~~~~~~
/home/buildbot/worker/build-shenandoah-jdkX-linux/build/src/hotspot/share/gc/shenandoah/heuristics/shenandoahHeuristics.hpp:142:16: error: 'virtual void ShenandoahHeuristics::choose_collection_set(ShenandoahCollectionSet*, int*)' was hidden [-Werror=overloaded-virtual]
   virtual void choose_collection_set(ShenandoahCollectionSet* collection_set, ShenandoahOldHeuristics* old_heuristics);
                ^~~~~~~~~~~~~~~~~~~~~
In file included from /home/buildbot/worker/build-shenandoah-jdkX-linux/build/src/hotspot/share/gc/shenandoah/shenandoahGeneration.hpp:29:0,
                 from /home/buildbot/worker/build-shenandoah-jdkX-linux/build/src/hotspot/share/gc/shenandoah/heuristics/shenandoahAdaptiveHeuristics.cpp:30:
/home/buildbot/worker/build-shenandoah-jdkX-linux/build/src/hotspot/share/gc/shenandoah/heuristics/shenandoahOldHeuristics.hpp:72:16: error:   by 'virtual void ShenandoahOldHeuristics::choose_collection_set(ShenandoahCollectionSet*, ShenandoahOldHeuristics*)' [-Werror=overloaded-virtual]
   virtual void choose_collection_set(ShenandoahCollectionSet* collection_set, ShenandoahOldHeuristics* old_heuristics);
                ^~~~~~~~~~~~~~~~~~~~~
```

Since there is a circularity between `shenandoahHeuristics.hpp` and `shenandoahOldHeuristics.hpp`, we are better off forward-declaring the missing symbol.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

### Reviewers
 * [Roman Kennke](https://openjdk.java.net/census#rkennke) (@rkennke - **Reviewer**)
 * [Zhengyu Gu](https://openjdk.java.net/census#zgu) (@zhengyu123 - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/shenandoah pull/34/head:pull/34` \
`$ git checkout pull/34`

Update a local copy of the PR: \
`$ git checkout pull/34` \
`$ git pull https://git.openjdk.java.net/shenandoah pull/34/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 34`

View PR using the GUI difftool: \
`$ git pr show -t 34`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/shenandoah/pull/34.diff">https://git.openjdk.java.net/shenandoah/pull/34.diff</a>

</details>
