### PR TITLE
Re-enable class unloading

### DIFF
--- a/src/hotspot/share/gc/shenandoah/mode/shenandoahGenerationalMode.cpp
+++ b/src/hotspot/share/gc/shenandoah/mode/shenandoahGenerationalMode.cpp
@@ -30,14 +30,6 @@
 #include "runtime/globals_extension.hpp"
 
 void ShenandoahGenerationalMode::initialize_flags() const {
-  // When we fill in dead objects during update refs, we use oop::size,
-  // which depends on the klass being loaded. However, if these dead objects
-  // were the last referrers to the klass, it will be unloaded and we'll
-  // crash. Class unloading is disabled until we're able to sort this out.
-  FLAG_SET_ERGO(ClassUnloading, false);
-  FLAG_SET_ERGO(ClassUnloadingWithConcurrentMark, false);
-  FLAG_SET_ERGO(ShenandoahUnloadClassesFrequency, 0);
-
   if (ClassUnloading) {
     // Leaving this here for the day we re-enable class unloading
     FLAG_SET_DEFAULT(ShenandoahSuspendibleWorkers, true);
@@ -56,7 +48,6 @@ void ShenandoahGenerationalMode::initialize_flags() const {
   SHENANDOAH_CHECK_FLAG_SET(ShenandoahSATBBarrier);
   SHENANDOAH_CHECK_FLAG_SET(ShenandoahCASBarrier);
   SHENANDOAH_CHECK_FLAG_SET(ShenandoahCloneBarrier);
-  SHENANDOAH_CHECK_FLAG_UNSET(ClassUnloading);
 }
 
 const char *affiliation_name(ShenandoahRegionAffiliation type) {


### PR DESCRIPTION
Class unloading was disabled for generational mode for the reasons described in [PR 50](https://github.com/openjdk/shenandoah/pull/50). However, the code has since evolved to avoid using `oop::size` when filling in dead objects so we no longer require classes for unreachable objects to remain loaded.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

### Reviewers
 * [Roman Kennke](https://openjdk.java.net/census#rkennke) (@rkennke - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/shenandoah pull/55/head:pull/55` \
`$ git checkout pull/55`

Update a local copy of the PR: \
`$ git checkout pull/55` \
`$ git pull https://git.openjdk.java.net/shenandoah pull/55/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 55`

View PR using the GUI difftool: \
`$ git pr show -t 55`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/shenandoah/pull/55.diff">https://git.openjdk.java.net/shenandoah/pull/55.diff</a>

</details>
