### PR TITLE
Fix failing jtreg tests

### DIFF
--- a/src/hotspot/share/gc/shenandoah/shenandoahControlThread.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahControlThread.cpp
@@ -47,7 +47,6 @@
 #include "memory/metaspaceStats.hpp"
 #include "memory/universe.hpp"
 #include "runtime/atomic.hpp"
-#include "shenandoahOldGC.hpp"
 
 ShenandoahControlThread::ShenandoahControlThread() :
   ConcurrentGCThread(),
@@ -230,6 +229,8 @@ void ShenandoahControlThread::run_service() {
     assert (!gc_requested || cause != GCCause::_last_gc_cause, "GC cause should be set");
 
     if (gc_requested) {
+      // GC is starting, bump the internal ID
+      update_gc_id();
 
       heap->reset_bytes_allocated_since_gc_start();
 
@@ -272,9 +273,6 @@ void ShenandoahControlThread::run_service() {
           }
         }
       }
-
-      // GC is finished, bump the internal ID before notifying waiters.
-      update_gc_id();
 
       // If this was the requested GC cycle, notify waiters about it
       if (explicit_gc_requested || implicit_gc_requested) {

--- a/src/hotspot/share/gc/shenandoah/shenandoahControlThread.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahControlThread.cpp
@@ -36,6 +36,7 @@
 #include "gc/shenandoah/shenandoahMark.inline.hpp"
 #include "gc/shenandoah/shenandoahMonitoringSupport.hpp"
 #include "gc/shenandoah/shenandoahOopClosures.inline.hpp"
+#include "gc/shenandoah/shenandoahOldGC.hpp"
 #include "gc/shenandoah/shenandoahRootProcessor.inline.hpp"
 #include "gc/shenandoah/shenandoahUtils.hpp"
 #include "gc/shenandoah/shenandoahVMOperations.hpp"

--- a/test/hotspot/jtreg/gc/shenandoah/generational/TestCLIModeGenerational.java
+++ b/test/hotspot/jtreg/gc/shenandoah/generational/TestCLIModeGenerational.java
@@ -31,7 +31,7 @@ import sun.hotspot.WhiteBox;
  * @summary Test argument processing for -XX:+ShenandoahGCMode=generational.
  * @library /testlibrary /test/lib /
  * @build sun.hotspot.WhiteBox
- * @run driver ClassFileInstaller sun.hotspot.WhiteBox
+ * @run driver jdk.test.lib.helpers.ClassFileInstaller sun.hotspot.WhiteBox
  * @run main/othervm -Xbootclasspath/a:.
  *      -XX:+IgnoreUnrecognizedVMOptions
  *      -XX:+UnlockDiagnosticVMOptions -XX:+WhiteBoxAPI

--- a/test/hotspot/jtreg/gc/shenandoah/generational/TestConcurrentEvac.java
+++ b/test/hotspot/jtreg/gc/shenandoah/generational/TestConcurrentEvac.java
@@ -28,15 +28,7 @@ import sun.hotspot.WhiteBox;
 import java.util.Random;
 import java.util.HashMap;
 
-/* WARNING!
- *  As of the date on which this test was added into the jtreg suite, heuristic
- *  of old-gen GC passes is very simplistic.  A further shortcoming of the
- *  Generational Shenandoah as of introduction of this test is that it does
- *  not currently support full GC.  If garbage collection falls behind mutator
- *  allocations, a full GC will be triggered and Generational Shenandoah will
- *  abort itself with an assertion error.  Both of these limitations will be
- *  addressed in future releases of Generational Shenandoah.
- *
+/*
  *  To avoid the risk of false regressions identified by this test, the heap
  *  size is set artificially high.  Though this test is known to run reliably
  *  in 66 MB heap, the heap size for this test run is currently set to 256 MB.
@@ -48,7 +40,7 @@ import java.util.HashMap;
  * @summary Confirm that card marking and remembered set scanning do not crash.
  * @library /testlibrary /test/lib /
  * @build sun.hotspot.WhiteBox
- * @run driver ClassFileInstaller sun.hotspot.WhiteBox
+ * @run driver jdk.test.lib.helpers.ClassFileInstaller sun.hotspot.WhiteBox
  * @run main/othervm -Xbootclasspath/a:.
  *      -Xms256m -Xmx256m
  *      -XX:+IgnoreUnrecognizedVMOptions

--- a/test/hotspot/jtreg/gc/shenandoah/generational/TestSimpleGenerational.java
+++ b/test/hotspot/jtreg/gc/shenandoah/generational/TestSimpleGenerational.java
@@ -33,18 +33,13 @@ import java.util.Random;
  * @summary Confirm that card marking and remembered set scanning do not crash.
  * @library /testlibrary /test/lib /
  * @build sun.hotspot.WhiteBox
- * @run driver ClassFileInstaller sun.hotspot.WhiteBox
+ * @run driver jdk.test.lib.helpers.ClassFileInstaller sun.hotspot.WhiteBox
  * @run main/othervm -Xbootclasspath/a:.
  *      -XX:+IgnoreUnrecognizedVMOptions
  *      -XX:+UnlockDiagnosticVMOptions -XX:+WhiteBoxAPI
  *      -XX:+UseShenandoahGC -XX:ShenandoahGCMode=generational
  *      gc.shenandoah.generational.TestSimpleGenerational
  */
-
-/* This used to be part of the run command, but caused problems.
- *      -XX:+UnlockDiagnosticVMOptions -XX:+WhiteBoxAPI
- */
-
 public class TestSimpleGenerational {
   private static WhiteBox wb = WhiteBox.getWhiteBox();
   static private final int SeedForRandom = 46;


### PR DESCRIPTION
With these (minor) changes, generational Shenandoah passes the full suite of Shenandoah jtreg tests.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

### Reviewers
 * [Kelvin Nilsen](https://openjdk.java.net/census#kdnilsen) (@kdnilsen - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/shenandoah pull/73/head:pull/73` \
`$ git checkout pull/73`

Update a local copy of the PR: \
`$ git checkout pull/73` \
`$ git pull https://git.openjdk.java.net/shenandoah pull/73/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 73`

View PR using the GUI difftool: \
`$ git pr show -t 73`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/shenandoah/pull/73.diff">https://git.openjdk.java.net/shenandoah/pull/73.diff</a>

</details>
