### PR TITLE
Fix misuse of atomic flag

### DIFF
--- a/src/hotspot/share/gc/shenandoah/shenandoahControlThread.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahControlThread.cpp
@@ -522,7 +522,7 @@ void ShenandoahControlThread::resume_concurrent_old_cycle(ShenandoahGeneration* 
   if (heap->cancelled_gc()) {
     // It's possible the gc cycle was cancelled after the last time
     // the collection checked for cancellation. In which case, the
-    // old gc cycle is still completed and we have to deal with this
+    // old gc cycle is still completed, and we have to deal with this
     // cancellation. We set the degeneration point to be outside
     // the cycle because if this is an allocation failure, that is
     // what must be done (there is no degenerated old cycle). If the
@@ -746,7 +746,7 @@ void ShenandoahControlThread::notify_control_thread() {
 }
 
 bool ShenandoahControlThread::preempt_old_marking(GenerationMode generation) {
-  return generation == YOUNG && _allow_old_preemption.is_set();
+  return generation == YOUNG && _allow_old_preemption.try_unset();
 }
 
 void ShenandoahControlThread::handle_requested_gc(GCCause::Cause cause) {


### PR DESCRIPTION
This change fixes an assert that GC isn't cancelled in the middle of a safepoint. The assert was triggered during the tier2 test: `TestJNIGlobalRefs`. The test uses the _aggressive_ heuristic which runs GC's back to back. The atomic `_preemption_allowed` variable was being misused in a non-atomic way which could lead to the regulator thread cancelling GC after the control thread has gone to the final mark safepoint.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

### Reviewers
 * [Zhengyu Gu](https://openjdk.java.net/census#zgu) (@zhengyu123 - Committer)
 * [Aleksey Shipilev](https://openjdk.java.net/census#shade) (@shipilev - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/shenandoah pull/63/head:pull/63` \
`$ git checkout pull/63`

Update a local copy of the PR: \
`$ git checkout pull/63` \
`$ git pull https://git.openjdk.java.net/shenandoah pull/63/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 63`

View PR using the GUI difftool: \
`$ git pr show -t 63`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/shenandoah/pull/63.diff">https://git.openjdk.java.net/shenandoah/pull/63.diff</a>

</details>
