### PR TITLE
Enforce maximum capacity of young generation when allocating

### DIFF
--- a/src/hotspot/share/gc/shenandoah/shenandoahHeap.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahHeap.cpp
@@ -1102,6 +1102,10 @@ HeapWord* ShenandoahHeap::allocate_memory(ShenandoahAllocRequest& req) {
 }
 
 HeapWord* ShenandoahHeap::allocate_memory_under_lock(ShenandoahAllocRequest& req, bool& in_new_region) {
+  if (mode()->is_generational() && req.affiliation() == YOUNG_GENERATION && young_generation()->used() + req.size() >= young_generation()->max_capacity()) {
+    return nullptr;
+  }
+
   ShenandoahHeapLocker locker(lock());
   return _free_set->allocate(req, in_new_region);
 }

--- a/src/hotspot/share/gc/shenandoah/shenandoahInitLogger.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahInitLogger.cpp
@@ -27,6 +27,7 @@
 #include "gc/shenandoah/shenandoahHeapRegion.hpp"
 #include "gc/shenandoah/shenandoahInitLogger.hpp"
 #include "gc/shenandoah/shenandoahGeneration.hpp"
+#include "gc/shenandoah/shenandoahYoungGeneration.hpp"
 #include "gc/shenandoah/heuristics/shenandoahHeuristics.hpp"
 #include "gc/shenandoah/mode/shenandoahMode.hpp"
 #include "logging/log.hpp"
@@ -41,8 +42,17 @@ void ShenandoahInitLogger::print_heap() {
   log_info(gc, init)("Mode: %s",
                      heap->mode()->name());
 
-  log_info(gc, init)("Heuristics: %s",
-                     heap->global_generation()->heuristics()->name());
+  if (!heap->mode()->is_generational()) {
+    log_info(gc, init)("Heuristics: %s", heap->global_generation()->heuristics()->name());
+  } else {
+    log_info(gc, init)("Young Heuristics: %s", heap->young_generation()->heuristics()->name());
+    log_info(gc, init)("Old Heuristics: %s", heap->old_generation()->heuristics()->name());
+    log_info(gc, init)("Young Generation Max: " SIZE_FORMAT "%s",
+                       byte_size_in_proper_unit(heap->young_generation()->max_capacity()),
+                       proper_unit_for_byte_size(heap->young_generation()->max_capacity()));
+  }
+
+
 
   log_info(gc, init)("Heap Region Count: " SIZE_FORMAT,
                      ShenandoahHeapRegion::region_count());


### PR DESCRIPTION
Also log young generation maximum capacity during initialization.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

### Reviewers
 * [Kelvin Nilsen](https://openjdk.java.net/census#kdnilsen) (@kdnilsen - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/shenandoah pull/93/head:pull/93` \
`$ git checkout pull/93`

Update a local copy of the PR: \
`$ git checkout pull/93` \
`$ git pull https://git.openjdk.java.net/shenandoah pull/93/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 93`

View PR using the GUI difftool: \
`$ git pr show -t 93`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/shenandoah/pull/93.diff">https://git.openjdk.java.net/shenandoah/pull/93.diff</a>

</details>
