### PR TITLE
Mixed evacuation fixes

### DIFF
--- a/src/hotspot/share/gc/shenandoah/shenandoahCollectionSet.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahCollectionSet.cpp
@@ -40,6 +40,7 @@ ShenandoahCollectionSet::ShenandoahCollectionSet(ShenandoahHeap* heap, ReservedS
   _cset_map(_map_space.base() + ((uintx)heap_base >> _region_size_bytes_shift)),
   _biased_cset_map(_map_space.base()),
   _heap(heap),
+  _has_old_regions(false),
   _garbage(0),
   _used(0),
   _region_count(0),
@@ -87,6 +88,7 @@ void ShenandoahCollectionSet::add_region(ShenandoahHeapRegion* r) {
   _region_count++;
   _garbage += r->garbage();
   _used += r->used();
+  _has_old_regions |= r->is_old();
 
   // Update the region status too. State transition would be checked internally.
   r->make_cset();
@@ -107,6 +109,8 @@ void ShenandoahCollectionSet::clear() {
 
   _region_count = 0;
   _current_index = 0;
+
+  _has_old_regions = false;
 }
 
 ShenandoahHeapRegion* ShenandoahCollectionSet::claim_next() {

--- a/src/hotspot/share/gc/shenandoah/shenandoahCollectionSet.hpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahCollectionSet.hpp
@@ -79,7 +79,8 @@ public:
 
   bool has_old_regions() const { return _has_old_regions; }
   size_t used()          const { return _used; }
-  size_t garbage()       const { return _garbage;   }
+
+  size_t garbage()       const { return _garbage; }
   void clear();
 
 private:

--- a/src/hotspot/share/gc/shenandoah/shenandoahCollectionSet.hpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahCollectionSet.hpp
@@ -42,6 +42,7 @@ private:
 
   ShenandoahHeap* const _heap;
 
+  bool                  _has_old_regions;
   size_t                _garbage;
   size_t                _used;
   size_t                _region_count;
@@ -76,8 +77,9 @@ public:
 
   void print_on(outputStream* out) const;
 
-  size_t used()      const { return _used; }
-  size_t garbage()   const { return _garbage;   }
+  bool has_old_regions() const { return _has_old_regions; }
+  size_t used()          const { return _used; }
+  size_t garbage()       const { return _garbage;   }
   void clear();
 
 private:

--- a/src/hotspot/share/gc/shenandoah/shenandoahHeap.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahHeap.cpp
@@ -2130,7 +2130,7 @@ private:
     // We update references for global, old, and young collections.
     assert(_heap->active_generation()->is_mark_complete(), "Expected complete marking");
     ShenandoahMarkingContext* const ctx = _heap->marking_context();
-
+    bool is_mixed = _heap->collection_set()->has_old_regions();
     while (r != NULL) {
       HeapWord* update_watermark = r->get_update_watermark();
       assert (update_watermark >= r->bottom(), "sanity");
@@ -2140,31 +2140,17 @@ private:
           _heap->marked_object_oop_iterate(r, &cl, update_watermark);
         } else {
           assert(r->affiliation() == OLD_GENERATION, "Should not be updating references on FREE regions");
-          if (!_heap->is_gc_generation_young()) {
-            // Old region in an old or global cycle.
-            // We need to make sure that the next cycle does not iterate over dead objects
+          if (!_heap->is_gc_generation_young() || is_mixed) {
+            // Old region global or mixed cycle.
+            // We need to make sure that the next remembered set scan does not iterate over dead objects
             // which haven't had their references updated.
             r->oop_iterate(&cl, /*fill_dead_objects*/ true, /* reregister_coalesced_objects */ true);
           } else {
-            // Old region in a young cycle.
+            // Old region in a young cycle with no old regions.
             if (!ShenandoahUseSimpleCardScanning) {
               _heap->card_scan()->process_region(r, &cl);
             } else if (ShenandoahBarrierSet::barrier_set()->card_table()->is_dirty(MemRegion(r->bottom(), r->top()))) {
-              if (r->is_humongous()) {
-                r->oop_iterate_humongous(&cl);
-              } else {
-                // We don't have liveness information about this region.
-                // Therefore we process all objects, rather than just marked ones.
-                // Otherwise subsequent traversals will encounter stale pointers.
-                HeapWord *p = r->bottom();
-                ShenandoahObjectToOopBoundedClosure<T> objs(&cl, p, update_watermark);
-                // Anything beyond update_watermark is not yet allocated or initialized.
-                while (p < update_watermark) {
-                  oop obj = oop(p);
-                  objs.do_object(obj);
-                  p += obj->size();
-                }
-              }
+              update_all_references(&cl, r, update_watermark);
             }
           }
         }
@@ -2176,6 +2162,25 @@ private:
         return;
       }
       r = _regions->next();
+    }
+  }
+
+  template<class T>
+  void update_all_references(T* cl, ShenandoahHeapRegion* r, HeapWord* update_watermark) {
+    if (r->is_humongous()) {
+      r->oop_iterate_humongous(cl);
+    } else {
+      // We don't have liveness information about this region.
+      // Therefore we process all objects, rather than just marked ones.
+      // Otherwise subsequent traversals will encounter stale pointers.
+      HeapWord *p = r->bottom();
+      ShenandoahObjectToOopBoundedClosure<T> objs(cl, p, update_watermark);
+      // Anything beyond update_watermark is not yet allocated or initialized.
+      while (p < update_watermark) {
+        oop obj = oop(p);
+        objs.do_object(obj);
+        p += obj->size();
+      }
     }
   }
 };

--- a/src/hotspot/share/gc/shenandoah/shenandoahHeap.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahHeap.cpp
@@ -2173,7 +2173,7 @@ private:
       // We don't have liveness information about this region.
       // Therefore we process all objects, rather than just marked ones.
       // Otherwise subsequent traversals will encounter stale pointers.
-      HeapWord *p = r->bottom();
+      HeapWord* p = r->bottom();
       ShenandoahObjectToOopBoundedClosure<T> objs(cl, p, update_watermark);
       // Anything beyond update_watermark is not yet allocated or initialized.
       while (p < update_watermark) {

--- a/src/hotspot/share/gc/shenandoah/shenandoahHeap.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahHeap.cpp
@@ -2141,7 +2141,7 @@ private:
         } else {
           assert(r->affiliation() == OLD_GENERATION, "Should not be updating references on FREE regions");
           if (!_heap->is_gc_generation_young() || is_mixed) {
-            // Old region global or mixed cycle.
+            // Old region in global or mixed cycle (in which case, old regions should be marked).
             // We need to make sure that the next remembered set scan does not iterate over dead objects
             // which haven't had their references updated.
             r->oop_iterate(&cl, /*fill_dead_objects*/ true, /* reregister_coalesced_objects */ true);

--- a/src/hotspot/share/gc/shenandoah/shenandoahHeap.inline.hpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahHeap.inline.hpp
@@ -230,10 +230,6 @@ inline HeapWord* ShenandoahHeap::allocate_from_plab(Thread* thread, size_t size)
     obj = allocate_from_plab_slow(thread, size);
   }
 
-  if (mode()->is_generational() && obj != NULL) {
-    ShenandoahHeap::heap()->card_scan()->register_object(obj);
-  }
-
   return obj;
 }
 

--- a/src/hotspot/share/gc/shenandoah/shenandoahOldGeneration.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahOldGeneration.cpp
@@ -82,10 +82,12 @@ class ShenandoahProcessOldSATB : public SATBBufferClosure {
     for (size_t i = 0; i < size; ++i) {
       oop *p = (oop *) &buffer[i];
       ShenandoahHeapRegion* region = _heap->heap_region_containing(*p);
-      if (!region->is_trash()) {
-        ShenandoahMark::mark_through_ref<oop, OLD, STRING_DEDUP>(p, _queue, NULL, _mark_context, false);
-      } else {
-        ++_trashed_oops;
+      if (region->is_old()) {
+        if (!region->is_trash()) {
+          ShenandoahMark::mark_through_ref<oop, OLD, STRING_DEDUP>(p, _queue, NULL, _mark_context, false);
+        } else {
+          ++_trashed_oops;
+        }
       }
     }
   }

--- a/src/hotspot/share/gc/shenandoah/shenandoahScanRemembered.inline.hpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahScanRemembered.inline.hpp
@@ -594,7 +594,7 @@ inline void ShenandoahScanRemembered<RememberedSet>::oops_do(OopClosure* cl) {
   ShenandoahHeap* heap = ShenandoahHeap::heap();
   for (size_t i = 0, n = heap->num_regions(); i < n; ++i) {
     ShenandoahHeapRegion* region = heap->get_region(i);
-    if (region->affiliation() == OLD_GENERATION) {
+    if (region->is_old() && region->is_active() && !region->is_cset()) {
       HeapWord* start_of_range = region->bottom();
       HeapWord* end_of_range = region->top();
       size_t start_cluster_no = cluster_for_addr(start_of_range);


### PR DESCRIPTION
This PR has a few bug fixes, the most important of which corrects an error that prevented references between old regions from being updated. To handle this case we expose the notion of _mixed_ collections to the update reference loop. This lets us continue using the optimization of only updating references in the remembered set during a _pure_ young collection. The other fixes are comparatively minor and described in their commit message.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

### Reviewers
 * [Roman Kennke](https://openjdk.java.net/census#rkennke) (@rkennke - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/shenandoah pull/43/head:pull/43` \
`$ git checkout pull/43`

Update a local copy of the PR: \
`$ git checkout pull/43` \
`$ git pull https://git.openjdk.java.net/shenandoah pull/43/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 43`

View PR using the GUI difftool: \
`$ git pr show -t 43`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/shenandoah/pull/43.diff">https://git.openjdk.java.net/shenandoah/pull/43.diff</a>

</details>
