### PR TITLE
Clear young generation reference to old mark queues when starting global collect

### DIFF
--- a/src/hotspot/share/gc/shenandoah/shenandoahGlobalGeneration.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahGlobalGeneration.cpp
@@ -29,6 +29,7 @@
 #include "gc/shenandoah/shenandoahHeapRegion.inline.hpp"
 #include "gc/shenandoah/shenandoahUtils.hpp"
 #include "gc/shenandoah/shenandoahVerifier.hpp"
+#include "gc/shenandoah/shenandoahYoungGeneration.hpp"
 #include "gc/shenandoah/heuristics/shenandoahHeuristics.hpp"
 
 const char* ShenandoahGlobalGeneration::name() const {
@@ -64,6 +65,7 @@ void ShenandoahGlobalGeneration::set_concurrent_mark_in_progress(bool in_progres
     // any stale state in the old generation.
     heap->purge_old_satb_buffers(true /* abandon */);
     heap->old_generation()->cancel_marking();
+    heap->young_generation()->set_old_gen_task_queues(nullptr);
   }
 
   heap->set_concurrent_young_mark_in_progress(in_progress);


### PR DESCRIPTION
If concurrent marking in old is preempted by a _global_ collection, the old mark is abandoned. The young generation should no longer hold a reference to the old mark queues.  Without this fix, collections in young generation may erroneously behave as though concurrent mark in old is still running.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

### Reviewers
 * [Roman Kennke](https://openjdk.java.net/census#rkennke) (@rkennke - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/shenandoah pull/99/head:pull/99` \
`$ git checkout pull/99`

Update a local copy of the PR: \
`$ git checkout pull/99` \
`$ git pull https://git.openjdk.java.net/shenandoah pull/99/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 99`

View PR using the GUI difftool: \
`$ git pr show -t 99`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/shenandoah/pull/99.diff">https://git.openjdk.java.net/shenandoah/pull/99.diff</a>

</details>
