### PR TITLE
Add missing override keyword to fix MacOS (clang) builds

### DIFF
--- a/src/hotspot/share/gc/shenandoah/heuristics/shenandoahOldHeuristics.hpp
+++ b/src/hotspot/share/gc/shenandoah/heuristics/shenandoahOldHeuristics.hpp
@@ -80,7 +80,7 @@ public:
   ShenandoahOldHeuristics(ShenandoahGeneration* generation, ShenandoahHeuristics* trigger_heuristic);
 
   // Return true iff chosen collection set includes at least one old-gen HeapRegion.
-  virtual bool choose_collection_set(ShenandoahCollectionSet* collection_set, ShenandoahOldHeuristics* old_heuristics);
+  virtual bool choose_collection_set(ShenandoahCollectionSet* collection_set, ShenandoahOldHeuristics* old_heuristics) override;
 
   // Return true iff the collection set is primed with at least one old-gen region.
   bool prime_collection_set(ShenandoahCollectionSet* set);

--- a/src/hotspot/share/gc/shenandoah/shenandoahGlobalGeneration.hpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahGlobalGeneration.hpp
@@ -34,28 +34,28 @@ public:
   : ShenandoahGeneration(GLOBAL, max_queues, 0, 0) { }
 
 public:
-  virtual const char* name() const;
+  virtual const char* name() const override;
 
-  virtual size_t max_capacity() const;
-  virtual size_t soft_max_capacity() const;
-  virtual size_t used_regions_size() const;
-  virtual size_t used() const;
-  virtual size_t available() const;
+  virtual size_t max_capacity() const override;
+  virtual size_t soft_max_capacity() const override;
+  virtual size_t used_regions_size() const override;
+  virtual size_t used() const override;
+  virtual size_t available() const override;
 
-  virtual void prepare_gc(bool do_old_gc_bootstrap);
+  virtual void prepare_gc(bool do_old_gc_bootstrap) override;
 
-  virtual void set_concurrent_mark_in_progress(bool in_progress);
+  virtual void set_concurrent_mark_in_progress(bool in_progress)  override;
 
-  bool contains(ShenandoahHeapRegion* region) const;
+  bool contains(ShenandoahHeapRegion* region) const  override;
 
   bool contains(oop obj) const override { return true; }
 
-  void parallel_heap_region_iterate(ShenandoahHeapRegionClosure* cl);
+  void parallel_heap_region_iterate(ShenandoahHeapRegionClosure* cl)  override;
 
-  void heap_region_iterate(ShenandoahHeapRegionClosure* cl);
+  void heap_region_iterate(ShenandoahHeapRegionClosure* cl)  override;
 
  protected:
-  bool is_concurrent_mark_in_progress();
+  bool is_concurrent_mark_in_progress()  override;
 };
 
 #endif // SHARE_VM_GC_SHENANDOAH_SHENANDOAHGLOBALGENERATION_HPP


### PR DESCRIPTION
Adding the `override` keyword for overriding virtual methods to fix Mac builds.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

### Reviewers
 * [Kelvin Nilsen](https://openjdk.java.net/census#kdnilsen) (@kdnilsen - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/shenandoah pull/101/head:pull/101` \
`$ git checkout pull/101`

Update a local copy of the PR: \
`$ git checkout pull/101` \
`$ git pull https://git.openjdk.java.net/shenandoah pull/101/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 101`

View PR using the GUI difftool: \
`$ git pr show -t 101`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/shenandoah/pull/101.diff">https://git.openjdk.java.net/shenandoah/pull/101.diff</a>

</details>
