### PR TITLE
Degenerate to marking phase if cancellation detected after final mark

### DIFF
--- a/src/hotspot/share/gc/shenandoah/shenandoahConcurrentGC.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahConcurrentGC.cpp
@@ -123,6 +123,8 @@ bool ShenandoahConcurrentGC::collect(GCCause::Cause cause) {
   // Complete marking under STW, and start evacuation
   vmop_entry_final_mark();
 
+  check_cancellation_and_abort(ShenandoahDegenPoint::_degenerated_mark);
+
   // Concurrent stack processing
   if (heap->is_evacuation_in_progress()) {
     entry_thread_roots();


### PR DESCRIPTION
If an allocation failure occurs between the end of concurrent mark and the start of final mark, then the degenerate cycle resumes from the 'outside of cycle' degenerated point. For other modes, this is merely a performance problem (as described in [JDK-8261093](https://bugs.openjdk.java.net/browse/JDK-8261093)). For the generational mode, this is a correctness problem because the degenerated cycle will swap the remembered set cards again. Because the concurrent marking was incomplete, this could lose information about which cards should be dirty during the degenerated (re) mark.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

### Reviewers
 * [Roman Kennke](https://openjdk.java.net/census#rkennke) (@rkennke - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/shenandoah pull/105/head:pull/105` \
`$ git checkout pull/105`

Update a local copy of the PR: \
`$ git checkout pull/105` \
`$ git pull https://git.openjdk.java.net/shenandoah pull/105/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 105`

View PR using the GUI difftool: \
`$ git pr show -t 105`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/shenandoah/pull/105.diff">https://git.openjdk.java.net/shenandoah/pull/105.diff</a>

</details>
