### PR TITLE
Only register retired plab waste in old regions

### DIFF
--- a/src/hotspot/share/gc/shenandoah/shenandoahHeap.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahHeap.cpp
@@ -927,7 +927,7 @@ void ShenandoahHeap::retire_plab(PLAB* plab) {
     size_t waste = plab->waste();
     HeapWord* top = plab->top();
     plab->retire();
-    if (top != NULL && plab->waste() > waste) {
+    if (top != NULL && plab->waste() > waste && is_in_old(top)) {
       // If retiring the plab created a filler object, then we
       // need to register it with our card scanner so it can
       // safely walk the region backing the plab.


### PR DESCRIPTION
This is a follow up to [PR 74](https://github.com/openjdk/shenandoah/pull/74) in which we register filler objects from retired gclabs. This should _only_ be done if the plab was in an old region. Registering young objects in the remembered set confuses the verifier.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

### Reviewers
 * [Kelvin Nilsen](https://openjdk.java.net/census#kdnilsen) (@kdnilsen - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/shenandoah pull/77/head:pull/77` \
`$ git checkout pull/77`

Update a local copy of the PR: \
`$ git checkout pull/77` \
`$ git pull https://git.openjdk.java.net/shenandoah pull/77/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 77`

View PR using the GUI difftool: \
`$ git pr show -t 77`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/shenandoah/pull/77.diff">https://git.openjdk.java.net/shenandoah/pull/77.diff</a>

</details>
