### PR TITLE
Do not coalesce dead objects in global cycle if GC was cancelled

### DIFF
--- a/src/hotspot/share/gc/shenandoah/shenandoahConcurrentGC.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahConcurrentGC.cpp
@@ -156,7 +156,7 @@ bool ShenandoahConcurrentGC::collect(GCCause::Cause cause) {
     entry_strong_roots();
   }
 
-  if (heap->mode()->is_generational() && _generation->generation_mode() == GLOBAL) {
+  if (!heap->cancelled_gc() && heap->mode()->is_generational() && _generation->generation_mode() == GLOBAL) {
     entry_global_coalesce_and_fill();
   }
 


### PR DESCRIPTION
Attempting to coalesce and fill with an incomplete mark context triggers an assert in debug builds (and may cause problems for a release build).