### PR TITLE
Only verify last object start for marked objects

### DIFF
--- a/src/hotspot/share/gc/shenandoah/shenandoahScanRemembered.inline.hpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahScanRemembered.inline.hpp
@@ -399,7 +399,7 @@ ShenandoahScanRemembered<RememberedSet>::verify_registration(HeapWord* address, 
   if (max_offset > CardTable::card_size_in_words) {
     max_offset = CardTable::card_size_in_words;
   }
-  size_t prev_offset = offset;
+  size_t prev_offset;
   if (!ctx) {
     do {
       oop obj = cast_to_oop(base_addr + offset);
@@ -438,18 +438,20 @@ ShenandoahScanRemembered<RememberedSet>::verify_registration(HeapWord* address, 
     // should represent this object.  Otherwise, last_offset is a don't care.
     ShenandoahHeapRegion* region = heap->heap_region_containing(base_addr + offset);
     HeapWord* tams = ctx->top_at_mark_start(region);
+    oop last_obj = nullptr;
     do {
       oop obj = cast_to_oop(base_addr + offset);
       if (ctx->is_marked(obj)) {
         prev_offset = offset;
         offset += obj->size();
+        last_obj = obj;
       } else {
         offset = ctx->get_next_marked_addr(base_addr + offset, tams) - base_addr;
         // offset will be zero if no objects are marked in this card.
       }
     } while (offset > 0 && offset < max_offset);
-    oop last_obj = cast_to_oop(base_addr + prev_offset);
-    if (prev_offset + last_obj->size() >= max_offset) {
+    if (last_obj != nullptr && prev_offset + last_obj->size() >= max_offset) {
+      // last marked object extends beyond end of card
       if (_scc->get_last_start(index) != prev_offset) {
         return false;
       }

--- a/src/hotspot/share/gc/shenandoah/shenandoahScanRemembered.inline.hpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahScanRemembered.inline.hpp
@@ -399,7 +399,7 @@ ShenandoahScanRemembered<RememberedSet>::verify_registration(HeapWord* address, 
   if (max_offset > CardTable::card_size_in_words) {
     max_offset = CardTable::card_size_in_words;
   }
-  size_t prev_offset;
+  size_t prev_offset = offset;
   if (!ctx) {
     do {
       oop obj = cast_to_oop(base_addr + offset);
@@ -439,9 +439,9 @@ ShenandoahScanRemembered<RememberedSet>::verify_registration(HeapWord* address, 
     ShenandoahHeapRegion* region = heap->heap_region_containing(base_addr + offset);
     HeapWord* tams = ctx->top_at_mark_start(region);
     do {
-      prev_offset = offset;
       oop obj = cast_to_oop(base_addr + offset);
       if (ctx->is_marked(obj)) {
+        prev_offset = offset;
         offset += obj->size();
       } else {
         offset = ctx->get_next_marked_addr(base_addr + offset, tams) - base_addr;


### PR DESCRIPTION
In some cases, verification could invoke `size` on an unmarked object resulting in a crash.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

### Reviewers
 * [Kelvin Nilsen](https://openjdk.java.net/census#kdnilsen) (@kdnilsen - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/shenandoah pull/103/head:pull/103` \
`$ git checkout pull/103`

Update a local copy of the PR: \
`$ git checkout pull/103` \
`$ git pull https://git.openjdk.java.net/shenandoah pull/103/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 103`

View PR using the GUI difftool: \
`$ git pr show -t 103`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/shenandoah/pull/103.diff">https://git.openjdk.java.net/shenandoah/pull/103.diff</a>

</details>
