### PR TITLE
Allow committers to review Shenandoah changes

### DIFF
--- a/.jcheck/conf
+++ b/.jcheck/conf
@@ -18,7 +18,7 @@ files=.*\.cpp|.*\.hpp|.*\.c|.*\.h|.*\.java|.*\.cc|.*\.hh|.*\.m|.*\.mm|.*\.gmk|.*
 ignore-tabs=.*\.gmk|Makefile
 
 [checks "reviewers"]
-reviewers=1
+committers=1
 ignore=duke
 
 [checks "committer"]


### PR DESCRIPTION
We shouldn't need formal distinction between reviewers and commiters in Shenandoah. I propose to allow all committers to also review changes.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [ ] Change must be properly reviewed

### Reviewers
 * [Aleksey Shipilev](https://openjdk.java.net/census#shade) (@shipilev - Committer)
 * [Zhengyu Gu](https://openjdk.java.net/census#zgu) (@zhengyu123 - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/shenandoah pull/45/head:pull/45` \
`$ git checkout pull/45`

Update a local copy of the PR: \
`$ git checkout pull/45` \
`$ git pull https://git.openjdk.java.net/shenandoah pull/45/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 45`

View PR using the GUI difftool: \
`$ git pr show -t 45`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/shenandoah/pull/45.diff">https://git.openjdk.java.net/shenandoah/pull/45.diff</a>

</details>
