### PR TITLE
Abandon old gen cset candidates upon global collection

### DIFF
--- a/src/hotspot/share/gc/shenandoah/heuristics/shenandoahOldHeuristics.cpp
+++ b/src/hotspot/share/gc/shenandoah/heuristics/shenandoahOldHeuristics.cpp
@@ -315,3 +315,12 @@ bool ShenandoahOldHeuristics::should_defer_gc() {
   return false;
 }
 
+void ShenandoahOldHeuristics::abandon_collection_candidates() {
+  _old_collection_candidates = 0;
+  _next_old_collection_candidate = 0;
+  _hidden_old_collection_candidates = 0;
+  _hidden_next_old_collection_candidate = 0;
+  _old_coalesce_and_fill_candidates = 0;
+  _first_coalesce_and_fill_candidate = 0;
+}
+

--- a/src/hotspot/share/gc/shenandoah/heuristics/shenandoahOldHeuristics.hpp
+++ b/src/hotspot/share/gc/shenandoah/heuristics/shenandoahOldHeuristics.hpp
@@ -100,6 +100,10 @@ public:
 
   bool should_defer_gc();
 
+  // If a GLOBAL gc occurs, it will collect the entire heap which invalidates any collection candidates being
+  // held by this heuristic for supplying mixed collections.
+  void abandon_collection_candidates();
+
 };
 
 #endif // SHARE_GC_SHENANDOAH_HEURISTICS_SHENANDOAHOLDHEURISTICS_HPP

--- a/src/hotspot/share/gc/shenandoah/shenandoahGeneration.hpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahGeneration.hpp
@@ -82,7 +82,7 @@ public:
   void reset_mark_bitmap();
 
   // Used by concurrent and degenerated GC to reset regions.
-  void prepare_gc();
+  virtual void prepare_gc();
   void prepare_regions_and_collection_set(bool concurrent);
 
   // Cancel marking (used by Full collect and when cancelling cycle).

--- a/src/hotspot/share/gc/shenandoah/shenandoahGlobalGeneration.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahGlobalGeneration.cpp
@@ -87,3 +87,12 @@ bool ShenandoahGlobalGeneration::is_concurrent_mark_in_progress() {
   return heap->is_concurrent_mark_in_progress();
 }
 
+void ShenandoahGlobalGeneration::prepare_gc() {
+  ShenandoahGeneration::prepare_gc();
+
+  ShenandoahHeap* heap = ShenandoahHeap::heap();
+  if (heap->mode()->is_generational()) {
+    heap->cancel_mixed_collections();
+  }
+}
+

--- a/src/hotspot/share/gc/shenandoah/shenandoahGlobalGeneration.hpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahGlobalGeneration.hpp
@@ -42,6 +42,8 @@ public:
   virtual size_t used() const;
   virtual size_t available() const;
 
+  virtual void prepare_gc();
+
   virtual void set_concurrent_mark_in_progress(bool in_progress);
 
   bool contains(ShenandoahHeapRegion* region) const;

--- a/src/hotspot/share/gc/shenandoah/shenandoahHeap.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahHeap.cpp
@@ -894,6 +894,11 @@ void ShenandoahHeap::retire_plab(PLAB* plab) {
   }
 }
 
+void ShenandoahHeap::cancel_mixed_collections() {
+  assert(_old_generation != NULL, "Should only have mixed collections in generation mode.");
+  _old_heuristics->abandon_collection_candidates();
+}
+
 HeapWord* ShenandoahHeap::allocate_new_tlab(size_t min_size,
                                             size_t requested_size,
                                             size_t* actual_size) {

--- a/src/hotspot/share/gc/shenandoah/shenandoahHeap.hpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahHeap.hpp
@@ -685,6 +685,7 @@ public:
   void clear_cards_for(ShenandoahHeapRegion* region);
   void mark_card_as_dirty(HeapWord* location);
   void retire_plab(PLAB* plab);
+  void cancel_mixed_collections();
 
 // ---------- Helper functions
 //


### PR DESCRIPTION
When a _global_ collection occurs, it will include the old generation. When this happens, it doesn't make sense to continue with mixed collections of the old generation. This changes fixes an assert caused by the same old region being added more than once to the collection set.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

### Reviewers
 * [Roman Kennke](https://openjdk.java.net/census#rkennke) (@rkennke - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/shenandoah pull/38/head:pull/38` \
`$ git checkout pull/38`

Update a local copy of the PR: \
`$ git checkout pull/38` \
`$ git pull https://git.openjdk.java.net/shenandoah pull/38/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 38`

View PR using the GUI difftool: \
`$ git pr show -t 38`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/shenandoah/pull/38.diff">https://git.openjdk.java.net/shenandoah/pull/38.diff</a>

</details>
