### PR TITLE
Split Generational Shenandoah memory pools

### DIFF
--- a/src/hotspot/share/gc/shenandoah/shenandoahHeap.hpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahHeap.hpp
@@ -476,6 +476,9 @@ public:
 private:
   ShenandoahMonitoringSupport* _monitoring_support;
   MemoryPool*                  _memory_pool;
+  MemoryPool*                  _young_gen_memory_pool;
+  MemoryPool*                  _old_gen_memory_pool;
+
   GCMemoryManager              _stw_memory_manager;
   GCMemoryManager              _cycle_memory_manager;
   ConcurrentGCTimer*           _gc_timer;

--- a/src/hotspot/share/gc/shenandoah/shenandoahMemoryPool.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahMemoryPool.cpp
@@ -24,13 +24,27 @@
 
 #include "precompiled.hpp"
 #include "gc/shenandoah/shenandoahMemoryPool.hpp"
+#include "gc/shenandoah/shenandoahYoungGeneration.hpp"
+#include "gc/shenandoah/shenandoahOldGeneration.hpp"
 
-ShenandoahMemoryPool::ShenandoahMemoryPool(ShenandoahHeap* heap) :
-        CollectedMemoryPool("Shenandoah",
+ShenandoahMemoryPool::ShenandoahMemoryPool(ShenandoahHeap* heap,
+                                           const char* name) :
+        CollectedMemoryPool(name,
                             heap->initial_capacity(),
                             heap->max_capacity(),
                             true /* support_usage_threshold */),
                             _heap(heap) {}
+
+ShenandoahMemoryPool::ShenandoahMemoryPool(ShenandoahHeap* heap,
+                                           const char* name,
+                                           size_t initial_capacity,
+                                           size_t max_capacity) :
+        CollectedMemoryPool(name,
+                            initial_capacity,
+                            max_capacity,
+                            true /* support_usage_threshold */),
+                            _heap(heap) {}
+
 
 MemoryUsage ShenandoahMemoryPool::get_memory_usage() {
   size_t initial   = initial_size();
@@ -50,4 +64,58 @@ MemoryUsage ShenandoahMemoryPool::get_memory_usage() {
   assert(used <= committed, "used: "      SIZE_FORMAT ", committed: " SIZE_FORMAT, used,      committed);
 
   return MemoryUsage(initial, used, committed, max);
+}
+
+size_t ShenandoahMemoryPool::used_in_bytes() {
+  return _heap->used();
+}
+
+size_t ShenandoahMemoryPool::max_size() const {
+  return _heap->max_capacity();
+}
+
+ShenandoahYoungGenMemoryPool::ShenandoahYoungGenMemoryPool(ShenandoahHeap* heap) :
+        ShenandoahMemoryPool(heap,
+                             "Shenandoah Young Gen",
+                             0,
+                             heap->max_capacity()) { }
+
+MemoryUsage ShenandoahYoungGenMemoryPool::get_memory_usage() {
+  size_t initial   = initial_size();
+  size_t max       = max_size();
+  size_t used      = used_in_bytes();
+  size_t committed = _heap->young_generation()->used_regions_size();
+
+  return MemoryUsage(initial, used, committed, max);
+}
+
+size_t ShenandoahYoungGenMemoryPool::used_in_bytes() {
+  return _heap->young_generation()->used();
+}
+
+size_t ShenandoahYoungGenMemoryPool::max_size() const {
+  return _heap->young_generation()->max_capacity();
+}
+
+ShenandoahOldGenMemoryPool::ShenandoahOldGenMemoryPool(ShenandoahHeap* heap) :
+        ShenandoahMemoryPool(heap,
+                             "Shenandoah Old Gen",
+                             0,
+                             heap->max_capacity()) { }
+
+MemoryUsage ShenandoahOldGenMemoryPool::get_memory_usage() {
+  size_t initial   = initial_size();
+  size_t max       = max_size();
+  size_t used      = used_in_bytes();
+  size_t committed = _heap->old_generation()->used_regions_size();
+
+  return MemoryUsage(initial, used, committed, max);
+}
+
+size_t ShenandoahOldGenMemoryPool::used_in_bytes() {
+  return _heap->old_generation()->used();
+}
+
+size_t ShenandoahOldGenMemoryPool::max_size() const {
+  return _heap->old_generation()->max_capacity();
 }

--- a/src/hotspot/share/gc/shenandoah/shenandoahMemoryPool.hpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahMemoryPool.hpp
@@ -32,14 +32,37 @@
 #endif
 
 class ShenandoahMemoryPool : public CollectedMemoryPool {
-private:
+protected:
    ShenandoahHeap* _heap;
 
 public:
-  ShenandoahMemoryPool(ShenandoahHeap* pool);
-  MemoryUsage get_memory_usage();
-  size_t used_in_bytes()              { return _heap->used(); }
-  size_t max_size() const             { return _heap->max_capacity(); }
+  ShenandoahMemoryPool(ShenandoahHeap* pool,
+                      const char* name = "Shenandoah");
+  virtual MemoryUsage get_memory_usage();
+  virtual size_t used_in_bytes();
+  virtual size_t max_size() const;
+
+protected:
+  ShenandoahMemoryPool(ShenandoahHeap* pool,
+                       const char* name,
+                       size_t initial_capacity,
+                       size_t max_capacity);
+};
+
+class ShenandoahYoungGenMemoryPool : public ShenandoahMemoryPool {
+public:
+  ShenandoahYoungGenMemoryPool(ShenandoahHeap* pool);
+  MemoryUsage get_memory_usage() override;
+  size_t used_in_bytes() override;
+  size_t max_size() const override;
+};
+
+class ShenandoahOldGenMemoryPool : public ShenandoahMemoryPool {
+public:
+  ShenandoahOldGenMemoryPool(ShenandoahHeap* pool);
+  MemoryUsage get_memory_usage() override;
+  size_t used_in_bytes() override;
+  size_t max_size() const override;
 };
 
 #endif // SHARE_GC_SHENANDOAH_SHENANDOAHMEMORYPOOL_HPP


### PR DESCRIPTION
Expose the Young Generation and the Old Generation as independent memory pools when running in generational mode

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

### Reviewers
 * [Roman Kennke](https://openjdk.java.net/census#rkennke) (@rkennke - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/shenandoah pull/100/head:pull/100` \
`$ git checkout pull/100`

Update a local copy of the PR: \
`$ git checkout pull/100` \
`$ git pull https://git.openjdk.java.net/shenandoah pull/100/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 100`

View PR using the GUI difftool: \
`$ git pr show -t 100`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/shenandoah/pull/100.diff">https://git.openjdk.java.net/shenandoah/pull/100.diff</a>

</details>
