### PR TITLE
Reset coalesce and fill boundary during global collect

### DIFF
--- a/src/hotspot/share/gc/shenandoah/shenandoahHeap.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahHeap.cpp
@@ -966,6 +966,10 @@ void ShenandoahHeap::coalesce_and_fill_old_regions() {
     virtual void heap_region_do(ShenandoahHeapRegion* region) override {
       // old region is not in the collection set and was not immediately trashed
       if (region->is_old() && region->is_active() && !region->is_humongous()) {
+        // Reset the coalesce and fill boundary because this is a global collect
+        // and cannot be preempted by young collects. We want to be sure the entire
+        // region is coalesced here and does not resume from a previously interrupted
+        // or completed coalescing.
         region->reset_coalesce_and_fill_boundary();
         region->oop_fill_and_coalesce();
       }


### PR DESCRIPTION
Normally, this happens during cset selection for the old generation. It also needs to happen for coalesce and fill at the end of global collections or objects may not be filled.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

### Reviewers
 * [Kelvin Nilsen](https://openjdk.java.net/census#kdnilsen) (@kdnilsen - Committer) ⚠️ Review applies to 50d110ba194e77a59e397c9bd2848e6084021d96


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/shenandoah pull/90/head:pull/90` \
`$ git checkout pull/90`

Update a local copy of the PR: \
`$ git checkout pull/90` \
`$ git pull https://git.openjdk.java.net/shenandoah pull/90/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 90`

View PR using the GUI difftool: \
`$ git pr show -t 90`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/shenandoah/pull/90.diff">https://git.openjdk.java.net/shenandoah/pull/90.diff</a>

</details>
