### PR TITLE
Fix 32-bit builds

### DIFF
--- a/src/hotspot/share/gc/shenandoah/shenandoahHeapRegionCounters.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahHeapRegionCounters.cpp
@@ -156,7 +156,7 @@ jlong ShenandoahHeapRegionCounters::encode_heap_status(ShenandoahHeap* heap) {
     if (heap->is_concurrent_old_mark_in_progress()) {
       status |= (1 << 2);
     }
-    log_develop_trace(gc)("%s, phase=%u, old_mark=%s, status=%zu",
+    log_develop_trace(gc)("%s, phase=%u, old_mark=%s, status=" JLONG_FORMAT,
       generation->name(), phase, BOOL_TO_STR(heap->is_concurrent_old_mark_in_progress()), status);
   }
 


### PR DESCRIPTION
Currently fails with:

```
/home/buildbot/worker/build-shenandoah-jdkX-linux/build/src/hotspot/share/gc/shenandoah/shenandoahHeapRegionCounters.cpp: In static member function 'static jlong ShenandoahHeapRegionCounters::encode_heap_status(ShenandoahHeap*)':
/home/buildbot/worker/build-shenandoah-jdkX-linux/build/src/hotspot/share/gc/shenandoah/shenandoahHeapRegionCounters.cpp:160:97: error: format '%zu' expects argument of type 'size_t', but argument 5 has type 'jlong {aka long long int}' [-Werror=format=]
       generation->name(), phase, BOOL_TO_STR(heap->is_concurrent_old_mark_in_progress()), status);
                                                                                                 ^
```

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

### Reviewers
 * [Roman Kennke](https://openjdk.java.net/census#rkennke) (@rkennke - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/shenandoah pull/49/head:pull/49` \
`$ git checkout pull/49`

Update a local copy of the PR: \
`$ git checkout pull/49` \
`$ git pull https://git.openjdk.java.net/shenandoah pull/49/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 49`

View PR using the GUI difftool: \
`$ git pr show -t 49`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/shenandoah/pull/49.diff">https://git.openjdk.java.net/shenandoah/pull/49.diff</a>

</details>
