### PR TITLE
Fix handling of weak references during verification

### DIFF
--- a/src/hotspot/share/gc/shenandoah/shenandoahRootVerifier.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahRootVerifier.cpp
@@ -53,7 +53,7 @@ ShenandoahGCStateResetter::~ShenandoahGCStateResetter() {
   assert(_heap->gc_state() == _gc_state, "Should be restored");
 }
 
-void ShenandoahRootVerifier::roots_do(OopClosure* oops) {
+void ShenandoahRootVerifier::roots_do(OopIterateClosure* oops) {
   ShenandoahGCStateResetter resetter;
   shenandoah_assert_safepoint();
 
@@ -70,7 +70,7 @@ void ShenandoahRootVerifier::roots_do(OopClosure* oops) {
   ShenandoahHeap* heap = ShenandoahHeap::heap();
   if (heap->mode()->is_generational() && heap->is_gc_generation_young()) {
     shenandoah_assert_safepoint();
-    heap->card_scan()->oops_do(oops);
+    heap->card_scan()->roots_do(oops);
   }
 
   // Do thread roots the last. This allows verification code to find
@@ -79,7 +79,7 @@ void ShenandoahRootVerifier::roots_do(OopClosure* oops) {
   Threads::possibly_parallel_oops_do(true, oops, NULL);
 }
 
-void ShenandoahRootVerifier::strong_roots_do(OopClosure* oops) {
+void ShenandoahRootVerifier::strong_roots_do(OopIterateClosure* oops) {
   ShenandoahGCStateResetter resetter;
   shenandoah_assert_safepoint();
 
@@ -92,7 +92,7 @@ void ShenandoahRootVerifier::strong_roots_do(OopClosure* oops) {
 
   ShenandoahHeap* heap = ShenandoahHeap::heap();
   if (heap->mode()->is_generational() && heap->is_gc_generation_young()) {
-    heap->card_scan()->oops_do(oops);
+    heap->card_scan()->roots_do(oops);
   }
 
   // Do thread roots the last. This allows verification code to find

--- a/src/hotspot/share/gc/shenandoah/shenandoahRootVerifier.hpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahRootVerifier.hpp
@@ -41,8 +41,8 @@ public:
 class ShenandoahRootVerifier : public AllStatic {
 public:
   // Used to seed ShenandoahVerifier, do not honor root type filter
-  static void roots_do(OopClosure* cl);
-  static void strong_roots_do(OopClosure* cl);
+  static void roots_do(OopIterateClosure* cl);
+  static void strong_roots_do(OopIterateClosure* cl);
 };
 
 #endif // SHARE_GC_SHENANDOAH_SHENANDOAHROOTVERIFIER_HPP

--- a/src/hotspot/share/gc/shenandoah/shenandoahScanRemembered.hpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahScanRemembered.hpp
@@ -1023,7 +1023,6 @@ public:
   //  implementations will want to update this value each time they
   //  cross one of these boundaries.
   void roots_do(OopIterateClosure* cl);
-  void oops_do(OopClosure* cl);
 };
 
 typedef ShenandoahScanRemembered<ShenandoahDirectCardMarkRememberedSet> RememberedScanner;

--- a/src/hotspot/share/gc/shenandoah/shenandoahScanRemembered.inline.hpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahScanRemembered.inline.hpp
@@ -810,27 +810,6 @@ ShenandoahScanRemembered<RememberedSet>::cluster_for_addr(HeapWordImpl **addr) {
   return result;
 }
 
-class ShenandoahOopIterateAdapter : public BasicOopIterateClosure {
- private:
-  OopClosure* _cl;
- public:
-  explicit ShenandoahOopIterateAdapter(OopClosure* cl) : _cl(cl) {}
-
-  void do_oop(oop* o) {
-    _cl->do_oop(o);
-  }
-
-  void do_oop(narrowOop* o) {
-    _cl->do_oop(o);
-  }
-};
-
-template<typename RememberedSet>
-inline void ShenandoahScanRemembered<RememberedSet>::oops_do(OopClosure* cl) {
-  ShenandoahOopIterateAdapter adapter(cl);
-  roots_do(&adapter);
-}
-
 template<typename RememberedSet>
 inline void ShenandoahScanRemembered<RememberedSet>::roots_do(OopIterateClosure* cl) {
   ShenandoahHeap* heap = ShenandoahHeap::heap();

--- a/src/hotspot/share/gc/shenandoah/shenandoahVerifier.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahVerifier.cpp
@@ -1052,7 +1052,7 @@ void ShenandoahVerifier::verify_after_fullgc() {
   );
 }
 
-class ShenandoahVerifyNoForwared : public OopClosure {
+class ShenandoahVerifyNoForwared : public BasicOopIterateClosure {
 private:
   template <class T>
   void do_oop_work(T* p) {
@@ -1072,7 +1072,7 @@ public:
   void do_oop(oop* p)       { do_oop_work(p); }
 };
 
-class ShenandoahVerifyInToSpaceClosure : public OopClosure {
+class ShenandoahVerifyInToSpaceClosure : public BasicOopIterateClosure {
 private:
   template <class T>
   void do_oop_work(T* p) {


### PR DESCRIPTION
This is fallout from our last big merge from upstream. When verifying reachable objects before evacuation during final mark, concurrent reference processing hasn't happened yet. For this reason, verification is required to ignore weak references which hold an unmarked referent (that would be cleared during reference processing). In our last merged, we inadvertently disabled the code to ignore weak references during certain verification phases.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

### Reviewers
 * [Kelvin Nilsen](https://openjdk.java.net/census#kdnilsen) (@kdnilsen - Committer)
 * [Roman Kennke](https://openjdk.java.net/census#rkennke) (@rkennke - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/shenandoah pull/68/head:pull/68` \
`$ git checkout pull/68`

Update a local copy of the PR: \
`$ git checkout pull/68` \
`$ git pull https://git.openjdk.java.net/shenandoah pull/68/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 68`

View PR using the GUI difftool: \
`$ git pr show -t 68`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/shenandoah/pull/68.diff">https://git.openjdk.java.net/shenandoah/pull/68.diff</a>

</details>
