### PR TITLE
More promotion fixes

### DIFF
--- a/src/hotspot/share/gc/shenandoah/shenandoahHeap.hpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahHeap.hpp
@@ -683,7 +683,9 @@ private:
 public:
   inline RememberedScanner* card_scan() { return _card_scan; }
   void clear_cards_for(ShenandoahHeapRegion* region);
-  void mark_card_as_dirty(HeapWord* location);
+  void dirty_cards(HeapWord* start, HeapWord* end);
+  void clear_cards(HeapWord* start, HeapWord* end);
+  void mark_card_as_dirty(void* location);
   void retire_plab(PLAB* plab);
 
 // ---------- Helper functions

--- a/src/hotspot/share/gc/shenandoah/shenandoahHeap.inline.hpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahHeap.inline.hpp
@@ -626,13 +626,25 @@ inline ShenandoahMarkingContext* ShenandoahHeap::marking_context() const {
 
 inline void ShenandoahHeap::clear_cards_for(ShenandoahHeapRegion* region) {
   if (mode()->is_generational()) {
-    _card_scan->mark_range_as_empty(region->bottom(), (uint32_t) (region->end() - region->bottom()));
+    _card_scan->mark_range_as_empty(region->bottom(), pointer_delta(region->end(), region->bottom()));
   }
 }
 
-inline void ShenandoahHeap::mark_card_as_dirty(HeapWord* location) {
+inline void ShenandoahHeap::dirty_cards(HeapWord* start, HeapWord* end) {
+  assert(mode()->is_generational(), "Should only be used for generational mode");
+  size_t words = pointer_delta(end, start);
+  _card_scan->mark_range_as_dirty(start, words);
+}
+
+inline void ShenandoahHeap::clear_cards(HeapWord* start, HeapWord* end) {
+  assert(mode()->is_generational(), "Should only be used for generational mode");
+  size_t words = pointer_delta(end, start);
+  _card_scan->mark_range_as_clean(start, words);
+}
+
+inline void ShenandoahHeap::mark_card_as_dirty(void* location) {
   if (mode()->is_generational()) {
-    _card_scan->mark_card_as_dirty(location);
+    _card_scan->mark_card_as_dirty((HeapWord*)location);
   }
 }
 

--- a/src/hotspot/share/gc/shenandoah/shenandoahHeapRegion.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahHeapRegion.cpp
@@ -880,8 +880,7 @@ size_t ShenandoahHeapRegion::promote() {
         heap->card_scan()->register_object(r->top());
         ShenandoahBarrierSet::barrier_set()->card_table()->clear_MemRegion(MemRegion(r->top(), r->end()));
       }
-
-      ShenandoahBarrierSet::barrier_set()->card_table()->dirty_MemRegion(MemRegion(r->bottom(), r->end()));
+      ShenandoahBarrierSet::barrier_set()->card_table()->dirty_MemRegion(MemRegion(r->bottom(), r->top()));
       r->set_affiliation(OLD_GENERATION);
       old_generation->increase_used(r->used());
       young_generation->decrease_used(r->used());

--- a/src/hotspot/share/gc/shenandoah/shenandoahHeapRegion.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahHeapRegion.cpp
@@ -875,10 +875,10 @@ size_t ShenandoahHeapRegion::promote() {
       ShenandoahHeapRegion* r = heap->get_region(i);
       log_debug(gc)("promoting region " SIZE_FORMAT ", from " SIZE_FORMAT " to " SIZE_FORMAT,
         r->index(), (size_t) r->bottom(), (size_t) r->top());
-      if (top() < end()) {
-        ShenandoahHeap::fill_with_object(top(), (end() - top()) / HeapWordSize);
-        heap->card_scan()->register_object(top());
-        ShenandoahBarrierSet::barrier_set()->card_table()->clear_MemRegion(MemRegion(top(), end()));
+      if (r->top() < r->end()) {
+        ShenandoahHeap::fill_with_object(r->top(), (r->end() - r->top()) / HeapWordSize);
+        heap->card_scan()->register_object(r->top());
+        ShenandoahBarrierSet::barrier_set()->card_table()->clear_MemRegion(MemRegion(r->top(), r->end()));
       }
       ShenandoahBarrierSet::barrier_set()->card_table()->dirty_MemRegion(MemRegion(bottom(), top()));
       r->set_affiliation(OLD_GENERATION);

--- a/src/hotspot/share/gc/shenandoah/shenandoahHeapRegion.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahHeapRegion.cpp
@@ -880,7 +880,8 @@ size_t ShenandoahHeapRegion::promote() {
         heap->card_scan()->register_object(r->top());
         ShenandoahBarrierSet::barrier_set()->card_table()->clear_MemRegion(MemRegion(r->top(), r->end()));
       }
-      ShenandoahBarrierSet::barrier_set()->card_table()->dirty_MemRegion(MemRegion(bottom(), top()));
+
+      ShenandoahBarrierSet::barrier_set()->card_table()->dirty_MemRegion(MemRegion(r->bottom(), r->end()));
       r->set_affiliation(OLD_GENERATION);
       old_generation->increase_used(r->used());
       young_generation->decrease_used(r->used());
@@ -895,7 +896,7 @@ size_t ShenandoahHeapRegion::promote() {
     old_generation->increase_used(used());
     young_generation->decrease_used(used());
 
-    ShenandoahBarrierSet::barrier_set()->card_table()->clear_MemRegion(MemRegion(top(), end()));
+    ShenandoahBarrierSet::barrier_set()->card_table()->dirty_MemRegion(MemRegion(bottom(), end()));
     // In terms of card marking, We could just set the whole occupied range in this region to dirty instead of iterating here.
     // Card scanning could correct false positives later and that would be more efficient.
     // But oop_iterate_objects() has other, indispensable effects: filling dead objects and registering object starts.

--- a/src/hotspot/share/gc/shenandoah/shenandoahHeapRegion.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahHeapRegion.cpp
@@ -483,6 +483,7 @@ void ShenandoahHeapRegion::oop_iterate_objects(OopIterateClosure* blk, bool fill
     ShenandoahHeap* heap = ShenandoahHeap::heap();
     ShenandoahMarkingContext* marking_context = heap->marking_context();
     assert(heap->active_generation()->is_mark_complete(), "sanity");
+    HeapWord* tams = marking_context->top_at_mark_start(this);
 
     while (obj_addr < t) {
       oop obj = oop(obj_addr);
@@ -494,8 +495,8 @@ void ShenandoahHeapRegion::oop_iterate_objects(OopIterateClosure* blk, bool fill
         obj_addr += obj->oop_iterate_size(blk);
       } else {
         // Object is not marked.  Coalesce and fill dead object with dead neighbors.
-        HeapWord* next_marked_obj = marking_context->get_next_marked_addr(obj_addr, t);
-        assert(next_marked_obj <= t, "next marked object cannot exceed top");
+        HeapWord* next_marked_obj = marking_context->get_next_marked_addr(obj_addr, tams);
+        assert(next_marked_obj <= tams, "next marked object cannot exceed top at mark start");
         size_t fill_size = next_marked_obj - obj_addr;
         ShenandoahHeap::fill_with_object(obj_addr, fill_size);
         if (reregister_coalesced_objects) {

--- a/src/hotspot/share/gc/shenandoah/shenandoahMark.inline.hpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahMark.inline.hpp
@@ -275,7 +275,7 @@ inline void ShenandoahMark::mark_through_ref(T *p, ShenandoahObjToScanQueue* q, 
     } else if (GENERATION == OLD) {
       // Old mark, found a young pointer.
       assert(ShenandoahHeap::heap()->is_in_young(obj), "Expected young object.");
-      ShenandoahHeap::heap()->mark_card_as_dirty(cast_from_oop<HeapWord*>(p));
+      ShenandoahHeap::heap()->mark_card_as_dirty(p);
     }
   }
 }

--- a/src/hotspot/share/gc/shenandoah/shenandoahMark.inline.hpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahMark.inline.hpp
@@ -275,7 +275,7 @@ inline void ShenandoahMark::mark_through_ref(T *p, ShenandoahObjToScanQueue* q, 
     } else if (GENERATION == OLD) {
       // Old mark, found a young pointer.
       assert(ShenandoahHeap::heap()->is_in_young(obj), "Expected young object.");
-      ShenandoahHeap::heap()->mark_card_as_dirty((HeapWord*)p);
+      ShenandoahHeap::heap()->mark_card_as_dirty(cast_from_oop<HeapWord*>(p));
     }
   }
 }


### PR DESCRIPTION
This PR addresses a few issues with region promotion:
* Fix typo in code which loops over continuation regions of humongous objects
* Don't rely on mark bits above TAMS when iterating oops
* Due to an as-yet-undiagnosed bug, we need to mark the cards for an entire region dirty when it's promoted

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

### Reviewers
 * [Roman Kennke](https://openjdk.java.net/census#rkennke) (@rkennke - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/shenandoah pull/39/head:pull/39` \
`$ git checkout pull/39`

Update a local copy of the PR: \
`$ git checkout pull/39` \
`$ git pull https://git.openjdk.java.net/shenandoah pull/39/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 39`

View PR using the GUI difftool: \
`$ git pr show -t 39`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/shenandoah/pull/39.diff">https://git.openjdk.java.net/shenandoah/pull/39.diff</a>

</details>
