### PR TITLE
Fix verifier handling of weak references when scanning the remembered set

### DIFF
--- a/src/hotspot/share/gc/shenandoah/shenandoahRootVerifier.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahRootVerifier.cpp
@@ -113,7 +113,7 @@ void ShenandoahRootVerifier::oops_do(OopClosure* oops) {
   ShenandoahHeap* heap = ShenandoahHeap::heap();
   if (heap->mode()->is_generational() && heap->is_gc_generation_young() && verify(RememberedSetRoots)) {
     shenandoah_assert_safepoint();
-    heap->card_scan()->oops_do(oops);
+    heap->card_scan()->oops_do_simple(oops);
   }
 
   if (verify(ThreadRoots)) {
@@ -125,7 +125,7 @@ void ShenandoahRootVerifier::oops_do(OopClosure* oops) {
   }
 }
 
-void ShenandoahRootVerifier::roots_do(OopClosure* oops) {
+void ShenandoahRootVerifier::roots_do(OopIterateClosure* oops) {
   ShenandoahGCStateResetter resetter;
   shenandoah_assert_safepoint();
 
@@ -149,7 +149,7 @@ void ShenandoahRootVerifier::roots_do(OopClosure* oops) {
   Threads::possibly_parallel_oops_do(true, oops, &blobs);
 }
 
-void ShenandoahRootVerifier::strong_roots_do(OopClosure* oops) {
+void ShenandoahRootVerifier::strong_roots_do(OopIterateClosure* oops) {
   ShenandoahGCStateResetter resetter;
   shenandoah_assert_safepoint();
 

--- a/src/hotspot/share/gc/shenandoah/shenandoahRootVerifier.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahRootVerifier.cpp
@@ -113,7 +113,7 @@ void ShenandoahRootVerifier::oops_do(OopClosure* oops) {
   ShenandoahHeap* heap = ShenandoahHeap::heap();
   if (heap->mode()->is_generational() && heap->is_gc_generation_young() && verify(RememberedSetRoots)) {
     shenandoah_assert_safepoint();
-    heap->card_scan()->oops_do_simple(oops);
+    heap->card_scan()->oops_do(oops);
   }
 
   if (verify(ThreadRoots)) {
@@ -140,7 +140,7 @@ void ShenandoahRootVerifier::roots_do(OopIterateClosure* oops) {
 
   ShenandoahHeap* heap = ShenandoahHeap::heap();
   if (heap->mode()->is_generational() && heap->is_gc_generation_young()) {
-    heap->card_scan()->oops_do(oops);
+    heap->card_scan()->roots_do(oops);
   }
 
   // Do thread roots the last. This allows verification code to find
@@ -163,7 +163,7 @@ void ShenandoahRootVerifier::strong_roots_do(OopIterateClosure* oops) {
 
   ShenandoahHeap* heap = ShenandoahHeap::heap();
   if (heap->mode()->is_generational() && heap->is_gc_generation_young()) {
-    heap->card_scan()->oops_do(oops);
+    heap->card_scan()->roots_do(oops);
   }
 
   // Do thread roots the last. This allows verification code to find

--- a/src/hotspot/share/gc/shenandoah/shenandoahRootVerifier.hpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahRootVerifier.hpp
@@ -64,8 +64,8 @@ public:
   void oops_do(OopClosure* cl);
 
   // Used to seed ShenandoahVerifier, do not honor root type filter
-  void roots_do(OopClosure* cl);
-  void strong_roots_do(OopClosure* cl);
+  void roots_do(OopIterateClosure* cl);
+  void strong_roots_do(OopIterateClosure* cl);
 
   static RootTypes combine(RootTypes t1, RootTypes t2);
 private:

--- a/src/hotspot/share/gc/shenandoah/shenandoahScanRemembered.hpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahScanRemembered.hpp
@@ -954,8 +954,8 @@ public:
   //  from dirty to clean and clean to dirty.  The do_oops
   //  implementations will want to update this value each time they
   //  cross one of these boundaries.
-  void oops_do(OopIterateClosure* cl);
-  void oops_do_simple(OopClosure* cl);
+  void roots_do(OopIterateClosure* cl);
+  void oops_do(OopClosure* cl);
 };
 
 typedef ShenandoahScanRemembered<ShenandoahDirectCardMarkRememberedSet> RememberedScanner;

--- a/src/hotspot/share/gc/shenandoah/shenandoahScanRemembered.hpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahScanRemembered.hpp
@@ -954,8 +954,8 @@ public:
   //  from dirty to clean and clean to dirty.  The do_oops
   //  implementations will want to update this value each time they
   //  cross one of these boundaries.
-
-  void oops_do(OopClosure* cl);
+  void oops_do(OopIterateClosure* cl);
+  void oops_do_simple(OopClosure* cl);
 };
 
 typedef ShenandoahScanRemembered<ShenandoahDirectCardMarkRememberedSet> RememberedScanner;

--- a/src/hotspot/share/gc/shenandoah/shenandoahScanRemembered.inline.hpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahScanRemembered.inline.hpp
@@ -589,8 +589,13 @@ class ShenandoahOopIterateAdapter : public BasicOopIterateClosure {
 };
 
 template<typename RememberedSet>
-inline void ShenandoahScanRemembered<RememberedSet>::oops_do(OopClosure* cl) {
+inline void ShenandoahScanRemembered<RememberedSet>::oops_do_simple(OopClosure* cl) {
   ShenandoahOopIterateAdapter adapter(cl);
+  oops_do(&adapter);
+}
+
+template<typename RememberedSet>
+inline void ShenandoahScanRemembered<RememberedSet>::oops_do(OopIterateClosure* cl) {
   ShenandoahHeap* heap = ShenandoahHeap::heap();
   for (size_t i = 0, n = heap->num_regions(); i < n; ++i) {
     ShenandoahHeapRegion* region = heap->get_region(i);
@@ -604,7 +609,7 @@ inline void ShenandoahScanRemembered<RememberedSet>::oops_do(OopClosure* cl) {
       size_t num_clusters = (size_t) ((num_heapwords - 1 + cluster_size) / cluster_size);
 
       // Remembered set scanner
-      process_clusters(start_cluster_no, num_clusters, end_of_range, &adapter);
+      process_clusters(start_cluster_no, num_clusters, end_of_range, cl);
     }
   }
 }

--- a/src/hotspot/share/gc/shenandoah/shenandoahScanRemembered.inline.hpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahScanRemembered.inline.hpp
@@ -589,13 +589,13 @@ class ShenandoahOopIterateAdapter : public BasicOopIterateClosure {
 };
 
 template<typename RememberedSet>
-inline void ShenandoahScanRemembered<RememberedSet>::oops_do_simple(OopClosure* cl) {
+inline void ShenandoahScanRemembered<RememberedSet>::oops_do(OopClosure* cl) {
   ShenandoahOopIterateAdapter adapter(cl);
-  oops_do(&adapter);
+  roots_do(&adapter);
 }
 
 template<typename RememberedSet>
-inline void ShenandoahScanRemembered<RememberedSet>::oops_do(OopIterateClosure* cl) {
+inline void ShenandoahScanRemembered<RememberedSet>::roots_do(OopIterateClosure* cl) {
   ShenandoahHeap* heap = ShenandoahHeap::heap();
   for (size_t i = 0, n = heap->num_regions(); i < n; ++i) {
     ShenandoahHeapRegion* region = heap->get_region(i);


### PR DESCRIPTION
In some use cases, `ShenandoahVerifier` is required to _ignore_ weak references (because they will be processed concurrently). Because of the way the remembered set scan handles oops, it must use an `OopIterateClosure` (not a bare `OopClosure`). To make use of the `OopClosure` passed to the remembered set scanner, it was wrapped in an "adapter" that sheared off the `ShenandoahIgnoreReferenceDiscoverer` configured on the passed in closure. This change removes the need to use such an adapter during the verifier's root scan.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

### Reviewers
 * [Zhengyu Gu](https://openjdk.java.net/census#zgu) (@zhengyu123 - Committer)
 * [Roman Kennke](https://openjdk.java.net/census#rkennke) (@rkennke - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/shenandoah pull/41/head:pull/41` \
`$ git checkout pull/41`

Update a local copy of the PR: \
`$ git checkout pull/41` \
`$ git pull https://git.openjdk.java.net/shenandoah pull/41/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 41`

View PR using the GUI difftool: \
`$ git pr show -t 41`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/shenandoah/pull/41.diff">https://git.openjdk.java.net/shenandoah/pull/41.diff</a>

</details>
