### PR TITLE
Coalesce and fill unmarked objects during global degenerated cycle

### DIFF
--- a/src/hotspot/share/gc/shenandoah/shenandoahConcurrentGC.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahConcurrentGC.cpp
@@ -72,20 +72,6 @@ public:
   }
 };
 
-class ShenandoahGlobalCoalesceAndFill : public ShenandoahHeapRegionClosure {
- public:
-  virtual void heap_region_do(ShenandoahHeapRegion* region) override {
-    // old region is not in the collection set and was not immediately trashed
-    if (region->is_old() && region->is_active() && !region->is_humongous()) {
-      region->oop_fill_and_coalesce();
-    }
-  }
-
-  virtual bool is_thread_safe() override {
-    return true;
-  }
-};
-
 ShenandoahConcurrentGC::ShenandoahConcurrentGC(ShenandoahGeneration* generation, bool do_old_gc_bootstrap) :
   _mark(generation),
   _degen_point(ShenandoahDegenPoint::_degenerated_unset),
@@ -1068,9 +1054,7 @@ void ShenandoahConcurrentGC::op_cleanup_complete() {
 }
 
 void ShenandoahConcurrentGC::op_global_coalesce_and_fill() {
-  ShenandoahHeap* const heap = ShenandoahHeap::heap();
-  ShenandoahGlobalCoalesceAndFill coalesce;
-  heap->parallel_heap_region_iterate(&coalesce);
+  ShenandoahHeap::heap()->coalesce_and_fill_old_regions();
 }
 
 bool ShenandoahConcurrentGC::check_cancellation_and_abort(ShenandoahDegenPoint point) {

--- a/src/hotspot/share/gc/shenandoah/shenandoahDegeneratedGC.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahDegeneratedGC.cpp
@@ -134,6 +134,10 @@ void ShenandoahDegenGC::op_degenerated() {
 
       op_cleanup_early();
 
+      if (heap->mode()->is_generational() && _generation->generation_mode() == GLOBAL) {
+        op_global_coalesce_and_fill();
+      }
+
     case _degenerated_evac:
       // If heuristics thinks we should do the cycle, this flag would be set,
       // and we can do evacuation. Otherwise, it would be the shortcut cycle.
@@ -280,6 +284,10 @@ void ShenandoahDegenGC::op_prepare_evacuation() {
 
 void ShenandoahDegenGC::op_cleanup_early() {
   ShenandoahHeap::heap()->recycle_trash();
+}
+
+void ShenandoahDegenGC::op_global_coalesce_and_fill() {
+  ShenandoahHeap::heap()->coalesce_and_fill_old_regions();
 }
 
 void ShenandoahDegenGC::op_evacuate() {

--- a/src/hotspot/share/gc/shenandoah/shenandoahDegeneratedGC.hpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahDegeneratedGC.hpp
@@ -52,6 +52,7 @@ private:
   void op_finish_mark();
   void op_prepare_evacuation();
   void op_cleanup_early();
+  void op_global_coalesce_and_fill();
   void op_evacuate();
   void op_init_updaterefs();
   void op_updaterefs();

--- a/src/hotspot/share/gc/shenandoah/shenandoahHeap.hpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahHeap.hpp
@@ -707,6 +707,7 @@ public:
   void mark_card_as_dirty(void* location);
   void retire_plab(PLAB* plab);
   void cancel_mixed_collections();
+  void coalesce_and_fill_old_regions();
 
 // ---------- Helper functions
 //


### PR DESCRIPTION
This is necessary to prevent the remembered set scan from iterating over garbage. We already do this for _concurrent_ global cycles, but it was missing from _degenerated _ global cycles.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

### Reviewers
 * [Kelvin Nilsen](https://openjdk.java.net/census#kdnilsen) (@kdnilsen - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/shenandoah pull/78/head:pull/78` \
`$ git checkout pull/78`

Update a local copy of the PR: \
`$ git checkout pull/78` \
`$ git pull https://git.openjdk.java.net/shenandoah pull/78/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 78`

View PR using the GUI difftool: \
`$ git pr show -t 78`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/shenandoah/pull/78.diff">https://git.openjdk.java.net/shenandoah/pull/78.diff</a>

</details>
