### PR TITLE
Reset top bitmap when region is immediately made into trash

### DIFF
--- a/src/hotspot/share/gc/shenandoah/shenandoahHeapRegion.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahHeapRegion.cpp
@@ -285,9 +285,7 @@ void ShenandoahHeapRegion::make_trash_immediate() {
   // On this path, we know there are no marked objects in the region,
   // tell marking context about it to bypass bitmap resets.
   assert(ShenandoahHeap::heap()->active_generation()->is_mark_complete(), "Marking should be complete here.");
-  // Leave top_bitmap alone.  If it is greater than bottom(), then we still need to clear between bottom() and top_bitmap()
-  // when this FREE region is repurposed for YOUNG or OLD.
-  // ShenandoahHeap::heap()->marking_context()->reset_top_bitmap(this);
+  ShenandoahHeap::heap()->marking_context()->reset_top_bitmap(this);
 }
 
 void ShenandoahHeapRegion::make_empty() {

--- a/src/hotspot/share/gc/shenandoah/shenandoahMarkingContext.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahMarkingContext.cpp
@@ -67,8 +67,7 @@ void ShenandoahMarkingContext::initialize_top_at_mark_start(ShenandoahHeapRegion
   HeapWord *bottom = r->bottom();
 
   _top_at_mark_starts_base[idx] = bottom;
-  // Arrange that the first time we use this bitmap, we clean from bottom to end.
-  _top_bitmaps[idx] = r->end();
+  _top_bitmaps[idx] = bottom;
 
   log_debug(gc)("SMC:initialize_top_at_mark_start for Region " SIZE_FORMAT ", TAMS: " PTR_FORMAT ", TopOfBitMap: " PTR_FORMAT,
                 r->index(), p2i(bottom), p2i(r->end()));


### PR DESCRIPTION
Resetting the top bitmap pointer for 100% garbage regions avoids having to clear the bitmap (which is already clear for regions with no live objects).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

### Reviewers
 * [Kelvin Nilsen](https://openjdk.java.net/census#kdnilsen) (@kdnilsen - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/shenandoah pull/104/head:pull/104` \
`$ git checkout pull/104`

Update a local copy of the PR: \
`$ git checkout pull/104` \
`$ git pull https://git.openjdk.java.net/shenandoah pull/104/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 104`

View PR using the GUI difftool: \
`$ git pr show -t 104`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/shenandoah/pull/104.diff">https://git.openjdk.java.net/shenandoah/pull/104.diff</a>

</details>
