### PR TITLE
Check explicitly for affiliation when updating references

### DIFF
--- a/src/hotspot/share/gc/shenandoah/shenandoahHeap.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahHeap.cpp
@@ -2139,8 +2139,7 @@ private:
       if (r->is_active() && !r->is_cset()) {
         if (!_heap->mode()->is_generational() || r->affiliation() == YOUNG_GENERATION) {
           _heap->marked_object_oop_iterate(r, &cl, update_watermark);
-        } else {
-          assert(r->affiliation() == OLD_GENERATION, "Should not be updating references on FREE regions");
+        } else if (r->affiliation() == OLD_GENERATION) {
           if (!_heap->is_gc_generation_young() || is_mixed) {
             // Old region in global or mixed cycle (in which case, old regions should be marked).
             // We need to make sure that the next remembered set scan does not iterate over dead objects


### PR DESCRIPTION
It's possible for a mutator allocation to 'activate' a region before setting the affiliation, which would trip the assert here (or worse, miss the assert and then go off the rails).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

### Reviewers
 * [Zhengyu Gu](https://openjdk.java.net/census#zgu) (@zhengyu123 - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/shenandoah pull/47/head:pull/47` \
`$ git checkout pull/47`

Update a local copy of the PR: \
`$ git checkout pull/47` \
`$ git pull https://git.openjdk.java.net/shenandoah pull/47/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 47`

View PR using the GUI difftool: \
`$ git pr show -t 47`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/shenandoah/pull/47.diff">https://git.openjdk.java.net/shenandoah/pull/47.diff</a>

</details>
