### PR TITLE
Rset scan improvements

### DIFF
--- a/src/hotspot/share/gc/shenandoah/shenandoahMark.inline.hpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahMark.inline.hpp
@@ -261,7 +261,9 @@ inline void ShenandoahMark::mark_through_ref(T *p, ShenandoahObjToScanQueue* q, 
   T o = RawAccess<>::oop_load(p);
   if (!CompressedOops::is_null(o)) {
     oop obj = CompressedOops::decode_not_null(o);
-
+    //HEY!
+    //printf("p = %p obj = %p\n", p, obj);
+    
     shenandoah_assert_not_forwarded(p, obj);
     shenandoah_assert_not_in_cset_except(p, obj, ShenandoahHeap::heap()->cancelled_gc());
 

--- a/src/hotspot/share/gc/shenandoah/shenandoahScanRemembered.inline.hpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahScanRemembered.inline.hpp
@@ -443,7 +443,7 @@ process_obj_array_upto(HeapWord *p, ClosureType *cl, objArrayOop array, uint sta
       return(0);  // Wait to pass over the header
     } else {
       int end_index = card_end - (p + header_size);
-      end_index = MAX2(len, end_index * OopsPerHeapWord);
+      end_index = MIN2(len, end_index * OopsPerHeapWord);
       if (scan) {
         array->oop_iterate_range(cl, start_index, end_index);
       }

--- a/src/hotspot/share/gc/shenandoah/shenandoahScanRemembered.inline.hpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahScanRemembered.inline.hpp
@@ -425,12 +425,11 @@ template <typename ClosureType>
 inline uint
 process_obj_array_upto(HeapWord *p, ClosureType *cl, objArrayOop array, uint start_index,
                        uint len, HeapWord* card_end, bool scan) {
-  //HeapWord *p = (HeapWord*) array;
   size_t size = array->size();
   HeapWord *array_end = p + size;
-  /*  if (len > 128) {
-    printf("big! %p\n", p);
-    }*/
+  if (len > 150) {
+    //printf("big! %d %p\n", len, p);
+  }
   if (array_end <= card_end) {
     if (scan) {
       array->oop_iterate_range(cl, start_index, len);

--- a/src/hotspot/share/gc/shenandoah/shenandoahScanRemembered.inline.hpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahScanRemembered.inline.hpp
@@ -428,7 +428,7 @@ process_obj_array_upto(HeapWord *p, ClosureType *cl, objArrayOop array, uint sta
   size_t size = array->size();
   HeapWord *array_end = p + size;
   if (len > 150) {
-    printf("big! %d %p\n", len, p);
+    //printf("big! %d %p\n", len, p);
   }
   if (array_end <= card_end) {
     if (scan) {

--- a/src/hotspot/share/gc/shenandoah/shenandoahScanRemembered.inline.hpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahScanRemembered.inline.hpp
@@ -428,7 +428,7 @@ process_obj_array_upto(HeapWord *p, ClosureType *cl, objArrayOop array, uint sta
   size_t size = array->size();
   HeapWord *array_end = p + size;
   if (len > 150) {
-    //printf("big! %d %p\n", len, p);
+    printf("big! %d %p\n", len, p);
   }
   if (array_end <= card_end) {
     if (scan) {
@@ -437,10 +437,13 @@ process_obj_array_upto(HeapWord *p, ClosureType *cl, objArrayOop array, uint sta
     return(len);
   } else {
     uint header_size = array->header_size();
+    uint object_size = array->object_size();
+    const uint OopsPerHeapWord = HeapWordSize/heapOopSize;
     if (p + header_size > card_end) {
       return(0);  // Wait to pass over the header
     } else {
-      int end_index = card_end - (p + header_size);  
+      int end_index = card_end - (p + header_size);
+      end_index = MAX2(len, end_index * OopsPerHeapWord);
       if (scan) {
         array->oop_iterate_range(cl, start_index, end_index);
       }

--- a/src/hotspot/share/gc/shenandoah/shenandoahScanRemembered.inline.hpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahScanRemembered.inline.hpp
@@ -423,9 +423,9 @@ ShenandoahScanRemembered<RememberedSet>::mark_range_as_empty(HeapWord *addr, siz
 // array, or len if all entries have been scanned.
 template <typename ClosureType>
 inline uint
-process_obj_array_upto(ClosureType *cl, objArrayOop array, uint start_index,
+process_obj_array_upto(HeapWord *p, ClosureType *cl, objArrayOop array, uint start_index,
                        uint len, HeapWord* card_end, bool scan) {
-  HeapWord *p = (HeapWord*) array;
+  //HeapWord *p = (HeapWord*) array;
   size_t size = array->size();
   HeapWord *array_end = p + size;
   if (array_end <= card_end) {
@@ -447,14 +447,14 @@ process_obj_array_upto(ClosureType *cl, objArrayOop array, uint start_index,
 
 template <typename ClosureType>
 inline uint
-scan_obj_array_upto(ClosureType *cl, objArrayOop array, uint start_index, uint len, HeapWord* card_end) {
-  return(process_obj_array_upto(cl, array, start_index, len, card_end, true));
+scan_obj_array_upto(HeapWord *p, ClosureType *cl, objArrayOop array, uint start_index, uint len, HeapWord* card_end) {
+  return(process_obj_array_upto(p, cl, array, start_index, len, card_end, true));
 }
 
 template <typename ClosureType>
 inline uint
-skip_obj_array_upto(ClosureType *cl, objArrayOop array, uint start_index, uint len, HeapWord* card_end) {
-  return(process_obj_array_upto(cl, array, start_index, len, card_end, false));
+skip_obj_array_upto(HeapWord *p, ClosureType *cl, objArrayOop array, uint start_index, uint len, HeapWord* card_end) {
+  return(process_obj_array_upto(p, cl, array, start_index, len, card_end, false));
 }
 
 template<typename RememberedSet>
@@ -511,13 +511,13 @@ ShenandoahScanRemembered<RememberedSet>::process_clusters(size_t first_cluster, 
               int len = array->length();
               //array->oop_iterate_range(cl, 0, len);
                 
-              int next_array_index = scan_obj_array_upto(cl, array, 0, len, endp);
+              int next_array_index = scan_obj_array_upto(p, cl, array, 0, len, endp);
               for (int overreach_card_index = card_index + 1; next_array_index < len; overreach_card_index++) {
                 HeapWord* card_endp = _rs->addr_for_card_index(overreach_card_index) + CardTable::card_size_in_words;
                 if (_rs->is_card_dirty(overreach_card_index)) {
-                  next_array_index = scan_obj_array_upto(cl, array, next_array_index, len, card_endp);
+                  next_array_index = scan_obj_array_upto(p, cl, array, next_array_index, len, card_endp);
                 } else {
-                  next_array_index = skip_obj_array_upto(cl, array, next_array_index, len, card_endp);
+                  next_array_index = skip_obj_array_upto(p, cl, array, next_array_index, len, card_endp);
                 }
               }
             } else if (obj->is_instance()) {
@@ -571,13 +571,13 @@ ShenandoahScanRemembered<RememberedSet>::process_clusters(size_t first_cluster, 
             int len = array->length();
             //array->oop_iterate_range(cl, 0, len);
             
-            int next_array_index = skip_obj_array_upto(cl, array, 0, len, endp);
+            int next_array_index = skip_obj_array_upto(p, cl, array, 0, len, endp);
             for (uint overreach_card_index = card_index + 1; next_array_index < len; overreach_card_index++) {
               HeapWord* card_endp = _rs->addr_for_card_index(overreach_card_index) + CardTable::card_size_in_words;
               if (_rs->is_card_dirty(overreach_card_index)) {
-                next_array_index = scan_obj_array_upto(cl, array, next_array_index, len, card_endp);
+                next_array_index = scan_obj_array_upto(p, cl, array, next_array_index, len, card_endp);
               } else {
-                next_array_index = skip_obj_array_upto(cl, array, next_array_index, len, card_endp);
+                next_array_index = skip_obj_array_upto(p, cl, array, next_array_index, len, card_endp);
               }
             }
           } else if (obj->is_instance()) {

--- a/src/hotspot/share/gc/shenandoah/shenandoahScanRemembered.inline.hpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahScanRemembered.inline.hpp
@@ -582,8 +582,8 @@ ShenandoahScanRemembered<RememberedSet>::process_clusters(size_t first_cluster, 
             }
           } else if (obj->is_instance()) {
             obj->oop_iterate(cl);
-          } else {
-            // Case 3: Primitive array. Do nothing, no oops there. We use the same
+          } else { 
+            // Case 3: Primitive array. Do nothing -  no oops there. We use the same
             // performance tweak TypeArrayKlass::oop_oop_iterate_impl is using:
             // We skip iterating over the klass pointer since we know that
             // Universe::TypeArrayKlass never moves.

--- a/src/hotspot/share/gc/shenandoah/shenandoahScanRemembered.inline.hpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahScanRemembered.inline.hpp
@@ -437,7 +437,7 @@ process_obj_array_upto(HeapWord *p, ClosureType *cl, objArrayOop array, uint sta
     return(len);
   } else {
     uint header_size = array->header_size();
-    uint object_size = array->object_size();
+    // uint object_size = array->object_size();
     const uint OopsPerHeapWord = HeapWordSize/heapOopSize;
     if (p + header_size > card_end) {
       return(0);  // Wait to pass over the header

--- a/test/hotspot/jtreg/gc/shenandoah/TestRefprocSanity.java
+++ b/test/hotspot/jtreg/gc/shenandoah/TestRefprocSanity.java
@@ -23,7 +23,7 @@
  */
 
 /*
- * @test TestRefprocSanity
+ * @test TestRefprocSanity1
  * @summary Test that null references/referents work fine
  * @requires vm.gc.Shenandoah
  *
@@ -42,7 +42,7 @@
  */
 
 /*
- * @test TestRefprocSanity
+ * @test TestRefprocSanity2
  * @summary Test that null references/referents work fine
  * @requires vm.gc.Shenandoah
  *
@@ -57,6 +57,20 @@
  *
  * @run main/othervm -Xmx1g -Xms1g -XX:+UnlockDiagnosticVMOptions -XX:+UnlockExperimentalVMOptions
  *      -XX:+UseShenandoahGC -XX:ShenandoahGCMode=iu -XX:ShenandoahGCHeuristics=aggressive
+ *      TestRefprocSanity
+ *
+ * @run main/othervm -Xmx1g -Xms1g -XX:+UnlockDiagnosticVMOptions -XX:+UnlockExperimentalVMOptions
+ *      -XX:+UseShenandoahGC -XX:ShenandoahGCMode=generational
+ *      TestRefprocSanity
+ */
+
+/*
+ * @test TestRefprocSanity-Young 
+ * @summary Test that null references/referents work fine
+ * @requires vm.gc.Shenandoah
+ *
+ * @run main/othervm -Xmx1g -Xms1g -XX:+UnlockDiagnosticVMOptions -XX:+UnlockExperimentalVMOptions
+ *      -XX:+UseShenandoahGC -XX:ShenandoahGCMode=generational
  *      TestRefprocSanity
  */
 

--- a/test/hotspot/jtreg/gc/shenandoah/TestRefprocSanity.java
+++ b/test/hotspot/jtreg/gc/shenandoah/TestRefprocSanity.java
@@ -58,10 +58,6 @@
  * @run main/othervm -Xmx1g -Xms1g -XX:+UnlockDiagnosticVMOptions -XX:+UnlockExperimentalVMOptions
  *      -XX:+UseShenandoahGC -XX:ShenandoahGCMode=iu -XX:ShenandoahGCHeuristics=aggressive
  *      TestRefprocSanity
- *
- * @run main/othervm -Xmx1g -Xms1g -XX:+UnlockDiagnosticVMOptions -XX:+UnlockExperimentalVMOptions
- *      -XX:+UseShenandoahGC -XX:ShenandoahGCMode=generational
- *      TestRefprocSanity
  */
 
 /*


### PR DESCRIPTION
Speed up remset scan by skipping objects on clean pages.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must not contain extraneous whitespace
- [ ] Change must be properly reviewed

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/shenandoah pull/48/head:pull/48` \
`$ git checkout pull/48`

Update a local copy of the PR: \
`$ git checkout pull/48` \
`$ git pull https://git.openjdk.java.net/shenandoah pull/48/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 48`

View PR using the GUI difftool: \
`$ git pr show -t 48`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/shenandoah/pull/48.diff">https://git.openjdk.java.net/shenandoah/pull/48.diff</a>

</details>
