### PR TITLE
Remove vestigial command line options and removed unused code

### DIFF
--- a/src/hotspot/share/gc/shenandoah/shenandoah_globals.hpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoah_globals.hpp
@@ -405,10 +405,6 @@
           "Fix references with load reference barrier. Disabling this "     \
           "might degrade performance.")                                     \
                                                                             \
-  product(bool, ShenandoahUseSimpleCardScanning, false, DIAGNOSTIC,         \
-          "Testing: use simplified, very inefficient but much less complex" \
-          " card table scanning.")                                          \
-                                                                            \
   product(uintx, ShenandoahTenuredRegionUsageBias, 192, EXPERIMENTAL,       \
           "The collection set is comprised of heap regions that contain "   \
           "the greatest amount of garbage.  "                               \
@@ -428,10 +424,6 @@
                                                                             \
   product(bool, ShenandoahPromoteTenuredObjects, true, DIAGNOSTIC,          \
           "Turn on/off evacuating individual tenured young objects "        \
-          " to the old generation.")                                        \
-                                                                            \
-  product(bool, ShenandoahPromoteTenuredRegions, true, DIAGNOSTIC,          \
-          "Turn on/off transitioning tenured young regions "                \
           " to the old generation.")                                        \
                                                                             \
   product(bool, ShenandoahAllowOldMarkingPreemption, true, DIAGNOSTIC,      \


### PR DESCRIPTION
* Removed ShenandoahUseSimpleCardScanning and ShenandoahPromoteTenuredRegions command line options
* Removed preprocessor directives FAST_REMEMBERED_SET_SCANNING and CROSSING_OFFSETS_NO_LONGER_NEEDED

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

### Reviewers
 * [Roman Kennke](https://openjdk.java.net/census#rkennke) (@rkennke - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/shenandoah pull/85/head:pull/85` \
`$ git checkout pull/85`

Update a local copy of the PR: \
`$ git checkout pull/85` \
`$ git pull https://git.openjdk.java.net/shenandoah pull/85/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 85`

View PR using the GUI difftool: \
`$ git pr show -t 85`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/shenandoah/pull/85.diff">https://git.openjdk.java.net/shenandoah/pull/85.diff</a>

</details>
