### PR TITLE
Fix Windows builds

### DIFF
--- a/src/hotspot/share/gc/shenandoah/heuristics/shenandoahOldHeuristics.cpp
+++ b/src/hotspot/share/gc/shenandoah/heuristics/shenandoahOldHeuristics.cpp
@@ -236,9 +236,9 @@ void ShenandoahOldHeuristics::prepare_for_old_collections() {
 
     if (percent_garbage < collection_threshold_garbage_percent) {
       _hidden_next_old_collection_candidate = 0;
-      _hidden_old_collection_candidates = i;
-      _first_coalesce_and_fill_candidate = i;
-      _old_coalesce_and_fill_candidates = cand_idx - i;
+      _hidden_old_collection_candidates = (uint)i;
+      _first_coalesce_and_fill_candidate = (uint)i;
+      _old_coalesce_and_fill_candidates = (uint)(cand_idx - i);
 
       // Note that we do not coalesce and fill occupied humongous regions
       // HR: humongous regions, RR: regular regions, CF: coalesce and fill regions
@@ -252,7 +252,7 @@ void ShenandoahOldHeuristics::prepare_for_old_collections() {
 
   // If we reach here, all of non-humogous old-gen regions are candidates for collection set.
   _hidden_next_old_collection_candidate = 0;
-  _hidden_old_collection_candidates = first_humongous_non_empty;
+  _hidden_old_collection_candidates = (uint)first_humongous_non_empty;
   _first_coalesce_and_fill_candidate = 0;
   _old_coalesce_and_fill_candidates = 0;
 

--- a/src/hotspot/share/gc/shenandoah/shenandoahOldGC.hpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahOldGC.hpp
@@ -35,6 +35,8 @@ class ShenandoahOldGC : public ShenandoahConcurrentGC {
   ShenandoahOldGC(ShenandoahGeneration* generation, ShenandoahSharedFlag& allow_preemption);
   bool collect(GCCause::Cause cause);
  private:
+  ShenandoahHeapRegion** _coalesce_and_fill_region_array;
+
   void entry_old_evacuations();
   void entry_coalesce_and_fill();
   ShenandoahSharedFlag& _allow_preemption;


### PR DESCRIPTION
Windows builds are currently failing with:

```
c:\buildbot\worker\build-shenandoah-jdkx-windows\build\src\hotspot\share\gc\shenandoah\shenandoahOldGC.cpp(149): error C2131: expression did not evaluate to a constant
c:\buildbot\worker\build-shenandoah-jdkx-windows\build\src\hotspot\share\gc\shenandoah\shenandoahOldGC.cpp(149): note: failure was caused by a read of a variable outside its lifetime
c:\buildbot\worker\build-shenandoah-jdkx-windows\build\src\hotspot\share\gc\shenandoah\shenandoahOldGC.cpp(149): note: see usage of 'coalesce_and_fill_regions_count'
make[3]: *** [lib/CompileJvm.gmk:143: /cygdrive/c/buildbot/worker/build-shenandoah-jdkx-windows/build/build/windows-x86_64-server-fastdebug/hotspot/variant-server/libjvm/objs/shenandoahOldGC.obj] Error 1
```

...and:

```
c:\buildbot\worker\build-shenandoah-jdkx-windows\build\src\hotspot\share\gc\shenandoah\heuristics\shenandoahOldHeuristics.cpp(239): error C2220: the following warning is treated as an error
c:\buildbot\worker\build-shenandoah-jdkx-windows\build\src\hotspot\share\gc\shenandoah\heuristics\shenandoahOldHeuristics.cpp(239): warning C4267: '=': conversion from 'size_t' to 'uint', possible loss of data
c:\buildbot\worker\build-shenandoah-jdkx-windows\build\src\hotspot\share\gc\shenandoah\heuristics\shenandoahOldHeuristics.cpp(240): warning C4267: '=': conversion from 'size_t' to 'uint', possible loss of data
c:\buildbot\worker\build-shenandoah-jdkx-windows\build\src\hotspot\share\gc\shenandoah\heuristics\shenandoahOldHeuristics.cpp(241): warning C4267: '=': conversion from 'size_t' to 'uint', possible loss of data
c:\buildbot\worker\build-shenandoah-jdkx-windows\build\src\hotspot\share\gc\shenandoah\heuristics\shenandoahOldHeuristics.cpp(255): warning C4267: '=': conversion from 'size_t' to 'uint', possible loss of data
make[3]: *** [lib/CompileJvm.gmk:143: /cygdrive/c/buildbot/worker/build-shenandoah-jdkx-windows/build/build/windows-x86_64-server-fastdebug/hotspot/variant-server/libjvm/objs/shenandoahOldHeuristics.obj] Error 1
make[2]: *** [make/Main.gmk:252: hotspot-server-libs] Error 2
```

Additional testing:
 - [x] Windows x86_64 builds
 - [x] Linux x86_64 hotspot_gc_shenandoah

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

### Reviewers
 * [Roman Kennke](https://openjdk.java.net/census#rkennke) (@rkennke - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/shenandoah pull/35/head:pull/35` \
`$ git checkout pull/35`

Update a local copy of the PR: \
`$ git checkout pull/35` \
`$ git pull https://git.openjdk.java.net/shenandoah pull/35/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 35`

View PR using the GUI difftool: \
`$ git pr show -t 35`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/shenandoah/pull/35.diff">https://git.openjdk.java.net/shenandoah/pull/35.diff</a>

</details>
