### PR TITLE
Update alloc liveness data during final mark of old generation

### DIFF
--- a/src/hotspot/share/gc/shenandoah/shenandoahGeneration.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahGeneration.cpp
@@ -199,9 +199,11 @@ bool ShenandoahGeneration::prepare_regions_and_collection_set(bool concurrent) {
     parallel_heap_region_iterate(&cl);
     heap->assert_pinned_region_status();
 
-    // Also capture update_watermark for old-gen regions.
-    ShenandoahCaptureUpdateWaterMarkForOld old_cl(complete_marking_context());
-    heap->old_generation()->parallel_heap_region_iterate(&old_cl);
+    if (generation_mode() == YOUNG) {
+      // Also capture update_watermark for old-gen regions.
+      ShenandoahCaptureUpdateWaterMarkForOld old_cl(complete_marking_context());
+      heap->old_generation()->parallel_heap_region_iterate(&old_cl);
+    }
   }
 
   {

--- a/src/hotspot/share/gc/shenandoah/shenandoahGeneration.hpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahGeneration.hpp
@@ -93,7 +93,7 @@ public:
   virtual void prepare_gc(bool do_old_gc_bootstrap);
 
   // Return true iff prepared collection set includes at least one old-gen HeapRegion.
-  bool prepare_regions_and_collection_set(bool concurrent);
+  virtual bool prepare_regions_and_collection_set(bool concurrent);
 
   // Cancel marking (used by Full collect and when cancelling cycle).
   void cancel_marking();

--- a/src/hotspot/share/gc/shenandoah/shenandoahOldGC.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahOldGC.cpp
@@ -97,12 +97,7 @@ void ShenandoahOldGC::op_final_mark() {
     // We need to do this because weak root cleaning reports the number of dead handles
     JvmtiTagMap::set_needs_cleaning();
 
-    {
-      ShenandoahGCPhase phase(ShenandoahPhaseTimings::choose_cset);
-      ShenandoahHeapLocker locker(heap->lock());
-      // Old-gen choose_collection_set() does not directly manipulate heap->collection_set() so no need to clear it.
-      _generation->heuristics()->choose_collection_set(nullptr, nullptr);
-    }
+    _generation->prepare_regions_and_collection_set(true);
 
     heap->set_unload_classes(false);
     heap->prepare_concurrent_roots();

--- a/src/hotspot/share/gc/shenandoah/shenandoahOldGeneration.hpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahOldGeneration.hpp
@@ -46,6 +46,8 @@ class ShenandoahOldGeneration : public ShenandoahGeneration {
 
   void set_concurrent_mark_in_progress(bool in_progress) override;
 
+  bool prepare_regions_and_collection_set(bool concurrent) override;
+
   // We leave the SATB barrier on for the entirety of the old generation
   // marking phase. In some cases, this can cause a write to a perfectly
   // reachable oop to enqueue a pointer that later becomes garbage (because


### PR DESCRIPTION
Final mark for old generation was missing the use of `ShenandoahFinalMarkUpdateRegionStateClosure` to update region liveness data with allocated objects. In some cases, this could lead to objects being promoted into old regions that appear to have no live data resulting in these promoted objects being erroneously collected.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

### Reviewers
 * [Roman Kennke](https://openjdk.java.net/census#rkennke) (@rkennke - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/shenandoah pull/60/head:pull/60` \
`$ git checkout pull/60`

Update a local copy of the PR: \
`$ git checkout pull/60` \
`$ git pull https://git.openjdk.java.net/shenandoah pull/60/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 60`

View PR using the GUI difftool: \
`$ git pr show -t 60`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/shenandoah/pull/60.diff">https://git.openjdk.java.net/shenandoah/pull/60.diff</a>

</details>
