### PR TITLE
Introduce second mark bitmap to support remembered set scan

### DIFF
--- a/src/hotspot/share/gc/shenandoah/heuristics/shenandoahHeuristics.cpp
+++ b/src/hotspot/share/gc/shenandoah/heuristics/shenandoahHeuristics.cpp
@@ -112,7 +112,7 @@ void ShenandoahHeuristics::choose_collection_set(ShenandoahCollectionSet* collec
       free_regions++;
       free += ShenandoahHeapRegion::region_size_bytes();
     } else if (region->is_regular()) {
-      if (!region->has_live() && !heap->mode()->is_generational()) {
+      if (!region->has_live()) {
         // We can recycle it right away and put it in the free set.
         immediate_regions++;
         immediate_garbage += garbage;

--- a/src/hotspot/share/gc/shenandoah/heuristics/shenandoahOldHeuristics.hpp
+++ b/src/hotspot/share/gc/shenandoah/heuristics/shenandoahOldHeuristics.hpp
@@ -53,16 +53,6 @@ protected:
   uint _hidden_old_collection_candidates;
   uint _hidden_next_old_collection_candidate;
 
-  // if (_generation->generation_mode() == OLD)
-  //  _old_coalesce_and_fill_candidates represents the number of regions
-  //  that were chosen for the garbage contained therein to be coalesced
-  //  and filled and _first_coalesce_and_fill_candidate represents the
-  //  the index of the first such region within the _region_data array.
-  // if (_generation->generation_mode() != OLD) these two variables are
-  //  not used.
-  uint _old_coalesce_and_fill_candidates;
-  uint _first_coalesce_and_fill_candidate;
-
   // Prepare for evacuation of old-gen regions by capturing the mark results of a recently completed concurrent mark pass.
   void prepare_for_old_collections();
 
@@ -87,16 +77,6 @@ public:
 
   // Adjust internal state to reflect that one fewer old-collection candidate remains to be processed.
   void consume_old_collection_candidate();
-
-  // How many old-collection regions were identified at the end of the most recent old-gen mark to require their
-  // unmarked objects to be coalesced and filled?
-  uint old_coalesce_and_fill_candidates();
-
-  // Fill in buffer with all of the old-collection regions that were identified at the end of the most recent old-gen
-  // mark to require their unmarked objects to be coalesced and filled.  The buffer array must have at least
-  // old_coalesce_and_fill_candidates() entries, or memory may be corrupted when this function overwrites the
-  // end of the array.
-  void get_coalesce_and_fill_candidates(ShenandoahHeapRegion** buffer);
 
   bool should_defer_gc();
 

--- a/src/hotspot/share/gc/shenandoah/mode/shenandoahGenerationalMode.cpp
+++ b/src/hotspot/share/gc/shenandoah/mode/shenandoahGenerationalMode.cpp
@@ -30,13 +30,6 @@
 #include "runtime/globals_extension.hpp"
 
 void ShenandoahGenerationalMode::initialize_flags() const {
-  // When we fill in dead objects during update refs, we use oop::size,
-  // which depends on the klass being loaded. However, if these dead objects
-  // were the last referrers to the klass, it will be unloaded and we'll
-  // crash. Class unloading is disabled until we're able to sort this out.
-  FLAG_SET_ERGO(ClassUnloading, false);
-  FLAG_SET_ERGO(ClassUnloadingWithConcurrentMark, false);
-  FLAG_SET_ERGO(ShenandoahUnloadClassesFrequency, 0);
 
   if (ClassUnloading) {
     // Leaving this here for the day we re-enable class unloading
@@ -56,7 +49,6 @@ void ShenandoahGenerationalMode::initialize_flags() const {
   SHENANDOAH_CHECK_FLAG_SET(ShenandoahSATBBarrier);
   SHENANDOAH_CHECK_FLAG_SET(ShenandoahCASBarrier);
   SHENANDOAH_CHECK_FLAG_SET(ShenandoahCloneBarrier);
-  SHENANDOAH_CHECK_FLAG_UNSET(ClassUnloading);
 }
 
 const char *affiliation_name(ShenandoahRegionAffiliation type) {

--- a/src/hotspot/share/gc/shenandoah/shenandoahBitmapRegion.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahBitmapRegion.cpp
@@ -1,3 +1,26 @@
+/*
+ * Copyright (c) 2013, 2021, Red Hat, Inc. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ *
+ */
 
 #include "gc/shared/gc_globals.hpp"
 #include "gc/shenandoah/shenandoahAsserts.hpp"

--- a/src/hotspot/share/gc/shenandoah/shenandoahBitmapRegion.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahBitmapRegion.cpp
@@ -22,6 +22,8 @@
  *
  */
 
+#include "precompiled.hpp"
+
 #include "gc/shared/gc_globals.hpp"
 #include "gc/shenandoah/shenandoahAsserts.hpp"
 #include "gc/shenandoah/shenandoahBitmapRegion.hpp"

--- a/src/hotspot/share/gc/shenandoah/shenandoahBitmapRegion.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahBitmapRegion.cpp
@@ -1,0 +1,165 @@
+
+#include "gc/shared/gc_globals.hpp"
+#include "gc/shenandoah/shenandoahAsserts.hpp"
+#include "gc/shenandoah/shenandoahBitmapRegion.hpp"
+#include "gc/shenandoah/shenandoahHeap.inline.hpp"
+#include "gc/shenandoah/shenandoahHeapRegion.hpp"
+#include "memory/virtualspace.hpp"
+#include "runtime/globals.hpp"
+#include "runtime/os.hpp"
+#include "services/memTracker.hpp"
+#include "utilities/powerOfTwo.hpp"
+
+class ShenandoahPretouchBitmapTask : public AbstractGangTask {
+ private:
+  ShenandoahRegionIterator _regions;
+  char* _bitmap_base;
+  const size_t _bitmap_size;
+  const size_t _page_size;
+ public:
+  ShenandoahPretouchBitmapTask(char* bitmap_base, size_t bitmap_size, size_t page_size) :
+    AbstractGangTask("Shenandoah Pretouch Bitmap"),
+    _bitmap_base(bitmap_base),
+    _bitmap_size(bitmap_size),
+    _page_size(page_size) {}
+
+  virtual void work(uint worker_id) {
+    ShenandoahHeapRegion* r = _regions.next();
+    while (r != NULL) {
+      size_t start = r->index()       * ShenandoahHeapRegion::region_size_bytes() / MarkBitMap::heap_map_factor();
+      size_t end   = (r->index() + 1) * ShenandoahHeapRegion::region_size_bytes() / MarkBitMap::heap_map_factor();
+      assert (end <= _bitmap_size, "end is sane: " SIZE_FORMAT " < " SIZE_FORMAT, end, _bitmap_size);
+
+      if (r->is_committed()) {
+        os::pretouch_memory(_bitmap_base + start, _bitmap_base + end, _page_size);
+      }
+
+      r = _regions.next();
+    }
+  }
+};
+
+void ShenandoahBitmapRegion::initialize(size_t bitmap_size,
+                                        size_t bitmap_bytes_per_region,
+                                        size_t num_committed_regions) {
+  _bitmap_size = bitmap_size;
+  size_t bitmap_page_size = UseLargePages ? (size_t)os::large_page_size() : (size_t)os::vm_page_size();
+
+  guarantee(bitmap_bytes_per_region != 0,
+            "Bitmap bytes per region should not be zero");
+  guarantee(is_power_of_2(bitmap_bytes_per_region),
+            "Bitmap bytes per region should be power of two: " SIZE_FORMAT, bitmap_bytes_per_region);
+
+  if (bitmap_page_size > bitmap_bytes_per_region) {
+    _bitmap_regions_per_slice = bitmap_page_size / bitmap_bytes_per_region;
+    _bitmap_bytes_per_slice = bitmap_page_size;
+  } else {
+    _bitmap_regions_per_slice = 1;
+    _bitmap_bytes_per_slice = bitmap_bytes_per_region;
+  }
+
+  guarantee(_bitmap_regions_per_slice >= 1,
+            "Should have at least one region per slice: " SIZE_FORMAT,
+            _bitmap_regions_per_slice);
+
+  guarantee(((_bitmap_bytes_per_slice) % bitmap_page_size) == 0,
+            "Bitmap slices should be page-granular: bps = Bitmap slices should be page-granular: bps = " SIZE_FORMAT ", page size = " SIZE_FORMAT,
+              _bitmap_bytes_per_slice, bitmap_page_size);
+
+  ReservedSpace bitmap(_bitmap_size, bitmap_page_size);
+  MemTracker::record_virtual_memory_type(bitmap.base(), mtGC);
+  _bitmap_region = MemRegion((HeapWord*) bitmap.base(), bitmap.size() / HeapWordSize);
+  _bitmap_region_special = bitmap.special();
+
+  if (!_bitmap_region_special) {
+    size_t bitmap_init_commit = _bitmap_bytes_per_slice *
+                                align_up(num_committed_regions, _bitmap_regions_per_slice) / _bitmap_regions_per_slice;
+    bitmap_init_commit = MIN2(_bitmap_size, bitmap_init_commit);
+    os::commit_memory_or_exit((char *) _bitmap_region.start(), bitmap_init_commit, bitmap_page_size, false,
+                              "Cannot commit bitmap memory");
+  }
+}
+
+bool ShenandoahBitmapRegion::commit_bitmap_slice(ShenandoahHeapRegion *r) {
+  shenandoah_assert_heaplocked();
+
+  // Bitmaps in special regions do not need commits
+  if (_bitmap_region_special) {
+    return true;
+  }
+
+  if (is_bitmap_slice_committed(r, true)) {
+    // Some other region from the group is already committed, meaning the bitmap
+    // slice is already committed, we exit right away.
+    return true;
+  }
+
+  // Commit the bitmap slice:
+  size_t slice = r->index() / _bitmap_regions_per_slice;
+  size_t off = _bitmap_bytes_per_slice * slice;
+  size_t len = _bitmap_bytes_per_slice;
+  char* start = (char*) _bitmap_region.start() + off;
+
+  if (!os::commit_memory(start, len, false)) {
+    return false;
+  }
+
+  if (AlwaysPreTouch) {
+    os::pretouch_memory(start, start + len, _pretouch_bitmap_page_size);
+  }
+
+  return true;
+}
+
+bool ShenandoahBitmapRegion::uncommit_bitmap_slice(ShenandoahHeapRegion *r) {
+  shenandoah_assert_heaplocked();
+
+  // Bitmaps in special regions do not need uncommits
+  if (_bitmap_region_special) {
+    return true;
+  }
+
+  if (is_bitmap_slice_committed(r, true)) {
+    // Some other region from the group is still committed, meaning the bitmap
+    // slice is should stay committed, exit right away.
+    return true;
+  }
+
+  // Uncommit the bitmap slice:
+  size_t slice = r->index() / _bitmap_regions_per_slice;
+  size_t off = _bitmap_bytes_per_slice * slice;
+  size_t len = _bitmap_bytes_per_slice;
+  if (!os::uncommit_memory((char*)_bitmap_region.start() + off, len)) {
+    return false;
+  }
+  return true;
+}
+
+bool ShenandoahBitmapRegion::is_bitmap_slice_committed(ShenandoahHeapRegion* r, bool skip_self) {
+  ShenandoahHeap* heap = ShenandoahHeap::heap();
+  size_t slice = r->index() / _bitmap_regions_per_slice;
+
+  size_t regions_from = _bitmap_regions_per_slice * slice;
+  size_t regions_to   = MIN2(heap->num_regions(), _bitmap_regions_per_slice * (slice + 1));
+  for (size_t g = regions_from; g < regions_to; g++) {
+    assert (g / _bitmap_regions_per_slice == slice, "same slice");
+    if (skip_self && g == r->index()) continue;
+    if (heap->get_region(g)->is_committed()) {
+      return true;
+    }
+  }
+  return false;
+}
+
+void ShenandoahBitmapRegion::pretouch(size_t pretouch_bitmap_page_size) {
+  _pretouch_bitmap_page_size = pretouch_bitmap_page_size;
+  ShenandoahHeap* heap = ShenandoahHeap::heap();
+  ShenandoahPretouchBitmapTask bcl((char*)_bitmap_region.start(), _bitmap_size, _pretouch_bitmap_page_size);
+  heap->workers()->run_task(&bcl);
+}
+
+ShenandoahBitmapRegion::ShenandoahBitmapRegion() :
+  _bitmap_region_special(false),
+  _bitmap_size(0),
+  _bitmap_regions_per_slice(0),
+  _bitmap_bytes_per_slice(0), _pretouch_bitmap_page_size(0) {}

--- a/src/hotspot/share/gc/shenandoah/shenandoahBitmapRegion.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahBitmapRegion.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013, 2021, Red Hat, Inc. All rights reserved.
+ * Copyright (c) 2021, Red Hat, Inc. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/hotspot/share/gc/shenandoah/shenandoahBitmapRegion.hpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahBitmapRegion.hpp
@@ -30,10 +30,9 @@
 class ShenandoahHeapRegion;
 
 /*
- * The purpose of this class to encapsulate operations on
- * the memory backing instances of Shenandoah's mark bitmap.
- * The encapsulation allows Shenandoah to use a secondary
- * mark bitmap to support remembered set scans during
+ * The purpose of this class to encapsulate operations on the memory backing
+ * instances of Shenandoah's mark bitmap. The encapsulation allows Shenandoah
+ * to use a secondary mark bitmap to support remembered set scans during
  * concurrent marking of the old generation.
  */
 class ShenandoahBitmapRegion {

--- a/src/hotspot/share/gc/shenandoah/shenandoahBitmapRegion.hpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahBitmapRegion.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013, 2021, Red Hat, Inc. All rights reserved.
+ * Copyright (c) 2021, Red Hat, Inc. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -29,6 +29,13 @@
 
 class ShenandoahHeapRegion;
 
+/*
+ * The purpose of this class to encapsulate operations on
+ * the memory backing instances of Shenandoah's mark bitmap.
+ * The encapsulation allows Shenandoah to use a secondary
+ * mark bitmap to support remembered set scans during
+ * concurrent marking of the old generation.
+ */
 class ShenandoahBitmapRegion {
  public:
 

--- a/src/hotspot/share/gc/shenandoah/shenandoahBitmapRegion.hpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahBitmapRegion.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, Amazon.com, Inc. or its affiliates. All rights reserved.
+ * Copyright (c) 2013, 2021, Red Hat, Inc. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -22,22 +22,39 @@
  *
  */
 
-#ifndef SHARE_GC_SHENANDOAH_SHENANDOAHOLDGC_HPP
-#define SHARE_GC_SHENANDOAH_SHENANDOAHOLDGC_HPP
+#ifndef SHARE_GC_SHENANDOAH_SHENANDOAHBITMAPREGION_HPP
+#define SHARE_GC_SHENANDOAH_SHENANDOAHBITMAPREGION_HPP
 
-#include "gc/shared/gcCause.hpp"
-#include "gc/shenandoah/shenandoahConcurrentGC.hpp"
+#include "memory/memRegion.hpp"
 
-class ShenandoahGeneration;
+class ShenandoahHeapRegion;
 
-class ShenandoahOldGC : public ShenandoahConcurrentGC {
+class ShenandoahBitmapRegion {
  public:
-  ShenandoahOldGC(ShenandoahGeneration* generation, ShenandoahSharedFlag& allow_preemption);
-  bool collect(GCCause::Cause cause);
+
+  ShenandoahBitmapRegion();
+
+  void initialize(size_t bitmap_size,
+                  size_t bitmap_bytes_per_region,
+                  size_t num_committed_regions);
+
+  bool commit_bitmap_slice(ShenandoahHeapRegion *r);
+  bool uncommit_bitmap_slice(ShenandoahHeapRegion *r);
+  bool is_bitmap_slice_committed(ShenandoahHeapRegion *r, bool skip_self = false);
+
+  void pretouch(size_t pretouch_bitmap_page_size);
+
+  MemRegion bitmap_region() { return _bitmap_region; }
+
  private:
-  void entry_old_evacuations();
-  ShenandoahSharedFlag& _allow_preemption;
+  MemRegion _bitmap_region;
+  bool _bitmap_region_special;
+
+  size_t _bitmap_size;
+  size_t _bitmap_regions_per_slice;
+  size_t _bitmap_bytes_per_slice;
+  size_t _pretouch_bitmap_page_size;
 };
 
 
-#endif //SHARE_GC_SHENANDOAH_SHENANDOAHOLDGC_HPP
+#endif //SHENANDOAHBITMAPREGION_HPP

--- a/src/hotspot/share/gc/shenandoah/shenandoahControlThread.hpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahControlThread.hpp
@@ -1,3 +1,4 @@
+
 /*
  * Copyright (c) 2013, 2021, Red Hat, Inc. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
@@ -162,12 +163,11 @@ public:
   void print_on(outputStream* st) const;
   void print() const;
 
-  void service_concurrent_normal_cycle(const ShenandoahHeap* heap,
+  void service_concurrent_normal_cycle(ShenandoahHeap* heap,
                                        const GenerationMode generation,
                                        GCCause::Cause cause);
 
-  void service_concurrent_old_cycle(const ShenandoahHeap* heap,
-                                    GCCause::Cause &cause);
+  void service_concurrent_old_cycle(ShenandoahHeap* heap, GCCause::Cause &cause);
 
   void set_gc_mode(GCMode new_mode);
   GCMode gc_mode() {

--- a/src/hotspot/share/gc/shenandoah/shenandoahFreeSet.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahFreeSet.cpp
@@ -170,6 +170,9 @@ HeapWord* ShenandoahFreeSet::try_allocate_in(ShenandoahHeapRegion* r, Shenandoah
     // This free region might have garbage in its remembered set representation.
     _heap->clear_cards_for(r);
     r->set_affiliation(req.affiliation());
+    if (req.affiliation() == OLD_GENERATION) {
+      _heap->previous_marking_context()->clear_bitmap(r);
+    }
   } else if (r->affiliation() != req.affiliation()) {
     return NULL;
   }

--- a/src/hotspot/share/gc/shenandoah/shenandoahGeneration.hpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahGeneration.hpp
@@ -30,6 +30,18 @@
 #include "gc/shenandoah/mode/shenandoahGenerationalMode.hpp"
 #include "gc/shenandoah/shenandoahLock.hpp"
 #include "gc/shenandoah/shenandoahMarkingContext.hpp"
+#include "gc/shenandoah/shenandoahReferenceProcessor.hpp"
+
+class ShenandoahGlobalIsAliveClosure: public ShenandoahIsMarkedClosure {
+ public:
+  virtual bool is_marked(oop obj) override {
+    return ShenandoahHeap::heap()->marking_context()->is_marked(obj);
+  }
+
+  virtual bool is_marked_strong(oop obj) override {
+    return ShenandoahHeap::heap()->marking_context()->is_marked_strong(obj);
+  }
+};
 
 class ShenandoahHeapRegion;
 class ShenandoahHeapRegionClosure;
@@ -108,6 +120,10 @@ public:
   void set_mark_complete();
   void set_mark_incomplete();
 
+  virtual ShenandoahIsMarkedClosure* is_alive_closure() {
+    return &_is_alive_closure;
+  }
+
   ShenandoahMarkingContext* complete_marking_context();
 
   // Task queues
@@ -129,6 +145,8 @@ protected:
 
 private:
   void confirm_heuristics_mode();
+
+  ShenandoahGlobalIsAliveClosure _is_alive_closure;
 };
 
 #endif // SHARE_VM_GC_SHENANDOAH_SHENANDOAHGENERATION_HPP

--- a/src/hotspot/share/gc/shenandoah/shenandoahGlobalGeneration.hpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahGlobalGeneration.hpp
@@ -30,7 +30,7 @@
 // A "generation" that represents the whole heap.
 class ShenandoahGlobalGeneration : public ShenandoahGeneration {
 public:
-  ShenandoahGlobalGeneration(uint max_queues)
+  explicit ShenandoahGlobalGeneration(uint max_queues)
   : ShenandoahGeneration(GLOBAL, max_queues, 0, 0) { }
 
 public:

--- a/src/hotspot/share/gc/shenandoah/shenandoahHeap.hpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahHeap.hpp
@@ -31,6 +31,7 @@
 #include "gc/shenandoah/mode/shenandoahGenerationalMode.hpp"
 #include "gc/shenandoah/shenandoahAsserts.hpp"
 #include "gc/shenandoah/shenandoahAllocRequest.hpp"
+#include "gc/shenandoah/shenandoahBitmapRegion.hpp"
 #include "gc/shenandoah/shenandoahLock.hpp"
 #include "gc/shenandoah/shenandoahEvacOOMHandler.hpp"
 #include "gc/shenandoah/shenandoahPadding.hpp"
@@ -603,20 +604,17 @@ public:
 // ---------- Marking support
 //
 private:
-  ShenandoahMarkingContext* _marking_context;
-  MemRegion  _bitmap_region;
+  ShenandoahMarkingContext* _active_marking_context;
+  ShenandoahMarkingContext* _previous_marking_context;
+  ShenandoahBitmapRegion _bitmap_region_1;
+  ShenandoahBitmapRegion _bitmap_region_2;
+
   MemRegion  _aux_bitmap_region;
   MarkBitMap _verification_bit_map;
   MarkBitMap _aux_bit_map;
 
-  size_t _bitmap_size;
-  size_t _bitmap_regions_per_slice;
-  size_t _bitmap_bytes_per_slice;
-
   size_t _pretouch_heap_page_size;
-  size_t _pretouch_bitmap_page_size;
 
-  bool _bitmap_region_special;
   bool _aux_bitmap_region_special;
 
   ShenandoahLiveData** _liveness_cache;
@@ -624,6 +622,9 @@ private:
 public:
   inline ShenandoahMarkingContext* complete_marking_context() const;
   inline ShenandoahMarkingContext* marking_context() const;
+  inline ShenandoahMarkingContext* previous_marking_context() const;
+  inline ShenandoahMarkingContext* stable_marking_context() const;
+  inline void swap_marking_contexts();
 
   template<class T>
   inline void marked_object_iterate(ShenandoahHeapRegion* region, T* cl);

--- a/src/hotspot/share/gc/shenandoah/shenandoahHeapRegion.hpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahHeapRegion.hpp
@@ -367,10 +367,7 @@ public:
 
   void recycle();
 
-  // coalesce contiguous spans of garbage objects by filling header and reregistering start locations with remembered set.
-  void oop_fill_and_coalesce();
-
-  void oop_iterate(OopIterateClosure* cl, bool fill_dead_objects = false, bool reregister_coalesced_objects = false);
+  void oop_iterate(OopIterateClosure* cl);
   void oop_iterate_humongous(OopIterateClosure* cl);
 
   HeapWord* block_start(const void* p) const;
@@ -421,8 +418,7 @@ private:
   void do_commit();
   void do_uncommit();
 
-  void oop_iterate_objects(OopIterateClosure* cl, bool fill_dead_objects, bool reregister_coalesced_objects);
-  void oop_iterate_objects(bool fill_dead_objects, bool reregister_coalesced_objects);
+  void oop_iterate_objects(OopIterateClosure* cl);
 
   inline void internal_increase_live_data(size_t s);
 

--- a/src/hotspot/share/gc/shenandoah/shenandoahHeapRegionCounters.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahHeapRegionCounters.cpp
@@ -156,7 +156,7 @@ jlong ShenandoahHeapRegionCounters::encode_heap_status(ShenandoahHeap* heap) {
     if (heap->is_concurrent_old_mark_in_progress()) {
       status |= (1 << 2);
     }
-    log_develop_trace(gc)("%s, phase=%u, old_mark=%s, status=%zu",
+    log_develop_trace(gc)("%s, phase=%u, old_mark=%s, status=" JLONG_FORMAT,
       generation->name(), phase, BOOL_TO_STR(heap->is_concurrent_old_mark_in_progress()), status);
   }
 

--- a/src/hotspot/share/gc/shenandoah/shenandoahMarkingContext.hpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahMarkingContext.hpp
@@ -32,6 +32,7 @@
 #include "oops/oopsHierarchy.hpp"
 
 class ShenandoahObjToScanQueueSet;
+class ShenandoahBitmapRegion;
 
 /**
  * Encapsulate a marking bitmap with the top-at-mark-start and top-bitmaps array.
@@ -46,9 +47,10 @@ private:
   HeapWord** const _top_at_mark_starts;
 
   ShenandoahSharedFlag _is_complete;
+  ShenandoahBitmapRegion* _bitmap_region;
 
 public:
-  ShenandoahMarkingContext(MemRegion heap_region, MemRegion bitmap_region, size_t num_regions);
+  ShenandoahMarkingContext(MemRegion heap_region, ShenandoahBitmapRegion* bitmap_region, size_t num_regions);
 
   /*
    * Marks the object. Returns true if the object has not been marked before and has
@@ -73,10 +75,12 @@ public:
   inline HeapWord* top_at_mark_start(ShenandoahHeapRegion* r) const;
   inline void capture_top_at_mark_start(ShenandoahHeapRegion* r);
   inline void reset_top_at_mark_start(ShenandoahHeapRegion* r);
+  inline void set_top_at_mark_start(ShenandoahHeapRegion* r, HeapWord* tams);
   void initialize_top_at_mark_start(ShenandoahHeapRegion* r);
 
-  inline void reset_top_bitmap(ShenandoahHeapRegion *r);
-  void clear_bitmap(ShenandoahHeapRegion *r);
+  inline void set_top_bitmap(ShenandoahHeapRegion* r, HeapWord* top);
+  inline void reset_top_bitmap(ShenandoahHeapRegion* r);
+  void clear_bitmap(ShenandoahHeapRegion* r);
 
   bool is_bitmap_clear() const;
   bool is_bitmap_clear_range(HeapWord* start, HeapWord* end) const;
@@ -84,6 +88,8 @@ public:
   bool is_complete();
   void mark_complete();
   void mark_incomplete();
+
+  bool is_marked_with_size(oop obj, HeapWord* end, size_t* size) const;
 };
 
 #endif // SHARE_GC_SHENANDOAH_SHENANDOAHMARKINGCONTEXT_HPP

--- a/src/hotspot/share/gc/shenandoah/shenandoahMarkingContext.inline.hpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahMarkingContext.inline.hpp
@@ -92,8 +92,16 @@ inline void ShenandoahMarkingContext::reset_top_at_mark_start(ShenandoahHeapRegi
   _top_at_mark_starts_base[r->index()] = r->bottom();
 }
 
+inline void ShenandoahMarkingContext::set_top_at_mark_start(ShenandoahHeapRegion* r, HeapWord* tams) {
+  _top_at_mark_starts_base[r->index()] = tams;
+}
+
 inline HeapWord* ShenandoahMarkingContext::top_at_mark_start(ShenandoahHeapRegion* r) const {
   return _top_at_mark_starts_base[r->index()];
+}
+
+inline void ShenandoahMarkingContext::set_top_bitmap(ShenandoahHeapRegion* r, HeapWord* top) {
+  _top_bitmaps[r->index()] = top;
 }
 
 inline void ShenandoahMarkingContext::reset_top_bitmap(ShenandoahHeapRegion* r) {

--- a/src/hotspot/share/gc/shenandoah/shenandoahOldGC.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahOldGC.cpp
@@ -34,47 +34,13 @@
 #include "gc/shenandoah/shenandoahWorkerPolicy.hpp"
 #include "utilities/events.hpp"
 
-class ShenandoahConcurrentCoalesceAndFillTask : public AbstractGangTask {
-private:
-  // remember nworkers, coalesce_and_fill_region_array,coalesce_and_fill_regions_count
-
-  uint _nworkers;
-  ShenandoahHeapRegion** _coalesce_and_fill_region_array;
-  uint _coalesce_and_fill_region_count;
-
-public:
-  ShenandoahConcurrentCoalesceAndFillTask(uint nworkers,
-                                          ShenandoahHeapRegion** coalesce_and_fill_region_array, uint region_count) :
-    AbstractGangTask("Shenandoah Concurrent Coalesce and Fill"),
-    _nworkers(nworkers),
-    _coalesce_and_fill_region_array(coalesce_and_fill_region_array),
-    _coalesce_and_fill_region_count(region_count) {
-  }
-
-  void work(uint worker_id) {
-    ShenandoahHeap* heap = ShenandoahHeap::heap();
-
-    for (uint region_idx = worker_id; region_idx < _coalesce_and_fill_region_count; region_idx += _nworkers) {
-      ShenandoahHeapRegion* r = _coalesce_and_fill_region_array[region_idx];
-      if (!r->is_humongous())
-        r->oop_fill_and_coalesce();
-      else {
-        // there's only one object in this region and it's not garbage, so no need to coalesce or fill
-      }
-    }
-  }
-};
-
-
 ShenandoahOldGC::ShenandoahOldGC(ShenandoahGeneration* generation, ShenandoahSharedFlag& allow_preemption) :
   ShenandoahConcurrentGC(generation), _allow_preemption(allow_preemption) {
-  _coalesce_and_fill_region_array = NEW_C_HEAP_ARRAY(ShenandoahHeapRegion*, ShenandoahHeap::heap()->num_regions(), mtGC);
 }
 
 void ShenandoahOldGC::entry_old_evacuations() {
   ShenandoahHeap* heap = ShenandoahHeap::heap();
   ShenandoahOldHeuristics* old_heuristics = heap->old_heuristics();
-  entry_coalesce_and_fill();
   old_heuristics->start_old_evacuations();
 }
 
@@ -96,30 +62,9 @@ bool ShenandoahOldGC::collect(GCCause::Cause cause) {
   // should not have built a cset in final mark.
   assert(!heap->is_evacuation_in_progress(), "Old gen evacuations are not supported");
 
-  // Concurrent stack processing
-  if (heap->is_evacuation_in_progress()) {
-    entry_thread_roots();
-  }
-
-  // Process weak roots that might still point to regions that would be broken by cleanup
-  if (heap->is_concurrent_weak_root_in_progress()) {
-    entry_weak_refs();
-    entry_weak_roots();
-  }
-
-  // Final mark might have reclaimed some immediate garbage, kick cleanup to reclaim
-  // the space. This would be the last action if there is nothing to evacuate.
-  entry_cleanup_early();
-
   {
     ShenandoahHeapLocker locker(heap->lock());
     heap->free_set()->log_status();
-  }
-
-  // Perform concurrent class unloading
-  if (heap->unload_classes() &&
-      heap->is_concurrent_weak_root_in_progress()) {
-    entry_class_unloading();
   }
 
   // Processing strong roots
@@ -131,48 +76,4 @@ bool ShenandoahOldGC::collect(GCCause::Cause cause) {
 
   entry_rendezvous_roots();
   return true;
-}
-
-void ShenandoahOldGC::entry_coalesce_and_fill_message(char *buf, size_t len) const {
-  // ShenandoahHeap* const heap = ShenandoahHeap::heap();
-  jio_snprintf(buf, len, "Coalescing and filling (%s)", _generation->name());
-}
-
-void ShenandoahOldGC::op_coalesce_and_fill() {
-  ShenandoahHeap* const heap = ShenandoahHeap::heap();
-
-  WorkGang* workers = heap->workers();
-  uint nworkers = workers->active_workers();
-
-  assert(_generation->generation_mode() == OLD, "Only old-GC does coalesce and fill");
-
-  ShenandoahOldHeuristics* old_heuristics = heap->old_heuristics();
-  uint coalesce_and_fill_regions_count = old_heuristics->old_coalesce_and_fill_candidates();
-  assert(coalesce_and_fill_regions_count <= heap->num_regions(), "Sanity");
-  old_heuristics->get_coalesce_and_fill_candidates(_coalesce_and_fill_region_array);
-  ShenandoahConcurrentCoalesceAndFillTask task(nworkers, _coalesce_and_fill_region_array, coalesce_and_fill_regions_count);
-
-
-  // TODO:  We need to implement preemption of coalesce and fill.  If young-gen wants to run while we're working on this,
-  // we should preempt this code and then resume it after young-gen has finished.  This requires that we "remember" the state
-  // of each worker thread so it can be resumed where it left off.  Note that some worker threads may have processed more regions
-  // than others at the time of preemption.
-
-  workers->run_task(&task);
-}
-
-void ShenandoahOldGC::entry_coalesce_and_fill() {
-  char msg[1024];
-  ShenandoahHeap* const heap = ShenandoahHeap::heap();
-
-  entry_coalesce_and_fill_message(msg, sizeof(msg));
-  ShenandoahConcurrentPhase gc_phase(msg, ShenandoahPhaseTimings::coalesce_and_fill);
-
-  TraceCollectorStats tcs(heap->monitoring_support()->concurrent_collection_counters());
-  EventMark em("%s", msg);
-  ShenandoahWorkerScope scope(heap->workers(),
-                              ShenandoahWorkerPolicy::calc_workers_for_conc_marking(),
-                              "concurrent coalesce and fill");
-
-  op_coalesce_and_fill();
 }

--- a/src/hotspot/share/gc/shenandoah/shenandoahPhaseTimings.hpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahPhaseTimings.hpp
@@ -67,8 +67,6 @@ class outputStream;
   f(final_mark,                                     "Pause Final Mark (N)")            \
   f(finish_mark,                                    "  Finish Mark")                   \
   SHENANDOAH_PAR_PHASE_DO(finish_mark_,             "    FM: ", f)                     \
-  f(coalesce_and_fill,                              "Coalesce and Fill Old Dead")      \
-  SHENANDOAH_PAR_PHASE_DO(coalesce_and_fill_,       "    CFOD: ", f)                   \
   f(purge,                                          "  System Purge")                  \
   SHENANDOAH_PAR_PHASE_DO(purge_cu_par_,            "      CU: ", f)                   \
   f(purge_weak_par,                                 "    Weak Roots")                  \

--- a/src/hotspot/share/gc/shenandoah/shenandoahSTWMark.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahSTWMark.cpp
@@ -71,6 +71,7 @@ void ShenandoahSTWMark::mark() {
   ShenandoahReferenceProcessor* rp = heap->ref_processor();
   rp->reset_thread_locals();
   rp->set_soft_reference_policy(heap->soft_ref_policy()->should_clear_all_soft_refs());
+  rp->set_alive_closure(_generation->is_alive_closure());
 
   // Init mark, do not expect forwarded pointers in roots
   if (ShenandoahVerify) {

--- a/src/hotspot/share/gc/shenandoah/shenandoahScanRemembered.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahScanRemembered.cpp
@@ -84,6 +84,12 @@ void ShenandoahDirectCardMarkRememberedSet::merge_overreach(size_t first_cluster
     *bmp++ &= *omp++;
 }
 
+bool ShenandoahDirectCardMarkRememberedSet::is_live(HeapWord* p, HeapWord* endp, size_t* size) {
+  // TODO: We don't need to choose the marking context every time we call this method.
+  ShenandoahMarkingContext* ctx = _heap->stable_marking_context();
+  return ctx->is_marked_with_size(oop(p), endp, size);
+}
+
 ShenandoahScanRememberedTask::ShenandoahScanRememberedTask(ShenandoahObjToScanQueueSet* queue_set,
                                                            ShenandoahObjToScanQueueSet* old_queue_set,
                                                            ShenandoahReferenceProcessor* rp,

--- a/src/hotspot/share/gc/shenandoah/shenandoahScanRemembered.hpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahScanRemembered.hpp
@@ -270,6 +270,8 @@ public:
   void mark_overreach_card_as_dirty(void *p);
   size_t cluster_count();
 
+  bool is_live(HeapWord *p, HeapWord *endp, size_t* size);
+
   // Called by multiple GC threads at start of concurrent mark and evacuation phases.  Each parallel GC thread typically
   // initializes a different subranges of all overreach entries.
   void initialize_overreach(size_t first_cluster, size_t count);
@@ -755,23 +757,6 @@ public:
   // In its current implementation, unregister_object() serves the needs of coalescing objects.
   //
 
-  // Suppose we want to combine several dead objects into a single coalesced object.  How does this
-  // impact our representation of crossing map information?
-  //  1. If the newly coalesced region is contained entirely within a single region, that region's last
-  //     start entry either remains the same or it is changed to the start of the coalesced region.
-  //  2. For the region that holds the start of the coalesced object, it will not impact the first start
-  //     but it may impact the last start.
-  //  3. For following regions spanned entirely by the newly coalesced object, it will change has_object
-  //     to false (and make first-start and last-start "undefined").
-  //  4. For a following region that is spanned patially by the newly coalesced object, it may change
-  //     first-start value, but it will not change the last-start value.
-  //
-  // The range of addresses represented by the arguments to coalesce_objects() must represent a range
-  // of memory that was previously occupied exactly by one or more previously registered objects.  For
-  // convenience, it is legal to invoke coalesce_objects() with arguments that span a single previously
-  // registered object.
-  void coalesce_objects(HeapWord* address, size_t length_in_words);
-
   // The typical use case is going to look something like this:
   //   for each heapregion that comprises old-gen memory
   //     for each card number that corresponds to this heap region
@@ -891,7 +876,6 @@ public:
 
   size_t cluster_for_addr(HeapWord *addr);
   void register_object(HeapWord *addr);
-  void coalesce_objects(HeapWord *addr, size_t length_in_words);
 
   // clear the cards to clean, and clear the object_starts info to no objects
   void mark_range_as_empty(HeapWord *addr, size_t length_in_words);


### PR DESCRIPTION
## Motivation
After final mark, Shenandoah chooses the collection set (regions that will be reclaimed). If there is a sufficient amount of reclaimable memory in regions that are 100% garbage, it recycles them immediately and skips the evacuation and update reference phases (there are no pointers into these 100% garbage regions). Note that in this case there are still dead objects in regions outside of the collection set. During subsequent remembered set scans, Shenandoah must safely iterate objects in regions of memory indicated by marked cards. Specifically, it must not attempt to iterate over oops in the dead objects outside the collection set. Prior to the changes in this review, Generational Shenandoah disarmed these dead objects by coalescing them and then overwriting them with filler objects during the update references phase. There are some drawbacks to this approach:

* Originally, Generational Shenandoah used the oopDesc::size API to compute the size of filler objects. This API uses the klass for the oop to provide the size. Since we were using the size method on dead oops, if there were no instances of the klass still alive it could be unloaded during weak root processing and the size method would fail. To prevent this issue, we disabled ClassUnloading. 
* We now use the mark bitmap to compute the size of dead objects, but there is still a risk here: when young collections coalesce and fill dead objects during concurrent old generation marking, the mark bitmap is incomplete.
* It forced us to go through evacuation and update reference phases for every cycle. Our tests (Dacapo) show that approximately 33% of collections (with the default settings) find enough pure garbage regions to complete without evacuations.
* It forces the collector to perform work proportional to the amount of garbage outside the collection set (in the old generation). For performance reasons, the collector should avoid any work which is proportional to the amount of garbage.

## Overview of Changes
Rather than filling in dead objects to provide safety to the remembered set scan, the scan now uses the marking bit map to skip over dead objects. This leverages the work already completed during the marking phase and no longer requires any additional maintenance work during the update reference phase. There are, however, a few wrinkles to consider:

* The evacuation phase needs to update the mark bitmap. This essentially mimics the work currently done to register objects with the remembered set.
* During concurrent old marking, the remembered set scan cannot rely on the mark bitmap for the old generation. For this reason, a second bitmap has been added. At the beginning of a concurrent old mark, the bitmaps are switched. During concurrent old marking, the remembered set scan will use the previous (i.e., stable) bitmap for determining object liveness.
* Though not directly related to these changes, a fix for reference processing has been implemented in terms of these changes (i.e., the fix uses the secondary bitmap). Please note, the "fix" for reference processing is incorrect. It does not preserve the atomicity required when null'ing out references. Work on reference processing is proceeding on a separate branch, unrelated to these changes.

## Remaining Work

* Object registration should no longer be necessary. We can use the mark bitmap to tell us if a card has any objects.
* Shenandoah has an optimization to avoid clearing bitmap regions that are known to contain no marked bits. This optimization is currently disabled. It needs to be debugged (I think it is confused by extra marks made during evacuation).
* Region promotions that happen during a concurrent old mark must copy the bitmap of the promoted region - this is currently done in a most inefficient way.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

### Reviewers
 * [Roman Kennke](https://openjdk.java.net/census#rkennke) (@rkennke - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/shenandoah pull/50/head:pull/50` \
`$ git checkout pull/50`

Update a local copy of the PR: \
`$ git checkout pull/50` \
`$ git pull https://git.openjdk.java.net/shenandoah pull/50/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 50`

View PR using the GUI difftool: \
`$ git pr show -t 50`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/shenandoah/pull/50.diff">https://git.openjdk.java.net/shenandoah/pull/50.diff</a>

</details>
