### PR TITLE
Make immediate trash of old regions with no live objects

### DIFF
--- a/src/hotspot/share/gc/shenandoah/heuristics/shenandoahOldHeuristics.cpp
+++ b/src/hotspot/share/gc/shenandoah/heuristics/shenandoahOldHeuristics.cpp
@@ -171,9 +171,13 @@ void ShenandoahOldHeuristics::prepare_for_old_collections() {
     total_garbage += garbage;
 
     if (region->is_regular()) {
-      candidates[cand_idx]._region = region;
-      candidates[cand_idx]._garbage = garbage;
-      cand_idx++;
+      if (!region->has_live()) {
+        region->make_trash_immediate();
+      } else {
+        candidates[cand_idx]._region = region;
+        candidates[cand_idx]._garbage = garbage;
+        cand_idx++;
+      }
     } else if (region->is_humongous_start()) {
       if (!region->has_live()) {
         // The humongous object is dead, we can just return this region and the continuations


### PR DESCRIPTION
At the end of old marking we can immediately recycle regions with no live objects. This optimization is already done for young/global collects, but it was missing from old collections. This fixes an assertion during preparation for evacuation that _all_ cset regions have _some_ live data.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

### Reviewers
 * [Roman Kennke](https://openjdk.java.net/census#rkennke) (@rkennke - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/shenandoah pull/57/head:pull/57` \
`$ git checkout pull/57`

Update a local copy of the PR: \
`$ git checkout pull/57` \
`$ git pull https://git.openjdk.java.net/shenandoah pull/57/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 57`

View PR using the GUI difftool: \
`$ git pr show -t 57`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/shenandoah/pull/57.diff">https://git.openjdk.java.net/shenandoah/pull/57.diff</a>

</details>
