### PR TITLE
Fix Region Promotion

### DIFF
--- a/src/hotspot/share/gc/shenandoah/shenandoahHeap.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahHeap.cpp
@@ -1012,43 +1012,6 @@ HeapWord* ShenandoahHeap::allocate_memory(ShenandoahAllocRequest& req) {
 HeapWord* ShenandoahHeap::allocate_memory_under_lock(ShenandoahAllocRequest& req, bool& in_new_region) {
   ShenandoahHeapLocker locker(lock());
   HeapWord* result = _free_set->allocate(req, in_new_region);
-  // Register the newly allocated object while we're holding the global lock since there's no synchronization
-  // built in to the implementation of register_object().  There are potential races when multiple independent
-  // threads are allocating objects, some of which might span the same card region.  For example, consider
-  // a card table's memory region within which three objects are being allocated by three different threads:
-  //
-  // objects being "concurrently" allocated:
-  //    [-----a------][-----b-----][--------------c------------------]
-  //            [---- card table memory range --------------]
-  //
-  // Before any objects are allocated, this card's memory range holds no objects.  Note that:
-  //   allocation of object a wants to set the has-object, first-start, and last-start attributes of the preceding card region.
-  //   allocation of object b wants to set the has-object, first-start, and last-start attributes of this card region.
-  //   allocation of object c also wants to set the has-object, first-start, and last-start attributes of this card region.
-  //
-  // The thread allocating b and the thread allocating c can "race" in various ways, resulting in confusion, such as last-start
-  // representing object b while first-start represents object c.  This is why we need to require all register_object()
-  // invocations to be "mutually exclusive".  Later, when we use GCLABs and PLABs to allocate memory for promotions and evacuations,
-  // the protocol may work something like the following:
-  //   1. The GCLAB/PLAB is allocated by this (or similar) function, while holding the global lock.
-  //   2. The GCLAB/PLAB is always aligned at the start of a card memory range
-  //      and is always a multiple of the card-table memory range size.
-  //   3. Individual allocations carved from a GCLAB/PLAB are not immediately registered.
-  //   4. A PLAB is registered as a single object.
-  //   5. When a PLAB is eventually retired, all of the objects allocated within the GCLAB/PLAB are registered in batch by a
-   //      single thread.  No further synchronization is required because no other allocations will pertain to the same
-  //      card-table memory ranges.
-  //
-  // The other case that needs special handling is region promotion.  When a region is promoted, all objects contained
-  // in it are registered.  Since the region is a multiple of card table memory range sizes, there is no need for
-  // synchronization.
-  // TODO: figure out how to allow multiple threads to work together to register all of the objects in
-  // a promoted region, or at least try to balance the efforts so that different GC threads work
-  // on registering the objects of different heap regions.
-  //
-  if (mode()->is_generational() && result != NULL && req.affiliation() == ShenandoahRegionAffiliation::OLD_GENERATION) {
-    ShenandoahHeap::heap()->card_scan()->register_object(result);
-  }
   return result;
 }
 

--- a/src/hotspot/share/gc/shenandoah/shenandoahHeap.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahHeap.cpp
@@ -1262,6 +1262,37 @@ void ShenandoahHeap::gclabs_retire(bool resize) {
   }
 }
 
+class ShenandoahTagGCLABClosure : public ThreadClosure {
+public:
+  void do_thread(Thread* thread) {
+    PLAB* gclab = ShenandoahThreadLocalData::gclab(thread);
+    assert(gclab != NULL, "GCLAB should be initialized for %s", thread->name());
+    if (gclab->words_remaining() > 0) {
+      ShenandoahHeapRegion* r = ShenandoahHeap::heap()->heap_region_containing(gclab->allocate(0));
+      r->set_young_lab_flag();
+    }
+  }
+};
+
+void ShenandoahHeap::set_young_lab_region_flags() {
+  if (!UseTLAB) {
+    return;
+  }
+  for (size_t i = 0; i < _num_regions; i++) {
+    _regions[i]->clear_young_lab_flags();
+  }
+  ShenandoahTagGCLABClosure cl;
+  workers()->threads_do(&cl);
+  for (JavaThreadIteratorWithHandle jtiwh; JavaThread *t = jtiwh.next(); ) {
+    cl.do_thread(t);
+    ThreadLocalAllocBuffer& tlab = t->tlab();
+    if (tlab.end() != NULL) {
+      ShenandoahHeapRegion* r = heap_region_containing(tlab.start());
+      r->set_young_lab_flag();
+    }
+  }
+}
+
 // Returns size in bytes
 size_t ShenandoahHeap::unsafe_max_tlab_alloc(Thread *thread) const {
   if (ShenandoahElasticTLAB) {

--- a/src/hotspot/share/gc/shenandoah/shenandoahHeap.hpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahHeap.hpp
@@ -598,6 +598,8 @@ public:
   void tlabs_retire(bool resize);
   void gclabs_retire(bool resize);
 
+  void set_young_lab_region_flags();
+
 // ---------- Marking support
 //
 private:

--- a/src/hotspot/share/gc/shenandoah/shenandoahHeapRegion.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahHeapRegion.cpp
@@ -867,44 +867,37 @@ size_t ShenandoahHeapRegion::promote() {
   if (is_humongous_start()) {
     oop obj = oop(bottom());
     assert(marking_context->is_marked(obj), "promoted humongous object should be alive");
-
-    size_t index_limit = index() + ShenandoahHeapRegion::required_regions(obj->size() * HeapWordSize);
     heap->card_scan()->register_object(bottom());
+    size_t index_limit = index() + ShenandoahHeapRegion::required_regions(obj->size() * HeapWordSize);
     for (size_t i = index(); i < index_limit; i++) {
       ShenandoahHeapRegion* r = heap->get_region(i);
       log_debug(gc)("promoting region " SIZE_FORMAT ", clear cards from " SIZE_FORMAT " to " SIZE_FORMAT,
         r->index(), (size_t) r->bottom(), (size_t) r->top());
-
-      ShenandoahBarrierSet::barrier_set()->card_table()->clear_MemRegion(MemRegion(r->bottom(), r->end()));
+      if (top() < end()) {
+        ShenandoahHeap::fill_with_object(top(), (end() - top()) / HeapWordSize);
+        heap->card_scan()->register_object(top());
+        ShenandoahBarrierSet::barrier_set()->card_table()->clear_MemRegion(MemRegion(top(), end()));
+      }
+      ShenandoahBarrierSet::barrier_set()->card_table()->dirty_MemRegion(MemRegion(bottom(), top()));
       r->set_affiliation(OLD_GENERATION);
       old_generation->increase_used(r->used());
       young_generation->decrease_used(r->used());
     }
-    // HEY!  Better to call ShenandoahHeap::heap()->card_scan()->mark_range_as_clean(r->bottom(), obj->size())
-    //  and skip the calls to clear_MemRegion() above.
-
-    // Iterate over all humongous regions that are spanned by the humongous object obj.  The remnant
-    // of memory in the last humongous region that is not spanned by obj is currently not used.
-    obj->oop_iterate(&update_card_values);
     return index_limit - index();
   } else {
     log_debug(gc)("promoting region " SIZE_FORMAT ", clear cards from " SIZE_FORMAT " to " SIZE_FORMAT,
       index(), (size_t) bottom(), (size_t) top());
     assert(!is_humongous_continuation(), "should not promote humongous object continuation in isolation");
 
-    // Rather than scanning entire contents of the promoted region right now to determine which
-    // cards to mark dirty, we just mark them all as dirty.  Later, when we scan the remembered
-    // set, we will clear cards that are found to not contain live references to young memory.
-    // Ultimately, this approach is more efficient as it only scans the "dirty" cards once and
-    // the clean cards once.  The alternative approach of scanning all cards now and then scanning
-    // dirty cards again at next concurrent mark pass scans the clean cards once and the dirty
-    // cards twice.
-
-    // HEY!  Better to call ShenandoahHeap::heap()->card_scan()->mark_range_as_dirty(r->bottom(), obj->size());
-    ShenandoahBarrierSet::barrier_set()->card_table()->dirty_MemRegion(MemRegion(bottom(), end()));
     set_affiliation(OLD_GENERATION);
     old_generation->increase_used(used());
     young_generation->decrease_used(used());
+
+    ShenandoahBarrierSet::barrier_set()->card_table()->clear_MemRegion(MemRegion(top(), end()));
+    // In terms of card marking, We could just set the whole occupied range in this region to dirty instead of iterating here.
+    // Card scanning could correct false positives later and that would be more efficient.
+    // But oop_iterate_objects() has other, indispensable effects: filling dead objects and registering object starts.
+    // So while we are already doing this here, we may as well also set more precise card values.
     oop_iterate_objects(&update_card_values, /*fill_dead_objects*/ true, /* reregister_coalesced_objects */ false);
     return 1;
   }

--- a/src/hotspot/share/gc/shenandoah/shenandoahHeapRegion.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahHeapRegion.cpp
@@ -71,6 +71,7 @@ ShenandoahHeapRegion::ShenandoahHeapRegion(HeapWord* start, size_t index, bool c
   _tlab_allocs(0),
   _gclab_allocs(0),
   _plab_allocs(0),
+  _has_young_lab(false),
   _live_data(0),
   _critical_pins(0),
   _update_watermark(start),
@@ -871,7 +872,7 @@ size_t ShenandoahHeapRegion::promote() {
     size_t index_limit = index() + ShenandoahHeapRegion::required_regions(obj->size() * HeapWordSize);
     for (size_t i = index(); i < index_limit; i++) {
       ShenandoahHeapRegion* r = heap->get_region(i);
-      log_debug(gc)("promoting region " SIZE_FORMAT ", clear cards from " SIZE_FORMAT " to " SIZE_FORMAT,
+      log_debug(gc)("promoting region " SIZE_FORMAT ", from " SIZE_FORMAT " to " SIZE_FORMAT,
         r->index(), (size_t) r->bottom(), (size_t) r->top());
       if (top() < end()) {
         ShenandoahHeap::fill_with_object(top(), (end() - top()) / HeapWordSize);
@@ -885,7 +886,7 @@ size_t ShenandoahHeapRegion::promote() {
     }
     return index_limit - index();
   } else {
-    log_debug(gc)("promoting region " SIZE_FORMAT ", clear cards from " SIZE_FORMAT " to " SIZE_FORMAT,
+    log_debug(gc)("promoting region " SIZE_FORMAT ", from " SIZE_FORMAT " to " SIZE_FORMAT,
       index(), (size_t) bottom(), (size_t) top());
     assert(!is_humongous_continuation(), "should not promote humongous object continuation in isolation");
 

--- a/src/hotspot/share/gc/shenandoah/shenandoahHeapRegion.hpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahHeapRegion.hpp
@@ -212,6 +212,10 @@ public:
   void record_unpin();
   size_t pin_count() const;
 
+  void clear_young_lab_flags();
+  void set_young_lab_flag();
+  bool has_young_lab_flag();
+
 private:
   static size_t RegionCount;
   static size_t RegionSizeBytes;
@@ -243,6 +247,8 @@ private:
   size_t _tlab_allocs;
   size_t _gclab_allocs;
   size_t _plab_allocs;
+
+  bool _has_young_lab;
 
   volatile size_t _live_data;
   volatile size_t _critical_pins;

--- a/src/hotspot/share/gc/shenandoah/shenandoahHeapRegion.inline.hpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahHeapRegion.inline.hpp
@@ -135,4 +135,16 @@ inline void ShenandoahHeapRegion::set_update_watermark_at_safepoint(HeapWord* w)
   _update_watermark = w;
 }
 
+inline void ShenandoahHeapRegion::clear_young_lab_flags() {
+  _has_young_lab = false;
+}
+
+inline void ShenandoahHeapRegion::set_young_lab_flag() {
+  _has_young_lab = true;
+}
+
+inline bool ShenandoahHeapRegion::has_young_lab_flag() {
+  return _has_young_lab;
+}
+
 #endif // SHARE_GC_SHENANDOAH_SHENANDOAHHEAPREGION_INLINE_HPP

--- a/src/hotspot/share/gc/shenandoah/shenandoahThreadLocalData.hpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahThreadLocalData.hpp
@@ -45,10 +45,19 @@ private:
   uint8_t                 _oom_scope_nesting_level;
   bool                    _oom_during_evac;
   SATBMarkQueue           _satb_mark_queue;
+
+  // Thread-local allocation buffer for object evacuations.
+  // In generational mode, it is exclusive to the young generation.
   PLAB* _gclab;
   size_t _gclab_size;
+
+  // Thread-local allocation buffer only used in generational mode.
+  // Used both by mutator threads and by GC worker threads
+  // for evacuations within the old generation and
+  // for promotions from the young generation into the old generation.
   PLAB* _plab;
   size_t _plab_size;
+
   uint  _worker_id;
   int  _disarmed_value;
   double _paced_time;

--- a/src/hotspot/share/gc/shenandoah/shenandoahYoungGeneration.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahYoungGeneration.cpp
@@ -68,7 +68,7 @@ public:
     ShenandoahParallelWorkerSession worker_session(worker_id);
     ShenandoahHeapRegion* r = _regions->next();
     while (r != NULL) {
-      if (r->is_young() && r->age() >= InitialTenuringThreshold && (r->is_regular() || r->is_humongous_start())) {
+      if (r->is_young() && r->age() >= InitialTenuringThreshold && ((r->is_regular() && !r->has_young_lab_flag()) || r->is_humongous_start())) {
         // The above condition filtered out humongous continuations, among other states.
         // Here we rely on promote() below promoting related continuation regions when encountering a homongous start.
         size_t promoted = r->promote();
@@ -80,6 +80,7 @@ public:
 };
 
 void ShenandoahYoungGeneration::promote_tenured_regions() {
+  ShenandoahHeap::heap()->set_young_lab_region_flags();
   ShenandoahRegionIterator regions;
   ShenandoahPromoteTenuredRegionsTask task(&regions);
   ShenandoahHeap::heap()->workers()->run_task(&task);

--- a/src/hotspot/share/gc/shenandoah/shenandoahYoungGeneration.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahYoungGeneration.cpp
@@ -68,14 +68,11 @@ public:
     ShenandoahParallelWorkerSession worker_session(worker_id);
     ShenandoahHeapRegion* r = _regions->next();
     while (r != NULL) {
-      if (r->is_young()) {
-        // The thread that first encounters a humongous start region is responsible
-        // for promoting the continuation regions so we need this guard here to
-        // keep other worker threads from trying to promote the continuations.
-        if (r->age() >= InitialTenuringThreshold && !r->is_humongous_continuation()) {
-          size_t promoted = r->promote();
-          Atomic::add(&_promoted, promoted);
-        }
+      if (r->is_young() && r->age() >= InitialTenuringThreshold && (r->is_regular() || r->is_humongous_start())) {
+        // The above condition filtered out humongous continuations, among other states.
+        // Here we rely on promote() below promoting related continuation regions when encountering a homongous start.
+        size_t promoted = r->promote();
+        Atomic::add(&_promoted, promoted);
       }
       r = _regions->next();
     }


### PR DESCRIPTION
This is rebased pull request of https://github.com/openjdk/shenandoah/pull/32.

There are bugs in region promotion.

* Humongous object continuation region remainder object starts are not registered for remembered set scanning purposes.
* Also, iterating over humongous objects at promotion time to set card table values is inefficient. This is better delayed until card table scanning.
* Regions that are not either regular or humongous should not get promoted, in particular the cset region state needs to be excluded.
* We need to prevent regions that contain TLABs or GCLABs from getting promoted with these remaining active. One could retire those LABs once again at final update refs, but that would be inefficient. An alternative defensive and robust fix is to exclude regions that contain any TLAB or GCLAB from promotion. This should not restrict promotions much, because regions tend to fill up as they age and eventually they won't have LABs.

All of the above is fixed by the commits proposed here.
This PR is best applied after PR #30, the outcome of which it is rebased to at the moment.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

### Reviewers
 * [Roman Kennke](https://openjdk.java.net/census#rkennke) (@rkennke - **Reviewer**)


### Contributors
 * Bernd Mathiske `<bmathiske@openjdk.org>`

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/shenandoah pull/36/head:pull/36` \
`$ git checkout pull/36`

Update a local copy of the PR: \
`$ git checkout pull/36` \
`$ git pull https://git.openjdk.java.net/shenandoah pull/36/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 36`

View PR using the GUI difftool: \
`$ git pr show -t 36`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/shenandoah/pull/36.diff">https://git.openjdk.java.net/shenandoah/pull/36.diff</a>

</details>
