### PR TITLE
Padding used for alignment must fit an object

### DIFF
--- a/src/hotspot/share/gc/shenandoah/shenandoahHeapRegion.inline.hpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahHeapRegion.inline.hpp
@@ -46,6 +46,9 @@ HeapWord* ShenandoahHeapRegion::allocate_aligned(size_t size, ShenandoahAllocReq
   if (pointer_delta(end(), obj + unalignment_words) >= size) {
     if (unalignment_words > 0) {
       size_t pad_words = (alignment_in_bytes / HeapWordSize) - unalignment_words;
+      if (pad_words < ShenandoahHeap::min_fill_size()) {
+        pad_words += (alignment_in_bytes / HeapWordSize);
+      }
       ShenandoahHeap::fill_with_object(obj, pad_words);
       ShenandoahHeap::heap()->card_scan()->register_object(obj);
       obj += pad_words;
@@ -57,7 +60,7 @@ HeapWord* ShenandoahHeapRegion::allocate_aligned(size_t size, ShenandoahAllocReq
     HeapWord* new_top = obj + size;
     set_top(new_top);
     assert(is_object_aligned(new_top), "new top breaks alignment: " PTR_FORMAT, p2i(new_top));
-    assert(((uintptr_t) obj) % (alignment_in_bytes) == 0, "obj is not aligned: " PTR_FORMAT, p2i(obj));
+    assert(is_aligned(obj, alignment_in_bytes), "obj is not aligned: " PTR_FORMAT, p2i(obj));
 
     return obj;
   } else {


### PR DESCRIPTION
In some cases, alignment of new plabs on card boundaries may create padding which is too small to fill with an object. When this case is detected, we align on the plab on the next card boundary.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

### Reviewers
 * [Roman Kennke](https://openjdk.java.net/census#rkennke) (@rkennke - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/shenandoah pull/97/head:pull/97` \
`$ git checkout pull/97`

Update a local copy of the PR: \
`$ git checkout pull/97` \
`$ git pull https://git.openjdk.java.net/shenandoah pull/97/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 97`

View PR using the GUI difftool: \
`$ git pr show -t 97`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/shenandoah/pull/97.diff">https://git.openjdk.java.net/shenandoah/pull/97.diff</a>

</details>
