### PR TITLE
Remove log message that could access an out of bounds region

### DIFF
--- a/src/hotspot/share/gc/shenandoah/shenandoahHeap.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahHeap.cpp
@@ -1260,12 +1260,6 @@ public:
     // the update-refs processing that follows.  After the updating of old-gen references is done, it is ok to carve
     // this remnant object into smaller pieces during the subsequent evacuation pass, as long as the PLAB is made parsable
     // again before the next update-refs phase.
-    if (plab->top() != nullptr) {
-      ShenandoahHeapRegion* r = ShenandoahHeap::heap()->heap_region_containing(plab->top());
-      log_debug(gc)("Retiring plab with top: " PTR_FORMAT ", hard_end: " PTR_FORMAT
-                    " + AlignmentReserve, in %s Region " SIZE_FORMAT,
-                    p2i(plab->top()), p2i(plab->top() + plab->words_remaining()), affiliation_name(r->affiliation()), r->index());
-    } // else, don't bother to report retirement
     ShenandoahHeap::heap()->retire_plab(plab);
     if (_resize && ShenandoahThreadLocalData::plab_size(thread) > 0) {
       ShenandoahThreadLocalData::set_plab_size(thread, 0);


### PR DESCRIPTION
The message attempts to reference the region containing the top of the plab. When the plab is full and is at the end of the last region in the heap, there will be no containing region. Doesn't seem worth the trouble to special case for a debug message.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

### Reviewers
 * [Kelvin Nilsen](https://openjdk.java.net/census#kdnilsen) (@kdnilsen - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/shenandoah pull/66/head:pull/66` \
`$ git checkout pull/66`

Update a local copy of the PR: \
`$ git checkout pull/66` \
`$ git pull https://git.openjdk.java.net/shenandoah pull/66/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 66`

View PR using the GUI difftool: \
`$ git pr show -t 66`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/shenandoah/pull/66.diff">https://git.openjdk.java.net/shenandoah/pull/66.diff</a>

</details>
