### PR TITLE
Track promotion rate into old generation

### DIFF
--- a/src/hotspot/share/gc/shenandoah/heuristics/shenandoahAdaptiveHeuristics.cpp
+++ b/src/hotspot/share/gc/shenandoah/heuristics/shenandoahAdaptiveHeuristics.cpp
@@ -226,7 +226,7 @@ bool ShenandoahAdaptiveHeuristics::should_start_gc() {
     return true;
   }
 
-  // Check if are need to learn a bit about the application
+  // Check if we need to learn a bit about the application
   const size_t max_learn = ShenandoahLearningSteps;
   if (_gc_times_learned < max_learn) {
     size_t init_threshold = capacity / 100 * ShenandoahInitFreeThreshold;
@@ -252,6 +252,9 @@ bool ShenandoahAdaptiveHeuristics::should_start_gc() {
 
   double avg_cycle_time = _gc_time_history->davg() + (_margin_of_error_sd * _gc_time_history->dsd());
   double avg_alloc_rate = _allocation_rate.upper_bound(_margin_of_error_sd);
+  log_debug(gc)("%s: average GC time: %.2f ms, allocation rate: %.0f %s/s",
+    _generation->name(), avg_cycle_time * 1000, byte_size_in_proper_unit(avg_alloc_rate), proper_unit_for_byte_size(avg_alloc_rate));
+
   if (avg_cycle_time > allocation_headroom / avg_alloc_rate) {
     log_info(gc)("Trigger (%s): Average GC time (%.2f ms) is above the time for average allocation rate (%.0f %sB/s) to deplete free headroom (" SIZE_FORMAT "%s) (margin of error = %.2f)",
                  _generation->name(), avg_cycle_time * 1000,

--- a/src/hotspot/share/gc/shenandoah/heuristics/shenandoahAdaptiveOldHeuristics.cpp
+++ b/src/hotspot/share/gc/shenandoah/heuristics/shenandoahAdaptiveOldHeuristics.cpp
@@ -260,6 +260,9 @@ bool ShenandoahAdaptiveOldHeuristics::should_start_gc() {
 
   double avg_cycle_time = _gc_time_history->davg() + (_margin_of_error_sd * _gc_time_history->dsd());
   double avg_alloc_rate = _allocation_rate.upper_bound(_margin_of_error_sd);
+  log_debug(gc)("%s: average GC time: %.2f ms, allocation rate: %.0f %s/s",
+                _generation->name(), avg_cycle_time * 1000, byte_size_in_proper_unit(avg_alloc_rate), proper_unit_for_byte_size(avg_alloc_rate));
+
   if (avg_cycle_time > allocation_headroom / avg_alloc_rate) {
     log_info(gc)("Trigger (%s): Average GC time (%.2f ms) is above the time for average allocation rate (%.0f %sB/s) to deplete free headroom (" SIZE_FORMAT "%s) (margin of error = %.2f)",
                  _generation->name(), avg_cycle_time * 1000,

--- a/src/hotspot/share/gc/shenandoah/shenandoahFreeSet.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahFreeSet.cpp
@@ -242,6 +242,7 @@ HeapWord* ShenandoahFreeSet::try_allocate_in(ShenandoahHeapRegion* r, Shenandoah
       size_t waste = r->free();
       if (waste > 0) {
         increase_used(waste);
+        _heap->generation_for(req.affiliation())->increase_allocated(waste);
         _heap->notify_mutator_alloc_words(waste >> LogHeapWordSize, true);
       }
     }
@@ -384,7 +385,9 @@ HeapWord* ShenandoahFreeSet::allocate_contiguous(ShenandoahAllocRequest& req) {
 
   if (remainder != 0) {
     // Record this remainder as allocation waste
-    _heap->notify_mutator_alloc_words(ShenandoahHeapRegion::region_size_words() - remainder, true);
+    size_t waste = ShenandoahHeapRegion::region_size_words() - remainder;
+    _heap->notify_mutator_alloc_words(waste, true);
+    _heap->generation_for(req.affiliation())->increase_allocated(waste * HeapWordSize);
   }
 
   // Allocated at left/rightmost? Move the bounds appropriately.

--- a/src/hotspot/share/gc/shenandoah/shenandoahGeneration.hpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahGeneration.hpp
@@ -50,6 +50,7 @@ protected:
   // Usage
   size_t _affiliated_region_count;
   volatile size_t _used;
+  volatile size_t _bytes_allocated_since_gc_start;
   size_t _max_capacity;
   size_t _soft_max_capacity;
 
@@ -75,11 +76,13 @@ public:
   virtual size_t used() const { return _used; }
   virtual size_t available() const;
 
+  size_t bytes_allocated_since_gc_start();
+  void reset_bytes_allocated_since_gc_start();
+  void increase_allocated(size_t bytes);
+
   void set_soft_max_capacity(size_t soft_max_capacity) {
     _soft_max_capacity = soft_max_capacity;
   }
-
-  virtual size_t bytes_allocated_since_gc_start();
 
   void log_status() const;
 

--- a/src/hotspot/share/gc/shenandoah/shenandoahHeap.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahHeap.cpp
@@ -1059,28 +1059,7 @@ HeapWord* ShenandoahHeap::allocate_memory(ShenandoahAllocRequest& req) {
 
 HeapWord* ShenandoahHeap::allocate_memory_under_lock(ShenandoahAllocRequest& req, bool& in_new_region) {
   ShenandoahHeapLocker locker(lock());
-  HeapWord* result = _free_set->allocate(req, in_new_region);
-  if (result != NULL && req.affiliation() == ShenandoahRegionAffiliation::OLD_GENERATION) {
-    // Register the newly allocated object while we're holding the global lock since there's no synchronization
-    // built in to the implementation of register_object().  There are potential races when multiple independent
-    // threads are allocating objects, some of which might span the same card region.  For example, consider
-    // a card table's memory region within which three objects are being allocated by three different threads:
-    //
-    // objects being "concurrently" allocated:
-    //    [-----a------][-----b-----][--------------c------------------]
-    //            [---- card table memory range --------------]
-    //
-    // Before any objects are allocated, this card's memory range holds no objects.  Note that:
-    //   allocation of object a wants to set the has-object, first-start, and last-start attributes of the preceding card region.
-    //   allocation of object b wants to set the has-object, first-start, and last-start attributes of this card region.
-    //   allocation of object c also wants to set the has-object, first-start, and last-start attributes of this card region.
-    //
-    // The thread allocating b and the thread allocating c can "race" in various ways, resulting in confusion, such as last-start
-    // representing object b while first-start represents object c.  This is why we need to require all register_object()
-    // invocations to be "mutually exclusive" with respect to each card's memory range.
-    ShenandoahHeap::heap()->card_scan()->register_object(result);
-  }
-  return result;
+  return _free_set->allocate(req, in_new_region);
 }
 
 HeapWord* ShenandoahHeap::mem_allocate(size_t size,

--- a/src/hotspot/share/gc/shenandoah/shenandoahHeap.hpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahHeap.hpp
@@ -673,6 +673,7 @@ private:
   ShenandoahEvacOOMHandler _oom_evac_handler;
 
   inline oop try_evacuate_object(oop src, Thread* thread, ShenandoahHeapRegion* from_region, ShenandoahRegionAffiliation target_gen);
+  void handle_old_evacuation(HeapWord* obj, size_t words, bool promotion);
 
 public:
   static address in_cset_fast_test_addr();

--- a/src/hotspot/share/gc/shenandoah/shenandoahHeap.hpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahHeap.hpp
@@ -223,7 +223,6 @@ private:
   shenandoah_padding(0);
   volatile size_t _used;
   volatile size_t _committed;
-  volatile size_t _bytes_allocated_since_gc_start;
   shenandoah_padding(1);
 
   static size_t young_generation_capacity(size_t total_capacity);
@@ -237,9 +236,7 @@ public:
 
   void increase_committed(size_t bytes);
   void decrease_committed(size_t bytes);
-  void increase_allocated(size_t bytes);
 
-  size_t bytes_allocated_since_gc_start();
   void reset_bytes_allocated_since_gc_start();
 
   size_t min_capacity()      const;

--- a/src/hotspot/share/gc/shenandoah/shenandoahHeap.hpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahHeap.hpp
@@ -461,6 +461,7 @@ public:
   ShenandoahYoungGeneration* young_generation()  const { return _young_generation;  }
   ShenandoahGeneration*      global_generation() const { return _global_generation; }
   ShenandoahGeneration*      old_generation()    const { return _old_generation;    }
+  ShenandoahGeneration*      generation_for(ShenandoahRegionAffiliation affiliation) const;
 
   ShenandoahCollectorPolicy* shenandoah_policy() const { return _shenandoah_policy; }
   ShenandoahMode*            mode()              const { return _gc_mode;           }

--- a/src/hotspot/share/gc/shenandoah/shenandoahHeap.inline.hpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahHeap.inline.hpp
@@ -311,10 +311,6 @@ inline HeapWord* ShenandoahHeap::allocate_from_plab(Thread* thread, size_t size)
   if (obj == NULL) {
     obj = allocate_from_plab_slow(thread, size);
   }
-
-  if (mode()->is_generational() && obj != NULL) {
-    ShenandoahHeap::heap()->card_scan()->register_object_wo_lock(obj);
-  }
   return obj;
 }
 

--- a/src/hotspot/share/gc/shenandoah/shenandoahHeap.inline.hpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahHeap.inline.hpp
@@ -393,7 +393,7 @@ inline oop ShenandoahHeap::try_evacuate_object(oop p, Thread* thread, Shenandoah
 
   if (copy == NULL) {
     if (target_gen == OLD_GENERATION && from_region->affiliation() == YOUNG_GENERATION) {
-      // Indicate that a promotion attempt failed.
+      // TODO: Inform old generation heuristic of promotion failure
       return NULL;
     }
 
@@ -408,35 +408,19 @@ inline oop ShenandoahHeap::try_evacuate_object(oop p, Thread* thread, Shenandoah
   Copy::aligned_disjoint_words(cast_from_oop<HeapWord*>(p), copy, size);
 
   oop copy_val = cast_to_oop(copy);
-  if (target_gen == YOUNG_GENERATION) {
-    // Increment the age in young copies, absorbing region age.
-    // (Only retired regions will have more than zero age to pass along.)
-
-    ShenandoahHeap::increase_object_age(copy_val, from_region->age() + 1);
-
-    // Note that p may have been forwarded by another thread,
-    // anywhere between here and the check above for forwarding.
-    // In that case try_update_forwardee() below will not be successful
-    // and the increment we just performed will simply be forgotten,
-    // but it will have succeeded in said other thread.
-  }
 
   // Try to install the new forwarding pointer.
   oop result = ShenandoahForwarding::try_update_forwardee(p, copy_val);
   if (result == copy_val) {
-    if (target_gen == OLD_GENERATION) {
-      if (alloc_from_lab) {
-        card_scan()->register_object_wo_lock(copy);
-      }
-      // else, allocate_memory_under_lock() has already registered the object
-
-      // Mark the entire range of the evacuated object as dirty.  At next remembered set scan,
-      // we will clear dirty bits that do not hold interesting pointers.  It's more efficient to
-      // do this in batch, in a background GC thread than to try to carefully dirty only cards
-      // that hold interesting pointers right now.
-      card_scan()->mark_range_as_dirty(copy, size);
-    }
     // Successfully evacuated. Our copy is now the public one!
+    if (target_gen == OLD_GENERATION) {
+      handle_old_evacuation(copy, size, from_region->is_young());
+    } else if (target_gen == YOUNG_GENERATION) {
+      ShenandoahHeap::increase_object_age(copy_val, from_region->age() + 1);
+    } else {
+      ShouldNotReachHere();
+    }
+
     shenandoah_assert_correct(NULL, copy_val);
     return copy_val;
   }  else {


### PR DESCRIPTION
The member `_bytes_allocated_since_last_gc` has been moved into the `ShenandoahGeneration` abstraction and is updated accordingly. Evacuations into the old generation (i.e., promotion) are counted as allocations against the old generation. Promotion of entire regions is not recorded in the promotion rate.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

### Reviewers
 * [Roman Kennke](https://openjdk.java.net/census#rkennke) (@rkennke - **Reviewer**)
 * [Kelvin Nilsen](https://openjdk.java.net/census#kdnilsen) (@kdnilsen - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/shenandoah pull/70/head:pull/70` \
`$ git checkout pull/70`

Update a local copy of the PR: \
`$ git checkout pull/70` \
`$ git pull https://git.openjdk.java.net/shenandoah pull/70/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 70`

View PR using the GUI difftool: \
`$ git pr show -t 70`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/shenandoah/pull/70.diff">https://git.openjdk.java.net/shenandoah/pull/70.diff</a>

</details>
