### PR TITLE
Improve handling of cancellation after final mark

### DIFF
--- a/src/hotspot/share/gc/shenandoah/shenandoahConcurrentGC.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahConcurrentGC.cpp
@@ -123,6 +123,14 @@ bool ShenandoahConcurrentGC::collect(GCCause::Cause cause) {
   // Complete marking under STW, and start evacuation
   vmop_entry_final_mark();
 
+  // If GC was cancelled before final mark, then the safepoint operation will do nothing
+  // and the concurrent mark will still be in progress. In this case it is safe to resume
+  // the degenerated cycle from the marking phase. On the other hand, if the GC is cancelled
+  // after final mark (but before this check), then the final mark safepoint operation
+  // will have finished the mark (setting concurrent mark in progress to false). Final mark
+  // will also have setup state (in concurrent stack processing) that will not be safe to
+  // resume from the marking phase in the degenerated cycle. That is, if the cancellation
+  // occurred after final mark, we must resume the degenerated cycle after the marking phase.
   if (_generation->is_concurrent_mark_in_progress() && check_cancellation_and_abort(ShenandoahDegenPoint::_degenerated_mark)) {
     assert(!heap->is_concurrent_weak_root_in_progress(), "Weak roots should not be in progress when concurrent mark is in progress");
     return false;

--- a/src/hotspot/share/gc/shenandoah/shenandoahConcurrentGC.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahConcurrentGC.cpp
@@ -123,7 +123,10 @@ bool ShenandoahConcurrentGC::collect(GCCause::Cause cause) {
   // Complete marking under STW, and start evacuation
   vmop_entry_final_mark();
 
-  check_cancellation_and_abort(ShenandoahDegenPoint::_degenerated_mark);
+  if (_generation->is_concurrent_mark_in_progress() && check_cancellation_and_abort(ShenandoahDegenPoint::_degenerated_mark)) {
+    assert(!heap->is_concurrent_weak_root_in_progress(), "Weak roots should not be in progress when concurrent mark is in progress");
+    return false;
+  }
 
   // Concurrent stack processing
   if (heap->is_evacuation_in_progress()) {

--- a/src/hotspot/share/gc/shenandoah/shenandoahGeneration.hpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahGeneration.hpp
@@ -142,8 +142,6 @@ protected:
   void increase_used(size_t bytes);
   void decrease_used(size_t bytes);
 
-protected:
-
   virtual bool is_concurrent_mark_in_progress() = 0;
 
 private:

--- a/src/hotspot/share/gc/shenandoah/shenandoahGlobalGeneration.hpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahGlobalGeneration.hpp
@@ -54,7 +54,6 @@ public:
 
   void heap_region_iterate(ShenandoahHeapRegionClosure* cl)  override;
 
- protected:
   bool is_concurrent_mark_in_progress()  override;
 };
 

--- a/src/hotspot/share/gc/shenandoah/shenandoahOldGeneration.hpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahOldGeneration.hpp
@@ -69,7 +69,7 @@ class ShenandoahOldGeneration : public ShenandoahGeneration {
   // object at the barrier, but we reject this approach because it is likely
   // the performance impact would be too severe.
   void purge_satb_buffers(bool abandon);
- protected:
+
   bool is_concurrent_mark_in_progress() override;
 };
 

--- a/src/hotspot/share/gc/shenandoah/shenandoahYoungGeneration.hpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahYoungGeneration.hpp
@@ -54,7 +54,6 @@ public:
 
   void reserve_task_queues(uint workers) override;
 
- protected:
   bool is_concurrent_mark_in_progress() override;
 };
 


### PR DESCRIPTION
Handle case when gc is cancelled _after_ final mark but _before_ the control thread checks for cancellation. If final mark completes before the cancellation is detected, we can no longer degenerate to the marking phase.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

### Reviewers
 * [Kelvin Nilsen](https://openjdk.java.net/census#kdnilsen) (@kdnilsen - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/shenandoah pull/109/head:pull/109` \
`$ git checkout pull/109`

Update a local copy of the PR: \
`$ git checkout pull/109` \
`$ git pull https://git.openjdk.java.net/shenandoah pull/109/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 109`

View PR using the GUI difftool: \
`$ git pr show -t 109`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/shenandoah/pull/109.diff">https://git.openjdk.java.net/shenandoah/pull/109.diff</a>

</details>
