### PR TITLE
Degenerate to young cycles for out of cycle allocation failures

### DIFF
--- a/src/hotspot/share/gc/shenandoah/shenandoahConcurrentGC.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahConcurrentGC.cpp
@@ -113,7 +113,7 @@ bool ShenandoahConcurrentGC::collect(GCCause::Cause cause) {
 
     // Concurrent mark roots
     entry_mark_roots();
-    if (check_cancellation_and_abort(ShenandoahDegenPoint::_degenerated_outside_cycle)) return false;
+    if (check_cancellation_and_abort(ShenandoahDegenPoint::_degenerated_roots)) return false;
 
     // Continue concurrent mark
     entry_mark();

--- a/src/hotspot/share/gc/shenandoah/shenandoahConcurrentGC.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahConcurrentGC.cpp
@@ -107,6 +107,7 @@ bool ShenandoahConcurrentGC::collect(GCCause::Cause cause) {
 
     // Concurrent remembered set scanning
     if (_generation->generation_mode() == YOUNG) {
+      ShenandoahConcurrentPhase gc_phase("Concurrent remembered set scanning", ShenandoahPhaseTimings::init_scan_rset);
       _generation->scan_remembered_set();
     }
 

--- a/src/hotspot/share/gc/shenandoah/shenandoahControlThread.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahControlThread.cpp
@@ -135,7 +135,7 @@ void ShenandoahControlThread::run_service() {
       _degen_point = ShenandoahGC::_degenerated_outside_cycle;
 
       if (degen_point == ShenandoahGC::_degenerated_outside_cycle) {
-        _degen_generation = heap->global_generation();
+        _degen_generation = heap->mode()->is_generational() ? heap->young_generation() : heap->global_generation();
       } else {
         assert(_degen_generation != NULL, "Need to know which generation to resume.");
       }

--- a/src/hotspot/share/gc/shenandoah/shenandoahDegeneratedGC.hpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahDegeneratedGC.hpp
@@ -63,7 +63,7 @@ private:
   void op_degenerated_futile();
   void op_degenerated_fail();
 
-  const char* degen_event_message(ShenandoahDegenPoint point) const;
+  void degen_event_message(ShenandoahDegenPoint point, char* buf, size_t len) const;
   void upgrade_to_full();
 };
 

--- a/src/hotspot/share/gc/shenandoah/shenandoahGC.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahGC.cpp
@@ -39,6 +39,8 @@ const char* ShenandoahGC::degen_point_to_string(ShenandoahDegenPoint point) {
       return "<UNSET>";
     case _degenerated_outside_cycle:
       return "Outside of Cycle";
+    case _degenerated_roots:
+      return "Roots";
     case _degenerated_mark:
       return "Mark";
     case _degenerated_evac:

--- a/src/hotspot/share/gc/shenandoah/shenandoahGC.hpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahGC.hpp
@@ -50,6 +50,7 @@ public:
   enum ShenandoahDegenPoint {
     _degenerated_unset,
     _degenerated_outside_cycle,
+    _degenerated_roots,
     _degenerated_mark,
     _degenerated_evac,
     _degenerated_updaterefs,

--- a/src/hotspot/share/gc/shenandoah/shenandoahGeneration.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahGeneration.cpp
@@ -309,7 +309,6 @@ void ShenandoahGeneration::scan_remembered_set() {
   uint nworkers = heap->workers()->active_workers();
   reserve_task_queues(nworkers);
 
-  ShenandoahConcurrentPhase gc_phase("Concurrent remembered set scanning", ShenandoahPhaseTimings::init_scan_rset);
   ShenandoahReferenceProcessor* rp = ref_processor();
   ShenandoahRegionIterator regions;
   ShenandoahScanRememberedTask task(task_queues(), old_gen_task_queues(), rp, &regions);

--- a/src/hotspot/share/gc/shenandoah/shenandoahGeneration.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahGeneration.cpp
@@ -161,6 +161,7 @@ void ShenandoahGeneration::reset_mark_bitmap() {
 // location of the card table.  So the interim implementation of swap_remembered_set will copy the write-table
 // onto the read-table and will then clear the write-table.
 void ShenandoahGeneration::swap_remembered_set() {
+  // Must be sure that marking is complete before we swap remembered set.
   ShenandoahHeap* heap = ShenandoahHeap::heap();
   heap->assert_gc_workers(heap->workers()->active_workers());
   shenandoah_assert_safepoint();

--- a/src/hotspot/share/gc/shenandoah/shenandoahHeap.inline.hpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahHeap.inline.hpp
@@ -461,9 +461,7 @@ inline oop ShenandoahHeap::try_evacuate_object(oop p, Thread* thread, Shenandoah
       // we have to keep the fwdptr initialized and pointing to our (stale) copy.
       fill_with_object(copy, size);
       shenandoah_assert_correct(NULL, copy_val);
-      if (mode()->is_generational() && target_gen == OLD_GENERATION) {
-        card_scan()->register_object(copy);
-      }
+      // For non-LAB allocations, the object has already been registered
     }
     shenandoah_assert_correct(NULL, result);
     return result;

--- a/src/hotspot/share/gc/shenandoah/shenandoahSTWMark.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahSTWMark.cpp
@@ -114,6 +114,10 @@ void ShenandoahSTWMark::mark() {
 
   {
     // Mark
+    if (_generation->generation_mode() == YOUNG) {
+      _generation->scan_remembered_set();
+    }
+
     StrongRootsScope scope(nworkers);
     ShenandoahSTWMarkTask task(this);
     heap->workers()->run_task(&task);
@@ -121,7 +125,7 @@ void ShenandoahSTWMark::mark() {
     assert(task_queues()->is_empty(), "Should be empty");
   }
 
-  heap->global_generation()->set_mark_complete();
+  _generation->set_mark_complete();
 
   assert(task_queues()->is_empty(), "Should be empty");
   TASKQUEUE_STATS_ONLY(task_queues()->print_taskqueue_stats());
@@ -138,7 +142,6 @@ void ShenandoahSTWMark::mark_roots(uint worker_id) {
     case YOUNG: {
       ShenandoahInitMarkRootsClosure<YOUNG> init_mark(task_queues()->queue(worker_id));
       _root_scanner.roots_do(&init_mark, worker_id);
-      _generation->scan_remembered_set();
       break;
     }
     default:

--- a/src/hotspot/share/gc/shenandoah/shenandoahSTWMark.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahSTWMark.cpp
@@ -115,6 +115,7 @@ void ShenandoahSTWMark::mark() {
   {
     // Mark
     if (_generation->generation_mode() == YOUNG) {
+      // But only scan the remembered set for young generation.
       _generation->scan_remembered_set();
     }
 


### PR DESCRIPTION
### Summary
* Allocation failures outside of cycle degenerate to young collections (previously we ran a global cycle)
* Added new degen point "roots" because remembered set swap during init mark is _not_ idempotent
* There is also a change here to register old gen objects when they are allocated under a lock (this reverts a previous change)