### PR TITLE
Check that pointer is in heap before checking the affiliation of owning region

### DIFF
--- a/src/hotspot/share/gc/shenandoah/shenandoahHeap.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahHeap.cpp
@@ -753,11 +753,11 @@ bool ShenandoahHeap::is_in(const void* p) const {
 }
 
 bool ShenandoahHeap::is_in_young(const void* p) const {
-  return heap_region_containing(p)->affiliation() == ShenandoahRegionAffiliation::YOUNG_GENERATION;
+  return is_in(p) && heap_region_containing(p)->affiliation() == ShenandoahRegionAffiliation::YOUNG_GENERATION;
 }
 
 bool ShenandoahHeap::is_in_old(const void* p) const {
-  return heap_region_containing(p)->affiliation() == ShenandoahRegionAffiliation::OLD_GENERATION;
+  return is_in(p) && heap_region_containing(p)->affiliation() == ShenandoahRegionAffiliation::OLD_GENERATION;
 }
 
 void ShenandoahHeap::op_uncommit(double shrink_before, size_t shrink_until) {

--- a/src/hotspot/share/gc/shenandoah/shenandoahReferenceProcessor.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahReferenceProcessor.cpp
@@ -396,9 +396,9 @@ oop ShenandoahReferenceProcessor::drop(oop reference, ReferenceType type) {
   reference_set_discovered<T>(reference, NULL);
   // When this reference was discovered, it would not have been marked. If it ends up surviving
   // the cycle, we need to dirty the card if the reference is old and the referent is young.  Note
-  // that if the reference is not dropped, then its pointer to the referent will be nulled before
+  // that if the reference is not dropped, then its pointer to the referent will be cleared before
   // evacuation begins so card does not need to be dirtied.
-  if (heap->mode()->is_generational() && heap->is_old(reference) && heap->is_in_young(referent)) {
+  if (heap->mode()->is_generational() && heap->is_in_old(reference) && heap->is_in_young(referent)) {
     // Note: would be sufficient to mark only the card that holds the start of this Reference object.
     heap->card_scan()->mark_range_as_dirty(cast_from_oop<HeapWord*>(reference), reference->size());
   }

--- a/src/hotspot/share/gc/shenandoah/shenandoahReferenceProcessor.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahReferenceProcessor.cpp
@@ -396,7 +396,7 @@ oop ShenandoahReferenceProcessor::drop(oop reference, ReferenceType type) {
   reference_set_discovered<T>(reference, NULL);
   // When this reference was discovered, it would not have been marked. If it ends up surviving
   // the cycle, we need to dirty the card if the reference is old and the referent is young.  Note
-  // that if the reference is not dropped, then its pointer to the referent will be cleared before
+  // that if the reference is not dropped, then its pointer to the referent will be nulled before
   // evacuation begins so card does not need to be dirtied.
   if (heap->mode()->is_generational() && heap->is_in_old(reference) && heap->is_in_young(referent)) {
     // Note: would be sufficient to mark only the card that holds the start of this Reference object.


### PR DESCRIPTION
This is a small bug fix that was meant to go in with the concurrent remembered set scanning changes

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

### Reviewers
 * [Roman Kennke](https://openjdk.java.net/census#rkennke) (@rkennke - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/shenandoah pull/52/head:pull/52` \
`$ git checkout pull/52`

Update a local copy of the PR: \
`$ git checkout pull/52` \
`$ git pull https://git.openjdk.java.net/shenandoah pull/52/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 52`

View PR using the GUI difftool: \
`$ git pr show -t 52`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/shenandoah/pull/52.diff">https://git.openjdk.java.net/shenandoah/pull/52.diff</a>

</details>
