### PR TITLE
Reset task queue stats before rset scan

### DIFF
--- a/src/hotspot/share/gc/shenandoah/shenandoahConcurrentGC.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahConcurrentGC.cpp
@@ -114,6 +114,11 @@ bool ShenandoahConcurrentGC::collect(GCCause::Cause cause) {
   {
     ShenandoahBreakpointMarkScope breakpoint_mark_scope;
 
+    // Reset task queue stats here, rather than in mark_concurrent_roots
+    // because remembered set scan will `push` oops into the queues and
+    // resetting after this happens will lose those counts.
+    TASKQUEUE_STATS_ONLY(_mark.task_queues()->reset_taskqueue_stats());
+
     // Concurrent remembered set scanning
     if (_generation->generation_mode() == YOUNG) {
       _generation->scan_remembered_set();

--- a/src/hotspot/share/gc/shenandoah/shenandoahConcurrentMark.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahConcurrentMark.cpp
@@ -213,8 +213,6 @@ void ShenandoahConcurrentMark::mark_concurrent_roots() {
   ShenandoahHeap* const heap = ShenandoahHeap::heap();
   assert(!heap->has_forwarded_objects(), "Not expected");
 
-  TASKQUEUE_STATS_ONLY(task_queues()->reset_taskqueue_stats());
-
   WorkGang* workers = heap->workers();
   ShenandoahReferenceProcessor* rp = _generation->ref_processor();
   _generation->reserve_task_queues(workers->active_workers());

--- a/src/hotspot/share/gc/shenandoah/shenandoahPhaseTimings.hpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahPhaseTimings.hpp
@@ -53,9 +53,10 @@ class outputStream;
   f(init_mark_gross,                                "Pause Init Mark (G)")             \
   f(init_mark,                                      "Pause Init Mark (N)")             \
   f(init_manage_tlabs,                              "  Manage TLABs")                  \
-  f(init_scan_rset,                                 "  Scan Remembered Set")           \
-  SHENANDOAH_PAR_PHASE_DO(init_scan_rset_,          "    RS: ", f)                     \
   f(init_update_region_states,                      "  Update Region States")          \
+                                                                                       \
+  f(init_scan_rset,                                 "Concurrent Scan Remembered Set")  \
+  SHENANDOAH_PAR_PHASE_DO(init_scan_rset_,          "  RS: ", f)                       \
                                                                                        \
   f(conc_mark_roots,                                "Concurrent Mark Roots ")          \
   SHENANDOAH_PAR_PHASE_DO(conc_mark_roots,          "  CMR: ", f)                      \


### PR DESCRIPTION
This change fixes an assert caused when task queue stats were reset after the rset scan has pushed oops into the queues (all of those "pushes" become uncounted).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

### Reviewers
 * [Kelvin Nilsen](https://openjdk.java.net/census#kdnilsen) (@kdnilsen - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/shenandoah pull/69/head:pull/69` \
`$ git checkout pull/69`

Update a local copy of the PR: \
`$ git checkout pull/69` \
`$ git pull https://git.openjdk.java.net/shenandoah pull/69/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 69`

View PR using the GUI difftool: \
`$ git pr show -t 69`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/shenandoah/pull/69.diff">https://git.openjdk.java.net/shenandoah/pull/69.diff</a>

</details>
