### PR TITLE
Make use of nanoseconds for GC times

### DIFF
--- a/src/hotspot/share/runtime/timer.cpp
+++ b/src/hotspot/share/runtime/timer.cpp
@@ -38,6 +38,10 @@ double TimeHelper::counter_to_millis(jlong counter) {
   return counter_to_seconds(counter) * 1000.0;
 }
 
+double TimeHelper::counter_to_nanos(jlong counter) {
+  return counter_to_seconds(counter) * NANOUNITS;
+}
+
 jlong TimeHelper::millis_to_counter(jlong millis) {
   jlong freq = os::elapsed_frequency() / MILLIUNITS;
   return millis * freq;
@@ -46,6 +50,11 @@ jlong TimeHelper::millis_to_counter(jlong millis) {
 jlong TimeHelper::micros_to_counter(jlong micros) {
   jlong freq = os::elapsed_frequency() / MICROUNITS;
   return micros * freq;
+}
+
+jlong TimeHelper::nanos_to_counter(jlong nanos) {
+  jlong freq = os::elapsed_frequency() / NANOUNITS;
+  return nanos * freq;
 }
 
 void elapsedTimer::add(elapsedTimer t) {
@@ -72,6 +81,10 @@ double elapsedTimer::seconds() const {
 
 jlong elapsedTimer::milliseconds() const {
   return (jlong)TimeHelper::counter_to_millis(_counter);
+}
+
+jlong elapsedTimer::nanoseconds() const {
+  return (jlong)TimeHelper::counter_to_nanos(_counter);
 }
 
 jlong elapsedTimer::active_ticks() const {
@@ -102,6 +115,12 @@ jlong TimeStamp::milliseconds() const {
   assert(is_updated(), "must not be clear");
   jlong new_count = os::elapsed_counter();
   return (jlong)TimeHelper::counter_to_millis(new_count - _counter);
+}
+
+jlong TimeStamp::nanoseconds() const {
+  assert(is_updated(), "must not be clear");
+  jlong new_count = os::elapsed_counter();
+  return (jlong)TimeHelper::counter_to_nanos(new_count - _counter);
 }
 
 jlong TimeStamp::ticks_since_update() const {

--- a/src/hotspot/share/runtime/timer.hpp
+++ b/src/hotspot/share/runtime/timer.hpp
@@ -43,6 +43,7 @@ class elapsedTimer {
   void reset()               { _counter = 0; }
   double seconds() const;
   jlong milliseconds() const;
+  jlong nanoseconds() const;
   jlong ticks() const        { return _counter; }
   jlong active_ticks() const;
   bool  is_active() const { return _active; }
@@ -64,7 +65,12 @@ class TimeStamp {
   // returns seconds since updated
   // (must not be in a cleared state:  must have been previously updated)
   double seconds() const;
+  // returns milliseconds since updated
+  // (must not be in a cleared state:  must have been previously updated)
   jlong milliseconds() const;
+  // returns nanoseconds since updated
+  // (must not be in a cleared state:  must have been previously updated)
+  jlong nanoseconds() const;
   // ticks elapsed between VM start and last update
   jlong ticks() const { return _counter; }
   // ticks elapsed since last update
@@ -75,8 +81,10 @@ class TimeHelper {
  public:
   static double counter_to_seconds(jlong counter);
   static double counter_to_millis(jlong counter);
+  static double counter_to_nanos(jlong counter);
   static jlong millis_to_counter(jlong millis);
   static jlong micros_to_counter(jlong micros);
+  static jlong nanos_to_counter(jlong nanos);
 };
 
 #endif // SHARE_RUNTIME_TIMER_HPP

--- a/src/hotspot/share/services/gcNotifier.cpp
+++ b/src/hotspot/share/services/gcNotifier.cpp
@@ -151,8 +151,8 @@ static Handle createGcInfo(GCMemoryManager *gcManager, GCStatInfo *gcStatInfo,TR
   JavaCallArguments constructor_args(16);
   constructor_args.push_oop(getGcInfoBuilder(gcManager,THREAD));
   constructor_args.push_long(gcStatInfo->gc_index());
-  constructor_args.push_long(Management::ticks_to_ms(gcStatInfo->start_time()));
-  constructor_args.push_long(Management::ticks_to_ms(gcStatInfo->end_time()));
+  constructor_args.push_long(Management::ticks_to_ns(gcStatInfo->start_time()));
+  constructor_args.push_long(Management::ticks_to_ns(gcStatInfo->end_time()));
   constructor_args.push_oop(usage_before_gc_ah);
   constructor_args.push_oop(usage_after_gc_ah);
   constructor_args.push_oop(extra_array);

--- a/src/hotspot/share/services/management.cpp
+++ b/src/hotspot/share/services/management.cpp
@@ -1857,8 +1857,8 @@ JVM_ENTRY(void, jmm_GetLastGCStat(JNIEnv *env, jobject obj, jmmGCStat *gc_stat))
   }
 
   gc_stat->gc_index = stat.gc_index();
-  gc_stat->start_time = Management::ticks_to_ms(stat.start_time());
-  gc_stat->end_time = Management::ticks_to_ms(stat.end_time());
+  gc_stat->start_time = Management::ticks_to_ns(stat.start_time());
+  gc_stat->end_time = Management::ticks_to_ns(stat.end_time());
 
   // Current implementation does not have GC extension attributes
   gc_stat->num_gc_ext_attributes = 0;
@@ -2062,6 +2062,12 @@ jlong Management::ticks_to_ms(jlong ticks) {
   assert(os::elapsed_frequency() > 0, "Must be non-zero");
   return (jlong)(((double)ticks / (double)os::elapsed_frequency())
                  * (double)1000.0);
+}
+
+jlong Management::ticks_to_ns(jlong ticks) {
+  assert(os::elapsed_frequency() > 0, "Must be non-zero");
+  return (jlong)(((double)ticks / (double)os::elapsed_frequency())
+                 * (double)1000000000.0);
 }
 #endif // INCLUDE_MANAGEMENT
 

--- a/src/hotspot/share/services/management.hpp
+++ b/src/hotspot/share/services/management.hpp
@@ -63,6 +63,7 @@ public:
   static void initialize(TRAPS);
 
   static jlong ticks_to_ms(jlong ticks) NOT_MANAGEMENT_RETURN_(0L);
+  static jlong ticks_to_ns(jlong ticks) NOT_MANAGEMENT_RETURN_(0L);
   static jlong timestamp() NOT_MANAGEMENT_RETURN_(0L);
 
   static void* get_jmm_interface(int version);

--- a/src/hotspot/share/services/memoryManager.hpp
+++ b/src/hotspot/share/services/memoryManager.hpp
@@ -160,6 +160,7 @@ public:
   bool   is_gc_memory_manager()         { return true; }
   jlong  gc_time_ms()                   { return _accumulated_timer.milliseconds(); }
   size_t gc_count()                     { return _num_collections; }
+  jlong  gc_time_ns()                   { return _accumulated_timer.nanoseconds(); }
   int    num_gc_threads()               { return _num_gc_threads; }
   void   set_num_gc_threads(int count)  { _num_gc_threads = count; }
 

--- a/src/jdk.management/share/classes/com/sun/management/GcInfo.java
+++ b/src/jdk.management/share/classes/com/sun/management/GcInfo.java
@@ -124,7 +124,7 @@ public class GcInfo implements CompositeData, CompositeDataView {
      * @return the start time of this GC.
      */
     public long getStartTime() {
-        return startTime;
+        return startTime / 1000_000L;
     }
 
     /**
@@ -134,7 +134,7 @@ public class GcInfo implements CompositeData, CompositeDataView {
      * @return the end time of this GC.
      */
     public long getEndTime() {
-        return endTime;
+        return endTime / 1000_000L;
     }
 
     /**
@@ -143,7 +143,7 @@ public class GcInfo implements CompositeData, CompositeDataView {
      * @return the elapsed time of this GC in milliseconds.
      */
     public long getDuration() {
-        return endTime - startTime;
+        return (endTime - startTime) / 1000_000L;
     }
 
     /**


### PR DESCRIPTION
In multiple places for hotspot management the resolution used for times is milliseconds. With new collectors getting into sub-millisecond pause times, this resolution is not enough.

This change moves internal values in LastGcStat to use milliseconds. GcInfo is still reporting the values in milliseconds for compatibility reasons

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed (1 review required, with at least 1 [Committer](https://openjdk.org/bylaws#committer))

### Integration blocker
&nbsp;⚠️ Whitespace errors (failed with updated jcheck configuration in pull request)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/shenandoah.git pull/102/head:pull/102` \
`$ git checkout pull/102`

Update a local copy of the PR: \
`$ git checkout pull/102` \
`$ git pull https://git.openjdk.org/shenandoah.git pull/102/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 102`

View PR using the GUI difftool: \
`$ git pr show -t 102`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/shenandoah/pull/102.diff">https://git.openjdk.org/shenandoah/pull/102.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/shenandoah/pull/102#issuecomment-985090032)