### PR TITLE
Update card table when cycle degenerates during root scan

### DIFF
--- a/src/hotspot/share/gc/shenandoah/shenandoahDegeneratedGC.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahDegeneratedGC.cpp
@@ -128,6 +128,15 @@ void ShenandoahDegenGC::op_degenerated() {
         heap->cancel_concurrent_mark();
       }
 
+      if (_degen_point == ShenandoahDegenPoint::_degenerated_roots) {
+        // We only need this if the concurrent cycle has already swapped the card tables.
+        // Marking will use the 'read' table, but interesting pointers may have been
+        // recorded in the 'write' table in the time between the cancelled concurrent cycle
+        // and this degenerated cycle. These pointers need to be included the 'read' table
+        // used to scan the remembered set during the STW mark which follows here.
+        _generation->merge_write_table();
+      }
+
       op_reset();
 
       // STW mark

--- a/src/hotspot/share/gc/shenandoah/shenandoahGeneration.hpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahGeneration.hpp
@@ -90,6 +90,9 @@ protected:
   // Used by concurrent and degenerated GC to reset remembered set.
   void swap_remembered_set();
 
+  // Update the read cards with the state of the write table (write table is not cleared).
+  void merge_write_table();
+
   // Used by concurrent and degenerated GC to reset regions.
   virtual void prepare_gc(bool do_old_gc_bootstrap);
 


### PR DESCRIPTION
If the concurrent cycle degenerates during the root scan (after the card table has been swapped), we need to update the _read_ table (used during the STW mark) with any cards written during the transition to the degenerated cycle. Without this change, the remembered set scan on the STW mark will skip old to young pointers created during the transition.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

### Reviewers
 * [Kelvin Nilsen](https://openjdk.java.net/census#kdnilsen) (@kdnilsen - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/shenandoah pull/106/head:pull/106` \
`$ git checkout pull/106`

Update a local copy of the PR: \
`$ git checkout pull/106` \
`$ git pull https://git.openjdk.java.net/shenandoah pull/106/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 106`

View PR using the GUI difftool: \
`$ git pr show -t 106`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/shenandoah/pull/106.diff">https://git.openjdk.java.net/shenandoah/pull/106.diff</a>

</details>
