### PR TITLE
Fix Zero builds

### DIFF
--- a/src/hotspot/share/gc/shenandoah/mode/shenandoahGenerationalMode.cpp
+++ b/src/hotspot/share/gc/shenandoah/mode/shenandoahGenerationalMode.cpp
@@ -25,6 +25,7 @@
 #include "precompiled.hpp"
 #include "gc/shenandoah/mode/shenandoahGenerationalMode.hpp"
 #include "gc/shenandoah/heuristics/shenandoahHeuristics.hpp"
+#include "gc/shenandoah/shenandoahHeap.inline.hpp"
 #include "logging/log.hpp"
 #include "logging/logTag.hpp"
 #include "runtime/globals_extension.hpp"


### PR DESCRIPTION
There are many build failures in Zero configurations, all look like this:

```
/home/buildbot/worker/build-shenandoah-jdkX-linux/build/src/hotspot/share/gc/shenandoah/mode/shenandoahGenerationalMode.cpp: In function 'const char* affiliation_name(oop)':
/home/buildbot/worker/build-shenandoah-jdkX-linux/build/src/hotspot/share/gc/shenandoah/mode/shenandoahGenerationalMode.cpp:54:3: error: 'ShenandoahHeap' was not declared in this scope
   ShenandoahHeap* heap = ShenandoahHeap::heap();
   ^~~~~~~~~~~~~~
/home/buildbot/worker/build-shenandoah-jdkX-linux/build/src/hotspot/share/gc/shenandoah/mode/shenandoahGenerationalMode.cpp:54:19: error: 'heap' was not declared in this scope
   ShenandoahHeap* heap = ShenandoahHeap::heap();
                   ^~~~
/home/buildbot/worker/build-shenandoah-jdkX-linux/build/src/hotspot/share/gc/shenandoah/mode/shenandoahGenerationalMode.cpp:54:26: error: 'ShenandoahHeap' is not a class, namespace, or enumeration
   ShenandoahHeap* heap = ShenandoahHeap::heap();
                          ^~~~~~~~~~~~~~
/home/buildbot/worker/build-shenandoah-jdkX-linux/build/src/hotspot/share/gc/shenandoah/mode/shenandoahGenerationalMode.cpp:57:33: error: invalid use of incomplete type 'class ShenandoahHeapRegion'
   return affiliation_name(region->affiliation());
                                 ^~
In file included from /home/buildbot/worker/build-shenandoah-jdkX-linux/build/src/hotspot/share/gc/shenandoah/mode/shenandoahGenerationalMode.cpp:27:0:
/home/buildbot/worker/build-shenandoah-jdkX-linux/build/src/hotspot/share/gc/shenandoah/heuristics/shenandoahHeuristics.hpp:58:7: note: forward declaration of 'class ShenandoahHeapRegion'
   ... (rest of output omitted)

/home/shade/trunks/shenandoah-jdk/src/hotspot/share/gc/shenandoah/shenandoahHeap.hpp:277:38: error: inline function 'ShenandoahHeapRegion* const ShenandoahHeap::heap_region_containing(const void*) const' used but never defined [-Werror]
  277 |   inline ShenandoahHeapRegion* const heap_region_containing(const void* addr) const;
      |                                      ^~~~~~~~~~~~~~~~~~~~~~
```

Fix is trivial: add the inline header that carriers the required definitions.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

### Reviewers
 * [Roman Kennke](https://openjdk.java.net/census#rkennke) (@rkennke - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/shenandoah pull/58/head:pull/58` \
`$ git checkout pull/58`

Update a local copy of the PR: \
`$ git checkout pull/58` \
`$ git pull https://git.openjdk.java.net/shenandoah pull/58/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 58`

View PR using the GUI difftool: \
`$ git pr show -t 58`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/shenandoah/pull/58.diff">https://git.openjdk.java.net/shenandoah/pull/58.diff</a>

</details>
