### PR TITLE
Encode phase for each generation separately

### DIFF
--- a/src/hotspot/share/gc/shenandoah/shenandoahHeapRegionCounters.hpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahHeapRegionCounters.hpp
@@ -37,9 +37,14 @@
  *
  * variables:
  * - sun.gc.shenandoah.regions.status       current GC status:
- *     - bit 0 set when marking in progress
- *     - bit 1 set when evacuation in progress
- *     - bit 2 set when update refs in progress
+ *   | global | old   | young | mode |
+ *   |  0..1  | 2..3  | 4..5  | 6..7 |
+ *
+ *   For each generation:
+ *   0 = idle, 1 = marking, 2 = evacuating, 3 = updating refs
+ *
+ *   For mode:
+ *   0 = concurrent, 1 = degenerated, 2 = full
  *
  * two variable counters per region, with $max_regions (see above) counters:
  * - sun.gc.shenandoah.regions.region.$i.data
@@ -85,6 +90,9 @@ public:
   ShenandoahHeapRegionCounters();
   ~ShenandoahHeapRegionCounters();
   void update();
+
+private:
+  static jlong encode_heap_status(ShenandoahHeap* heap) ;
 };
 
 #endif // SHARE_GC_SHENANDOAH_SHENANDOAHHEAPREGIONCOUNTERS_HPP


### PR DESCRIPTION
This change encodes the state/activity of each generation separately for the overall collector status. There are complementary changes in [my fork of the visualizer](https://github.com/earthling-amzn/shenandoah-visualizer/tree/genshen-visualizer). There is no explicit versioning of the protocol between the encoding in the collector and the decoding in the visualizer. The change in this PR is compatible with the `genshen-visualizer` branch in my fork, but is _not_ compatible with the [upstream visualizer](https://github.com/openjdk/shenandoah-visualizer). Should I open a PR in the visualizer? Should we add a versioning scheme to the prototcol and try to maintain compatibility with older versions?

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

### Reviewers
 * [Roman Kennke](https://openjdk.java.net/census#rkennke) (@rkennke - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/shenandoah pull/46/head:pull/46` \
`$ git checkout pull/46`

Update a local copy of the PR: \
`$ git checkout pull/46` \
`$ git pull https://git.openjdk.java.net/shenandoah pull/46/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 46`

View PR using the GUI difftool: \
`$ git pr show -t 46`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/shenandoah/pull/46.diff">https://git.openjdk.java.net/shenandoah/pull/46.diff</a>

</details>
