### PR TITLE
Replace 'HEY!' comments with TODO and remove unnecessary usages

### DIFF
--- a/src/hotspot/share/gc/shenandoah/shenandoahBarrierSet.inline.hpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahBarrierSet.inline.hpp
@@ -417,7 +417,7 @@ void ShenandoahBarrierSet::arraycopy_barrier(T* src, T* dst, size_t count) {
 
   if (_heap->mode()->is_generational()) {
     assert(ShenandoahSATBBarrier, "Generational mode assumes SATB mode");
-    // HEY! Could we optimize here by checking that dst is in an old region?
+    // TODO: Could we optimize here by checking that dst is in an old region?
     if ((gc_state & ShenandoahHeap::OLD_MARKING) != 0) {
       // Note that we can't do the arraycopy marking using the 'src' array when
       // SATB mode is enabled (so we can't do this as part of the iteration for

--- a/src/hotspot/share/gc/shenandoah/shenandoahControlThread.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahControlThread.cpp
@@ -102,11 +102,10 @@ void ShenandoahControlThread::run_service() {
 
   ShenandoahCollectorPolicy* policy = heap->shenandoah_policy();
 
-  // HEY! heuristics are notified of allocation failures here and other outcomes
+  // Heuristics are notified of allocation failures here and other outcomes
   // of the cycle. They're also used here to control whether the Nth consecutive
-  // degenerated cycle should be 'promoted' to a full cycle. This changes the
-  // threading model for them somewhat, as they are now evaluated on a separate
-  // thread.
+  // degenerated cycle should be 'promoted' to a full cycle. The decision to
+  // trigger a cycle or not is evaluated on the regulator thread.
   ShenandoahHeuristics* global_heuristics = heap->global_generation()->heuristics();
   while (!in_graceful_shutdown() && !should_terminate()) {
     // Figure out if we have pending requests.

--- a/src/hotspot/share/gc/shenandoah/shenandoahHeap.inline.hpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahHeap.inline.hpp
@@ -573,8 +573,6 @@ inline void ShenandoahHeap::marked_object_iterate(ShenandoahHeapRegion* region, 
   assert(! region->is_humongous_continuation(), "no humongous continuation regions here");
 
   ShenandoahMarkingContext* const ctx = marking_context();
-  // HEY! All callers (at the time of this writing) have already asserted the mark context is complete.
-  // assert(ctx->is_complete(), "sanity");
 
   HeapWord* tams = ctx->top_at_mark_start(region);
 

--- a/src/hotspot/share/gc/shenandoah/shenandoahMark.inline.hpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahMark.inline.hpp
@@ -58,7 +58,7 @@ template <class T, StringDedupMode STRING_DEDUP>
 void ShenandoahMark::do_task(ShenandoahObjToScanQueue* q, T* cl, ShenandoahLiveData* live_data, StringDedup::Requests* const req, ShenandoahMarkTask* task) {
   oop obj = task->obj();
 
-  // HEY! This will push array chunks into the mark queue with no regard for
+  // TODO: This will push array chunks into the mark queue with no regard for
   // generations. I don't think it will break anything, but the young generation
   // scan might end up processing some old generation array chunks.
 

--- a/src/hotspot/share/gc/shenandoah/shenandoahMarkClosures.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahMarkClosures.cpp
@@ -61,12 +61,11 @@ void ShenandoahFinalMarkUpdateRegionStateClosure::heap_region_do(ShenandoahHeapR
     }
 
     if (ShenandoahHeap::heap()->mode()->is_generational()) {
-      // HEY! Allocations move the watermark when top moves, however compacting
+      // Allocations move the watermark when top moves, however compacting
       // objects will sometimes lower top beneath the watermark, after which,
       // attempts to read the watermark will assert out (watermark should not be
-      // higher than top). I think the right way™ to check for new allocations
-      // is to compare top with the TAMS as is done earlier in this function.
-      // if (r->top() != r->get_update_watermark()) {
+      // higher than top). The right way™ to check for new allocations is to compare
+      // top with the TAMS as is done earlier in this function.
       if (top > tams) {
         // There have been allocations in this region since the start of the cycle.
         // Any objects new to this region must not assimilate elevated age.

--- a/src/hotspot/share/gc/shenandoah/shenandoahScanRemembered.hpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahScanRemembered.hpp
@@ -538,7 +538,7 @@ public:
 
   ShenandoahCardCluster(RememberedSet *rs) {
     _rs = rs;
-    // HEY!  We don't really need object_starts entries for every card entry.  We only need these for
+    // TODO: We don't really need object_starts entries for every card entry.  We only need these for
     // the card entries that correspond to old-gen memory.  But for now, let's be quick and dirty.
     object_starts = (uint16_t *) malloc(rs->total_cards() * sizeof(uint16_t));
     if (object_starts == NULL)
@@ -875,7 +875,7 @@ public:
     delete _scc;
   }
 
-  // HEY!  We really don't want to share all of these APIs with arbitrary consumers of the ShenandoahScanRemembered abstraction.
+  // TODO:  We really don't want to share all of these APIs with arbitrary consumers of the ShenandoahScanRemembered abstraction.
   // But in the spirit of quick and dirty for the time being, I'm going to go ahead and publish everything for right now.  Some
   // of existing code already depends on having access to these services (because existing code has not been written to honor
   // full abstraction of remembered set scanning.  In the not too distant future, we want to try to make most, if not all, of


### PR DESCRIPTION
Replace idiosyncratic `HEY!` comments with `TODO` and remove it from places where it is no longer necessary. No code changes here, just changes in comments.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

### Reviewers
 * [Kelvin Nilsen](https://openjdk.java.net/census#kdnilsen) (@kdnilsen - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/shenandoah pull/87/head:pull/87` \
`$ git checkout pull/87`

Update a local copy of the PR: \
`$ git checkout pull/87` \
`$ git pull https://git.openjdk.java.net/shenandoah pull/87/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 87`

View PR using the GUI difftool: \
`$ git pr show -t 87`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/shenandoah/pull/87.diff">https://git.openjdk.java.net/shenandoah/pull/87.diff</a>

</details>
