### PR TITLE
Improve handling of promotion and old generation evacuation failures

### DIFF
--- a/src/hotspot/share/gc/shenandoah/heuristics/shenandoahOldHeuristics.hpp
+++ b/src/hotspot/share/gc/shenandoah/heuristics/shenandoahOldHeuristics.hpp
@@ -66,9 +66,11 @@ private:
   // This can be the 'static' or 'adaptive' heuristic.
   ShenandoahHeuristics* _trigger_heuristic;
 
+  // Flag is set when promotion failure is detected (by gc thread), cleared when old generation collection begins (by control thread)
+  volatile bool _promotion_failed;
+
   // Prepare for evacuation of old-gen regions by capturing the mark results of a recently completed concurrent mark pass.
   void prepare_for_old_collections();
-
 
  protected:
   virtual void choose_collection_set_from_regiondata(ShenandoahCollectionSet* set, RegionData* data, size_t data_size,
@@ -108,11 +110,14 @@ public:
   // end of the array.
   void get_coalesce_and_fill_candidates(ShenandoahHeapRegion** buffer);
 
-  bool should_defer_gc();
-
   // If a GLOBAL gc occurs, it will collect the entire heap which invalidates any collection candidates being
   // held by this heuristic for supplying mixed collections.
   void abandon_collection_candidates();
+
+  // Notify the heuristic of promotion failures. The promotion attempt will be skipped and the object will
+  // be evacuated into the young generation. The collection should complete normally, but we want to schedule
+  // an old collection as soon as possible.
+  void handle_promotion_failure();
 
   virtual void record_cycle_start() override;
 

--- a/src/hotspot/share/gc/shenandoah/shenandoahHeap.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahHeap.cpp
@@ -824,6 +824,12 @@ void ShenandoahHeap::handle_old_evacuation(HeapWord* obj, size_t words, bool pro
   }
 }
 
+void ShenandoahHeap::handle_old_evacuation_failure() {
+  if (_old_gen_oom_evac.try_set()) {
+    log_info(gc)("Old gen evac failure.");
+  }
+}
+
 void ShenandoahHeap::handle_promotion_failure() {
   old_heuristics()->handle_promotion_failure();
 }

--- a/src/hotspot/share/gc/shenandoah/shenandoahHeap.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahHeap.cpp
@@ -1078,9 +1078,6 @@ HeapWord* ShenandoahHeap::allocate_memory(ShenandoahAllocRequest& req) {
         pacer()->unpace_for_alloc(pacer_epoch, requested - actual);
       }
     } else {
-      if (req.is_old()) {
-        old_generation()->increase_allocated(actual_bytes);
-      }
       increase_used(actual_bytes);
     }
   }

--- a/src/hotspot/share/gc/shenandoah/shenandoahHeap.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahHeap.cpp
@@ -1078,6 +1078,9 @@ HeapWord* ShenandoahHeap::allocate_memory(ShenandoahAllocRequest& req) {
         pacer()->unpace_for_alloc(pacer_epoch, requested - actual);
       }
     } else {
+      if (req.is_old()) {
+        old_generation()->increase_allocated(actual_bytes);
+      }
       increase_used(actual_bytes);
     }
   }

--- a/src/hotspot/share/gc/shenandoah/shenandoahHeap.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahHeap.cpp
@@ -824,6 +824,10 @@ void ShenandoahHeap::handle_old_evacuation(HeapWord* obj, size_t words, bool pro
   }
 }
 
+void ShenandoahHeap::handle_promotion_failure() {
+  old_heuristics()->handle_promotion_failure();
+}
+
 HeapWord* ShenandoahHeap::allocate_from_gclab_slow(Thread* thread, size_t size) {
   // New object should fit the GCLAB size
   size_t min_size = MAX2(size, PLAB::min_size());

--- a/src/hotspot/share/gc/shenandoah/shenandoahHeap.hpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahHeap.hpp
@@ -668,9 +668,11 @@ public:
 private:
   ShenandoahCollectionSet* _collection_set;
   ShenandoahEvacOOMHandler _oom_evac_handler;
+  ShenandoahSharedFlag _old_gen_oom_evac;
 
   inline oop try_evacuate_object(oop src, Thread* thread, ShenandoahHeapRegion* from_region, ShenandoahRegionAffiliation target_gen);
   void handle_old_evacuation(HeapWord* obj, size_t words, bool promotion);
+  void handle_old_evacuation_failure();
   void handle_promotion_failure();
 
 public:
@@ -691,6 +693,8 @@ public:
   // Call before/after evacuation.
   inline void enter_evacuation(Thread* t);
   inline void leave_evacuation(Thread* t);
+
+  inline bool clear_old_evacuation_failure();
 
 // ---------- Generational support
 //

--- a/src/hotspot/share/gc/shenandoah/shenandoahHeap.hpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahHeap.hpp
@@ -671,6 +671,7 @@ private:
 
   inline oop try_evacuate_object(oop src, Thread* thread, ShenandoahHeapRegion* from_region, ShenandoahRegionAffiliation target_gen);
   void handle_old_evacuation(HeapWord* obj, size_t words, bool promotion);
+  void handle_promotion_failure();
 
 public:
   static address in_cset_fast_test_addr();

--- a/src/hotspot/share/gc/shenandoah/shenandoahHeap.inline.hpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahHeap.inline.hpp
@@ -389,7 +389,8 @@ inline oop ShenandoahHeap::try_evacuate_object(oop p, Thread* thread, Shenandoah
 
   if (copy == NULL) {
     if (target_gen == OLD_GENERATION && from_region->affiliation() == YOUNG_GENERATION) {
-      // TODO: Inform old generation heuristic of promotion failure
+      assert(mode()->is_generational(), "Should only be here in generational mode.");
+      handle_promotion_failure();
       return NULL;
     }
 

--- a/src/hotspot/share/gc/shenandoah/shenandoahHeap.inline.hpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahHeap.inline.hpp
@@ -315,7 +315,7 @@ inline HeapWord* ShenandoahHeap::allocate_from_plab(Thread* thread, size_t size)
 }
 
 inline oop ShenandoahHeap::evacuate_object(oop p, Thread* thread) {
-  assert(thread == Thread::current(), "Why would this be a different thread?");
+  assert(thread == Thread::current(), "Expected thread parameter to be current thread.");
   if (ShenandoahThreadLocalData::is_oom_during_evac(thread)) {
     // This thread went through the OOM during evac protocol and it is safe to return
     // the forward pointer. It must not attempt to evacuate any more.

--- a/src/hotspot/share/gc/shenandoah/shenandoahHeap.inline.hpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahHeap.inline.hpp
@@ -315,7 +315,8 @@ inline HeapWord* ShenandoahHeap::allocate_from_plab(Thread* thread, size_t size)
 }
 
 inline oop ShenandoahHeap::evacuate_object(oop p, Thread* thread) {
-  if (ShenandoahThreadLocalData::is_oom_during_evac(Thread::current())) {
+  assert(thread == Thread::current(), "Why would this be a different thread?");
+  if (ShenandoahThreadLocalData::is_oom_during_evac(thread)) {
     // This thread went through the OOM during evac protocol and it is safe to return
     // the forward pointer. It must not attempt to evacuate any more.
     return ShenandoahBarrierSet::resolve_forwarded(p);
@@ -388,10 +389,17 @@ inline oop ShenandoahHeap::try_evacuate_object(oop p, Thread* thread, Shenandoah
 #endif
 
   if (copy == NULL) {
-    if (target_gen == OLD_GENERATION && from_region->affiliation() == YOUNG_GENERATION) {
+    if (target_gen == OLD_GENERATION) {
       assert(mode()->is_generational(), "Should only be here in generational mode.");
-      handle_promotion_failure();
-      return NULL;
+      if (from_region->is_young()) {
+        // Signal that promotion failed. Will evacuate this old object somewhere in young gen.
+        handle_promotion_failure();
+        return NULL;
+      } else {
+        // Remember that evacuation to old gen failed. We'll want to trigger a full gc to recover from this
+        // after the evacuation threads have finished.
+        handle_old_evacuation_failure();
+      }
     }
 
     control_thread()->handle_alloc_failure_evac(size);
@@ -465,6 +473,10 @@ void ShenandoahHeap::increase_object_age(oop obj, uint additional_age) {
   } else {
     obj->set_mark(w);
   }
+}
+
+inline bool ShenandoahHeap::clear_old_evacuation_failure() {
+  return _old_gen_oom_evac.try_unset();
 }
 
 inline bool ShenandoahHeap::is_old(oop obj) const {


### PR DESCRIPTION
There are two changes here:
 * A promotion failure will cause the old generation heuristic to request an old collection.
 * An evacuation failure in the old generation will trigger a full collection.

Minor change:
 * If an allocation failure has been detected, the control thread will not sleep at the bottom of its loop.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

### Reviewers
 * [Kelvin Nilsen](https://openjdk.java.net/census#kdnilsen) (@kdnilsen - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/shenandoah pull/81/head:pull/81` \
`$ git checkout pull/81`

Update a local copy of the PR: \
`$ git checkout pull/81` \
`$ git pull https://git.openjdk.java.net/shenandoah pull/81/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 81`

View PR using the GUI difftool: \
`$ git pr show -t 81`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/shenandoah/pull/81.diff">https://git.openjdk.java.net/shenandoah/pull/81.diff</a>

</details>
