### PR TITLE
Fix preempt old preparation

### DIFF
--- a/src/hotspot/share/gc/shenandoah/heuristics/shenandoahOldHeuristics.cpp
+++ b/src/hotspot/share/gc/shenandoah/heuristics/shenandoahOldHeuristics.cpp
@@ -264,10 +264,14 @@ void ShenandoahOldHeuristics::start_old_evacuations() {
   _hidden_old_collection_candidates = 0;
 }
 
+uint ShenandoahOldHeuristics::unprocessed_old_or_hidden_collection_candidates() {
+  assert(_generation->generation_mode() == OLD, "This service only available for old-gc heuristics");
+  return _old_collection_candidates + _hidden_old_collection_candidates;
+}
 
 uint ShenandoahOldHeuristics::unprocessed_old_collection_candidates() {
   assert(_generation->generation_mode() == OLD, "This service only available for old-gc heuristics");
-  return _old_collection_candidates + _hidden_old_collection_candidates;
+  return _old_collection_candidates;
 }
 
 ShenandoahHeapRegion* ShenandoahOldHeuristics::next_old_collection_candidate() {
@@ -323,7 +327,7 @@ bool ShenandoahOldHeuristics::should_start_gc() {
   // Future refinement: under certain circumstances, we might be more sophisticated about this choice.
   // For example, we could choose to abandon the previous old collection before it has completed evacuations,
   // but this would require that we coalesce and fill all garbage within unevacuated collection-set regions.
-  if (unprocessed_old_collection_candidates() > 0) {
+  if (unprocessed_old_or_hidden_collection_candidates() > 0) {
     return false;
   }
 

--- a/src/hotspot/share/gc/shenandoah/heuristics/shenandoahOldHeuristics.cpp
+++ b/src/hotspot/share/gc/shenandoah/heuristics/shenandoahOldHeuristics.cpp
@@ -182,12 +182,12 @@ void ShenandoahOldHeuristics::prepare_for_old_collections() {
     total_garbage += garbage;
 
     if (region->is_regular()) {
-      region->reset_coalesce_and_fill_boundary();
       if (!region->has_live()) {
         region->make_trash_immediate();
         immediate_regions++;
         immediate_garbage += garbage;
       } else {
+        region->begin_preemptible_coalesce_and_fill();
         candidates[cand_idx]._region = region;
         candidates[cand_idx]._garbage = garbage;
         cand_idx++;

--- a/src/hotspot/share/gc/shenandoah/heuristics/shenandoahOldHeuristics.hpp
+++ b/src/hotspot/share/gc/shenandoah/heuristics/shenandoahOldHeuristics.hpp
@@ -92,6 +92,9 @@ public:
   // How many old-collection candidates have not yet been processed?
   uint unprocessed_old_collection_candidates();
 
+  // How many old or hidden collection candidates have not yet been processed?
+  uint unprocessed_old_or_hidden_collection_candidates();
+
   // Return the next old-collection candidate in order of decreasing amounts of garbage.  (We process most-garbage regions
   // first.)  This does not consume the candidate.  If the candidate is selected for inclusion in a collection set, then
   // the candidate is consumed by invoking consume_old_collection_candidate().

--- a/src/hotspot/share/gc/shenandoah/shenandoahFreeSet.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahFreeSet.cpp
@@ -178,7 +178,7 @@ HeapWord* ShenandoahFreeSet::try_allocate_in(ShenandoahHeapRegion* r, Shenandoah
     // old-gen concurrent mark (i.e. this region is allocated following the start of old-gen concurrent mark but before
     // concurrent preparations for mixed evacuations are completed), we mark this region as not requiring any
     // coalesce-and-fill processing.  This code is only necessary if req.affiliation() is OLD, but harmless if not.
-    r->finish_coalesce_and_fill();
+    r->end_preemptible_coalesce_and_fill();
     ctx->capture_top_at_mark_start(r);
 
     assert(ctx->top_at_mark_start(r) == r->bottom(), "Newly established allocation region starts with TAMS equal to bottom");

--- a/src/hotspot/share/gc/shenandoah/shenandoahHeap.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahHeap.cpp
@@ -976,7 +976,7 @@ void ShenandoahHeap::coalesce_and_fill_old_regions() {
         // and cannot be preempted by young collects. We want to be sure the entire
         // region is coalesced here and does not resume from a previously interrupted
         // or completed coalescing.
-        region->reset_coalesce_and_fill_boundary();
+        region->begin_preemptible_coalesce_and_fill();
         region->oop_fill_and_coalesce();
       }
     }

--- a/src/hotspot/share/gc/shenandoah/shenandoahHeap.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahHeap.cpp
@@ -896,7 +896,8 @@ HeapWord* ShenandoahHeap::allocate_from_plab_slow(Thread* thread, size_t size) {
 
   // Record new heuristic value even if we take any shortcut. This captures
   // the case when moderately-sized objects always take a shortcut. At some point,
-  // heuristics should catch up with them.
+  // heuristics should catch up with them.  Note that the requested new_size may
+  // not be honored, but we remember that this is the preferred size.
   ShenandoahThreadLocalData::set_plab_size(thread, new_size);
 
   if (new_size < size) {

--- a/src/hotspot/share/gc/shenandoah/shenandoahHeap.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahHeap.cpp
@@ -2703,7 +2703,8 @@ void ShenandoahHeap::verify_rem_set_at_mark() {
 
   log_debug(gc)("Verifying remembered set at %s mark", doing_mixed_evacuations()? "mixed": "young");
 
-  if (doing_mixed_evacuations() || active_generation()->generation_mode() == GLOBAL) {
+  if (doing_mixed_evacuations() ||
+      is_concurrent_prep_for_mixed_evacuation_in_progress() || active_generation()->generation_mode() == GLOBAL) {
     ctx = complete_marking_context();
   } else {
     ctx = nullptr;
@@ -2837,7 +2838,8 @@ void ShenandoahHeap::verify_rem_set_at_update_ref() {
   ShenandoahRegionIterator iterator;
   ShenandoahMarkingContext* ctx;
 
-  if (doing_mixed_evacuations() || active_generation()->generation_mode() == GLOBAL) {
+  if (doing_mixed_evacuations() ||
+      is_concurrent_prep_for_mixed_evacuation_in_progress() || active_generation()->generation_mode() == GLOBAL) {
     ctx = complete_marking_context();
   } else {
     ctx = nullptr;

--- a/src/hotspot/share/gc/shenandoah/shenandoahHeapRegion.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahHeapRegion.cpp
@@ -433,7 +433,7 @@ bool ShenandoahHeapRegion::oop_fill_and_coalesce() {
 
   assert(!is_humongous(), "No need to fill or coalesce humongous regions");
   if (!is_active()) {
-    finish_coalesce_and_fill();
+    end_preemptible_coalesce_and_fill();
     return true;
   }
 
@@ -473,7 +473,7 @@ bool ShenandoahHeapRegion::oop_fill_and_coalesce() {
     }
   }
   // Mark that this region has been coalesced and filled
-  finish_coalesce_and_fill();
+  end_preemptible_coalesce_and_fill();
   return true;
 }
 

--- a/src/hotspot/share/gc/shenandoah/shenandoahHeapRegion.hpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahHeapRegion.hpp
@@ -372,11 +372,11 @@ public:
 
   void recycle();
 
-  inline void reset_coalesce_and_fill_boundary() {
+  inline void begin_preemptible_coalesce_and_fill() {
     _coalesce_and_fill_boundary = _bottom;
   }
 
-  inline void finish_coalesce_and_fill() {
+  inline void end_preemptible_coalesce_and_fill() {
     _coalesce_and_fill_boundary = _end;
   }
 
@@ -386,10 +386,6 @@ public:
 
   inline HeapWord* resume_coalesce_and_fill() {
     return _coalesce_and_fill_boundary;
-  }
-
-  inline bool coalesce_and_fill_is_done() {
-    return _coalesce_and_fill_boundary >= _top;
   }
 
   // Coalesce contiguous spans of garbage objects by filling header and reregistering start locations with remembered set.

--- a/src/hotspot/share/gc/shenandoah/shenandoahOldGC.hpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahOldGC.hpp
@@ -42,7 +42,7 @@ class ShenandoahOldGC : public ShenandoahConcurrentGC {
  private:
   ShenandoahHeapRegion** _coalesce_and_fill_region_array;
 
-  void entry_old_evacuations();
+  void start_old_evacuations();
   bool entry_coalesce_and_fill();
   ShenandoahSharedFlag& _allow_preemption;
   bool op_coalesce_and_fill();

--- a/src/hotspot/share/gc/shenandoah/shenandoahScanRemembered.inline.hpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahScanRemembered.inline.hpp
@@ -504,7 +504,7 @@ ShenandoahScanRemembered<RememberedSet>::process_clusters(size_t first_cluster, 
   ShenandoahHeap* heap = ShenandoahHeap::heap();
   ShenandoahMarkingContext* ctx;
 
-  if (heap->doing_mixed_evacuations()) {
+  if (heap->doing_mixed_evacuations() || heap->is_concurrent_prep_for_mixed_evacuation_in_progress()) {
     ctx = heap->marking_context();
   } else {
     ctx = nullptr;


### PR DESCRIPTION
To address crashes found following integration of "preempt old preparation", several fixes have been implemented:

1. Defer mixed evacuations until after coalesce-and-fill is done
2. Fix verification of remembered set to use the marking context whenever old-gen is in the process of preparing for mixed evacuations.
3. Cosmetic improvement to change "misleading" function names.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

### Reviewers
 * [William Kemper](https://openjdk.java.net/census#wkemper) (@earthling-amzn - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/shenandoah pull/96/head:pull/96` \
`$ git checkout pull/96`

Update a local copy of the PR: \
`$ git checkout pull/96` \
`$ git pull https://git.openjdk.java.net/shenandoah pull/96/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 96`

View PR using the GUI difftool: \
`$ git pr show -t 96`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/shenandoah/pull/96.diff">https://git.openjdk.java.net/shenandoah/pull/96.diff</a>

</details>
