### PR TITLE
Borrow from old gen

### DIFF
--- a/src/hotspot/share/gc/shenandoah/heuristics/shenandoahAdaptiveHeuristics.cpp
+++ b/src/hotspot/share/gc/shenandoah/heuristics/shenandoahAdaptiveHeuristics.cpp
@@ -89,9 +89,6 @@ void ShenandoahAdaptiveHeuristics::choose_collection_set_from_regiondata(Shenand
   // we hit max_cset. When max_cset is hit, we terminate the cset selection. Note that in this scheme,
   // ShenandoahGarbageThreshold is the soft threshold which would be ignored until min_garbage is hit.
 
-  // KELVIN OJO:
-  // max_cset is constrained by reserved_for_young_evac.  the computations are more complex than the following.
-
   size_t max_cset    = (ShenandoahHeap::heap()->get_young_evac_reserve() / ShenandoahEvacWaste);
   size_t capacity    = ShenandoahHeap::heap()->young_generation()->soft_max_capacity();
 

--- a/src/hotspot/share/gc/shenandoah/heuristics/shenandoahAdaptiveHeuristics.cpp
+++ b/src/hotspot/share/gc/shenandoah/heuristics/shenandoahAdaptiveHeuristics.cpp
@@ -437,6 +437,7 @@ bool ShenandoahAdaptiveHeuristics::should_start_gc() {
                  _generation->name(), avg_cycle_time * 1000,
                  byte_size_in_proper_unit(rate), proper_unit_for_byte_size(rate),
                  byte_size_in_proper_unit(allocation_headroom), proper_unit_for_byte_size(allocation_headroom),
+
                  _spike_threshold_sd);
     _last_trigger = SPIKE;
     return true;

--- a/src/hotspot/share/gc/shenandoah/heuristics/shenandoahAdaptiveHeuristics.cpp
+++ b/src/hotspot/share/gc/shenandoah/heuristics/shenandoahAdaptiveHeuristics.cpp
@@ -94,18 +94,9 @@ void ShenandoahAdaptiveHeuristics::choose_collection_set_from_regiondata(Shenand
   // size_t free_target = (capacity / 100) * ShenandoahMinFreeThreshold + max_cset;
   // size_t min_garbage = (free_target > actual_free ? (free_target - actual_free) : 0);
 
-#ifdef DEPRECATED_CODE
-  log_info(gc, ergo)("Adaptive CSet Selection. Target Free: " SIZE_FORMAT "%s, Actual Free: "
-                     SIZE_FORMAT "%s, Max CSet: " SIZE_FORMAT "%s, Min Garbage: " SIZE_FORMAT "%s",
-                     byte_size_in_proper_unit(free_target), proper_unit_for_byte_size(free_target),
-                     byte_size_in_proper_unit(actual_free), proper_unit_for_byte_size(actual_free),
-                     byte_size_in_proper_unit(max_cset),    proper_unit_for_byte_size(max_cset),
-                     byte_size_in_proper_unit(min_garbage), proper_unit_for_byte_size(min_garbage));
-#else
   log_info(gc, ergo)("Adaptive CSet Selection. Max CSet: " SIZE_FORMAT "%s, Actual Free: " SIZE_FORMAT "%s.",
                      byte_size_in_proper_unit(max_cset),    proper_unit_for_byte_size(max_cset),
                      byte_size_in_proper_unit(actual_free), proper_unit_for_byte_size(actual_free));
-#endif
 
   // Better select garbage-first regions
   QuickSort::sort<RegionData>(data, (int)size, compare_by_garbage, false);

--- a/src/hotspot/share/gc/shenandoah/heuristics/shenandoahAdaptiveHeuristics.cpp
+++ b/src/hotspot/share/gc/shenandoah/heuristics/shenandoahAdaptiveHeuristics.cpp
@@ -67,8 +67,6 @@ void ShenandoahAdaptiveHeuristics::choose_collection_set_from_regiondata(Shenand
                                                                          RegionData* data, size_t size,
                                                                          size_t actual_free) {
   size_t garbage_threshold = ShenandoahHeapRegion::region_size_bytes() * ShenandoahGarbageThreshold / 100;
-  size_t live_bytes_in_collection_set = 0;
-  size_t collected_region_count = 0;
 
   // The logic for cset selection in adaptive is as follows:
   //
@@ -139,17 +137,12 @@ void ShenandoahAdaptiveHeuristics::choose_collection_set_from_regiondata(Shenand
 
     if ((new_cset <= max_cset) && ((r->garbage() > garbage_threshold) || (r->age() >= InitialTenuringThreshold))) {
       cset->add_region(r);
-      live_bytes_in_collection_set += r->get_live_data_bytes();
-      collected_region_count++;
       cur_cset = new_cset;
       // cur_garbage = new_garbage;
     } else if (biased_garbage == 0) {
       break;
-    } else {
-   }
+    }
   }
-  cset->set_young_region_count(collected_region_count);
-  cset->reserve_young_bytes_for_evacuation(live_bytes_in_collection_set);
 }
 
 void ShenandoahAdaptiveHeuristics::record_cycle_start() {

--- a/src/hotspot/share/gc/shenandoah/heuristics/shenandoahAggressiveHeuristics.cpp
+++ b/src/hotspot/share/gc/shenandoah/heuristics/shenandoahAggressiveHeuristics.cpp
@@ -52,18 +52,12 @@ void ShenandoahAggressiveHeuristics::choose_collection_set_from_regiondata(Shena
 
   // Note that there's no bound on collection set size.  If we try to collect too much memory, we'll get an alloc
   // failure during collection and we'll degenerate.
-  size_t region_count = 0;
-  size_t live_bytes_in_collection_set = 0;
   for (size_t idx = 0; idx < size; idx++) {
     ShenandoahHeapRegion* r = data[idx]._region;
     if (r->garbage() > 0) {
-      region_count++;
       cset->add_region(r);
-      live_bytes_in_collection_set += r->get_live_data_bytes();
     }
   }
-  cset->set_young_region_count(region_count);
-  cset->reserve_young_bytes_for_evacuation(live_bytes_in_collection_set);
 }
 
 bool ShenandoahAggressiveHeuristics::should_start_gc() {

--- a/src/hotspot/share/gc/shenandoah/heuristics/shenandoahCompactHeuristics.cpp
+++ b/src/hotspot/share/gc/shenandoah/heuristics/shenandoahCompactHeuristics.cpp
@@ -80,7 +80,6 @@ void ShenandoahCompactHeuristics::choose_collection_set_from_regiondata(Shenando
                                                                         size_t actual_free) {
   // Do not select too large CSet that would overflow the available free space
   size_t max_cset = actual_free * 3 / 4;
-  size_t region_count = 0;
 
   log_info(gc, ergo)("CSet Selection. Actual Free: " SIZE_FORMAT "%s, Max CSet: " SIZE_FORMAT "%s",
                      byte_size_in_proper_unit(actual_free), proper_unit_for_byte_size(actual_free),
@@ -94,10 +93,7 @@ void ShenandoahCompactHeuristics::choose_collection_set_from_regiondata(Shenando
     size_t new_cset = live_cset + r->get_live_data_bytes();
     if (new_cset < max_cset && r->garbage() > threshold) {
       live_cset = new_cset;
-      region_count++;
       cset->add_region(r);
     }
   }
-  cset->set_young_region_count(region_count);
-  cset->reserve_young_bytes_for_evacuation(live_cset);
 }

--- a/src/hotspot/share/gc/shenandoah/heuristics/shenandoahCompactHeuristics.cpp
+++ b/src/hotspot/share/gc/shenandoah/heuristics/shenandoahCompactHeuristics.cpp
@@ -80,6 +80,7 @@ void ShenandoahCompactHeuristics::choose_collection_set_from_regiondata(Shenando
                                                                         size_t actual_free) {
   // Do not select too large CSet that would overflow the available free space
   size_t max_cset = actual_free * 3 / 4;
+  size_t region_count = 0;
 
   log_info(gc, ergo)("CSet Selection. Actual Free: " SIZE_FORMAT "%s, Max CSet: " SIZE_FORMAT "%s",
                      byte_size_in_proper_unit(actual_free), proper_unit_for_byte_size(actual_free),
@@ -93,7 +94,10 @@ void ShenandoahCompactHeuristics::choose_collection_set_from_regiondata(Shenando
     size_t new_cset = live_cset + r->get_live_data_bytes();
     if (new_cset < max_cset && r->garbage() > threshold) {
       live_cset = new_cset;
+      region_count++;
       cset->add_region(r);
     }
   }
+  cset->set_young_region_count(region_count);
+  cset->reserve_young_bytes_for_evacuation(live_cset);
 }

--- a/src/hotspot/share/gc/shenandoah/heuristics/shenandoahHeuristics.cpp
+++ b/src/hotspot/share/gc/shenandoah/heuristics/shenandoahHeuristics.cpp
@@ -213,7 +213,7 @@ bool ShenandoahHeuristics::choose_collection_set(ShenandoahCollectionSet* collec
     // available to hold evacuated young-gen objects.  As currently implemented, the memory that is available within
     // non-empty regions that are not selected as part of the collection set can be allocated by the mutator while
     // GC is evacuating and updating references.
-    
+
     size_t region_size_bytes = ShenandoahHeapRegion::region_size_bytes();
     size_t free_affiliated_regions = immediate_regions + free_regions;
     size_t young_available = (free_affiliated_regions + young_generation->free_unaffiliated_regions()) * region_size_bytes;

--- a/src/hotspot/share/gc/shenandoah/heuristics/shenandoahHeuristics.cpp
+++ b/src/hotspot/share/gc/shenandoah/heuristics/shenandoahHeuristics.cpp
@@ -324,7 +324,7 @@ bool ShenandoahHeuristics::choose_collection_set(ShenandoahCollectionSet* collec
     potential_evac_supplement = potential_supplement_regions * region_size_bytes;
 
     // Leave some allocation runway for subsequent concurrent mark phase.
-    potential_evac_supplement = (potential_evac_supplement * ShenandoahBorrowPer128) / 128;
+    potential_evac_supplement = (potential_evac_supplement * ShenandoahBorrowPercent) / 100;
 
     heap->set_alloc_supplement_reserve(potential_evac_supplement);
 

--- a/src/hotspot/share/gc/shenandoah/heuristics/shenandoahHeuristics.cpp
+++ b/src/hotspot/share/gc/shenandoah/heuristics/shenandoahHeuristics.cpp
@@ -242,7 +242,7 @@ bool ShenandoahHeuristics::choose_collection_set(ShenandoahCollectionSet* collec
       // is not available to be allocated during evacuation.  To be safe, we assure that all memory required for evacuation
       // is available within "virgin" heap regions.
 
-      const size_t available_young_regions = young_generation->free_regions();
+      const size_t available_young_regions = free_regions + immediate_regions;
       const size_t available_old_regions = old_generation->free_regions();
       size_t already_reserved_old_bytes = heap->get_old_evac_reserve() + heap->get_promotion_reserve();
       size_t regions_reserved_for_evac_and_promotion = (already_reserved_old_bytes + region_size_bytes - 1) / region_size_bytes;
@@ -333,7 +333,7 @@ bool ShenandoahHeuristics::choose_collection_set(ShenandoahCollectionSet* collec
     potential_evac_supplement = potential_supplement_regions * region_size_bytes;
 
 #ifdef KELVIN_VERBOSE
-    printf("  potential_evac_supplement adjusted by borrowing: " SIZE_FORMAT "\n", potential_evac_supplement);
+    printf("  potential_evac_supplement adjusted by young-evac borrowing: " SIZE_FORMAT "\n", potential_evac_supplement);
     printf("    young_evacuation_reserve: " SIZE_FORMAT ", young_evac_regions: " SIZE_FORMAT ", available young: " SIZE_FORMAT "\n",
            young_evacuation_reserve, young_evac_regions, available_young_regions);
     printf("    borrowed_evac_regions: " SIZE_FORMAT ", potential_supplement_regions: " SIZE_FORMAT "\n",

--- a/src/hotspot/share/gc/shenandoah/heuristics/shenandoahHeuristics.cpp
+++ b/src/hotspot/share/gc/shenandoah/heuristics/shenandoahHeuristics.cpp
@@ -444,6 +444,10 @@ bool ShenandoahHeuristics::should_start_gc() {
   if (_guaranteed_gc_interval > 0) {
     double last_time_ms = (os::elapsedTime() - _last_cycle_end) * 1000;
     if (last_time_ms > _guaranteed_gc_interval) {
+#ifdef KELVIN_VERBOSE
+      printf("Trigger (%s): Time since last GC (%.0f ms) is larger than guaranteed interval (" UINTX_FORMAT " ms)\n",
+                   _generation->name(), last_time_ms, _guaranteed_gc_interval);
+#endif
       log_info(gc)("Trigger (%s): Time since last GC (%.0f ms) is larger than guaranteed interval (" UINTX_FORMAT " ms)",
                    _generation->name(), last_time_ms, _guaranteed_gc_interval);
       return true;

--- a/src/hotspot/share/gc/shenandoah/heuristics/shenandoahHeuristics.hpp
+++ b/src/hotspot/share/gc/shenandoah/heuristics/shenandoahHeuristics.hpp
@@ -99,6 +99,10 @@ protected:
   intx _gc_time_penalties;
   TruncatedSeq* _gc_time_history;
 
+  size_t _live_memory_last_cycle;
+  size_t _live_memory_penultimate_cycle;
+
+
   // There may be many threads that contend to set this flag
   ShenandoahSharedFlag _metaspace_oom;
 
@@ -126,6 +130,10 @@ public:
 
   void set_guaranteed_gc_interval(size_t guaranteed_gc_interval) {
     _guaranteed_gc_interval = guaranteed_gc_interval;
+  }
+
+  uint degenerated_cycles_in_a_row() {
+    return _degenerated_cycles_in_a_row;
   }
 
   virtual void record_cycle_start();
@@ -159,6 +167,10 @@ public:
   virtual void initialize();
 
   double time_since_last_gc() const;
+
+  void save_last_live_memory(size_t live_memory);
+  size_t get_last_live_memory();
+  size_t get_penultimate_live_memory();
 };
 
 #endif // SHARE_GC_SHENANDOAH_HEURISTICS_SHENANDOAHHEURISTICS_HPP

--- a/src/hotspot/share/gc/shenandoah/heuristics/shenandoahHeuristics.hpp
+++ b/src/hotspot/share/gc/shenandoah/heuristics/shenandoahHeuristics.hpp
@@ -131,8 +131,7 @@ public:
   void set_guaranteed_gc_interval(size_t guaranteed_gc_interval) {
 #undef KELVIN_VERBOSE_SPECIAL
 #ifdef KELVIN_VERBOSE_SPECIAL
-    printf("Setting guaranteed_gc_interval of " PTR_FORMAT " to " SIZE_FORMAT "\n", p2i(this), 
-           guaranteed_gc_interval);
+    printf("Setting guaranteed_gc_interval of " PTR_FORMAT " to " SIZE_FORMAT "\n", p2i(this), guaranteed_gc_interval);
 #endif
     _guaranteed_gc_interval = guaranteed_gc_interval;
   }

--- a/src/hotspot/share/gc/shenandoah/heuristics/shenandoahHeuristics.hpp
+++ b/src/hotspot/share/gc/shenandoah/heuristics/shenandoahHeuristics.hpp
@@ -129,10 +129,6 @@ public:
   bool has_metaspace_oom() const  { return _metaspace_oom.is_set(); }
 
   void set_guaranteed_gc_interval(size_t guaranteed_gc_interval) {
-#undef KELVIN_VERBOSE_SPECIAL
-#ifdef KELVIN_VERBOSE_SPECIAL
-    printf("Setting guaranteed_gc_interval of " PTR_FORMAT " to " SIZE_FORMAT "\n", p2i(this), guaranteed_gc_interval);
-#endif
     _guaranteed_gc_interval = guaranteed_gc_interval;
   }
 

--- a/src/hotspot/share/gc/shenandoah/heuristics/shenandoahHeuristics.hpp
+++ b/src/hotspot/share/gc/shenandoah/heuristics/shenandoahHeuristics.hpp
@@ -102,7 +102,6 @@ protected:
   size_t _live_memory_last_cycle;
   size_t _live_memory_penultimate_cycle;
 
-
   // There may be many threads that contend to set this flag
   ShenandoahSharedFlag _metaspace_oom;
 

--- a/src/hotspot/share/gc/shenandoah/heuristics/shenandoahHeuristics.hpp
+++ b/src/hotspot/share/gc/shenandoah/heuristics/shenandoahHeuristics.hpp
@@ -129,6 +129,11 @@ public:
   bool has_metaspace_oom() const  { return _metaspace_oom.is_set(); }
 
   void set_guaranteed_gc_interval(size_t guaranteed_gc_interval) {
+#undef KELVIN_VERBOSE_SPECIAL
+#ifdef KELVIN_VERBOSE_SPECIAL
+    printf("Setting guaranteed_gc_interval of " PTR_FORMAT " to " SIZE_FORMAT "\n", p2i(this), 
+           guaranteed_gc_interval);
+#endif
     _guaranteed_gc_interval = guaranteed_gc_interval;
   }
 

--- a/src/hotspot/share/gc/shenandoah/heuristics/shenandoahOldHeuristics.cpp
+++ b/src/hotspot/share/gc/shenandoah/heuristics/shenandoahOldHeuristics.cpp
@@ -45,10 +45,6 @@ ShenandoahOldHeuristics::ShenandoahOldHeuristics(ShenandoahGeneration* generatio
 
 bool ShenandoahOldHeuristics::prime_collection_set(ShenandoahCollectionSet* collection_set) {
   if (unprocessed_old_collection_candidates() == 0) {
-    // no candidates for inclusion in collection set.
-    collection_set->set_old_region_count(0);
-    collection_set->reserve_old_bytes_for_evacuation(0);
-
     return false;
   }
 
@@ -66,7 +62,7 @@ bool ShenandoahOldHeuristics::prime_collection_set(ShenandoahCollectionSet* coll
   // to old-gen regions.
   size_t max_old_evacuation_bytes = (heap->old_generation()->soft_max_capacity() * ShenandoahOldEvacReserve) / 100;
   const size_t young_evacuation_bytes = (heap->young_generation()->soft_max_capacity() * ShenandoahEvacReserve) / 100;
-  const size_t ratio_bound_on_old_evac_bytes = (young_evacuation_bytes * ShenandoahOldEvacRatioPer128) / 128;
+  const size_t ratio_bound_on_old_evac_bytes = (young_evacuation_bytes * ShenandoahOldEvacRatioPercent) / 100;
   if (max_old_evacuation_bytes > ratio_bound_on_old_evac_bytes) {
     max_old_evacuation_bytes = ratio_bound_on_old_evac_bytes;
   }
@@ -148,8 +144,6 @@ bool ShenandoahOldHeuristics::prime_collection_set(ShenandoahCollectionSet* coll
       break;
     }
   }
-  collection_set->reserve_old_bytes_for_evacuation(evacuated_old_bytes);
-  collection_set->set_old_region_count(included_old_regions);
 
   if (included_old_regions > 0) {
     log_info(gc)("Old-gen piggyback evac (" UINT32_FORMAT " regions, " SIZE_FORMAT " %s)",

--- a/src/hotspot/share/gc/shenandoah/heuristics/shenandoahOldHeuristics.cpp
+++ b/src/hotspot/share/gc/shenandoah/heuristics/shenandoahOldHeuristics.cpp
@@ -89,8 +89,6 @@ bool ShenandoahOldHeuristics::prime_collection_set(ShenandoahCollectionSet* coll
   // depletes old-gen available memory to the point that there is insufficient memory to hold old-gen objects
   // that need to be evacuated from within the old-gen collection set.
   //
-  // TODO: Enforcement of this budget is implemented with this patch.
-  //
   // Key idea: if there is not sufficient memory within old-gen to hold an object that wants to be promoted, defer
   // promotion until a subsequent evacuation pass.  Enforcement is provided at the time PLABs and shared allocations
   // in old-gen memory are requested.
@@ -123,7 +121,7 @@ bool ShenandoahOldHeuristics::prime_collection_set(ShenandoahCollectionSet* coll
 
     // If we choose region r to be collected, then we need to decrease the capacity to hold other evacuations by
     // the size of r's free memory.
-    if ((r->get_live_data_bytes() <= remaining_old_evacuation_budget) && 
+    if ((r->get_live_data_bytes() <= remaining_old_evacuation_budget) &&
         ((lost_evacuation_capacity + r->free() <= excess_old_capacity_for_evacuation)
          || (r->get_live_data_bytes() + r->free() <= remaining_old_evacuation_budget))) {
 
@@ -133,7 +131,7 @@ bool ShenandoahOldHeuristics::prime_collection_set(ShenandoahCollectionSet* coll
       lost_evacuation_capacity += r->free();
       remaining_old_evacuation_budget -= r->get_live_data_bytes();
       if (lost_evacuation_capacity > excess_old_capacity_for_evacuation) {
-        // This is slightly conservative because we really only need to remove from the remaining evacuation budget 
+        // This is slightly conservative because we really only need to remove from the remaining evacuation budget
         // the amount by which lost_evacution_capacity exceeds excess_old_capacity_for_evacuation, but this is relatively
         // rare event and current thought is to be a bit conservative rather than mess up the math on code that is so
         // difficult to test and maintain...
@@ -152,7 +150,6 @@ bool ShenandoahOldHeuristics::prime_collection_set(ShenandoahCollectionSet* coll
   }
   collection_set->reserve_old_bytes_for_evacuation(evacuated_old_bytes);
   collection_set->set_old_region_count(included_old_regions);
-
 
   if (included_old_regions > 0) {
     log_info(gc)("Old-gen piggyback evac (" UINT32_FORMAT " regions, " SIZE_FORMAT " %s)",

--- a/src/hotspot/share/gc/shenandoah/heuristics/shenandoahPassiveHeuristics.cpp
+++ b/src/hotspot/share/gc/shenandoah/heuristics/shenandoahPassiveHeuristics.cpp
@@ -62,7 +62,6 @@ void ShenandoahPassiveHeuristics::choose_collection_set_from_regiondata(Shenando
                      byte_size_in_proper_unit(max_cset),    proper_unit_for_byte_size(max_cset));
 
   size_t threshold = ShenandoahHeapRegion::region_size_bytes() * ShenandoahGarbageThreshold / 100;
-  size_t region_count = 0;
 
   size_t live_cset = 0;
   for (size_t idx = 0; idx < size; idx++) {
@@ -70,10 +69,7 @@ void ShenandoahPassiveHeuristics::choose_collection_set_from_regiondata(Shenando
     size_t new_cset = live_cset + r->get_live_data_bytes();
     if (new_cset < max_cset && r->garbage() > threshold) {
       live_cset = new_cset;
-      region_count++;
       cset->add_region(r);
     }
   }
-  cset->set_young_region_count(region_count);
-  cset->reserve_young_bytes_for_evacuation(live_cset);
 }

--- a/src/hotspot/share/gc/shenandoah/heuristics/shenandoahStaticHeuristics.cpp
+++ b/src/hotspot/share/gc/shenandoah/heuristics/shenandoahStaticHeuristics.cpp
@@ -64,17 +64,11 @@ void ShenandoahStaticHeuristics::choose_collection_set_from_regiondata(Shenandoa
                                                                        RegionData* data, size_t size,
                                                                        size_t free) {
   size_t threshold = ShenandoahHeapRegion::region_size_bytes() * ShenandoahGarbageThreshold / 100;
-  size_t live_bytes_in_collection_set = 0;
-  size_t region_count = 0;
 
   for (size_t idx = 0; idx < size; idx++) {
     ShenandoahHeapRegion* r = data[idx]._region;
     if (r->garbage() > threshold) {
       cset->add_region(r);
-      region_count++;
-      live_bytes_in_collection_set += r->get_live_data_bytes();
     }
   }
-  cset->set_young_region_count(region_count);
-  cset->reserve_young_bytes_for_evacuation(live_bytes_in_collection_set);
 }

--- a/src/hotspot/share/gc/shenandoah/heuristics/shenandoahStaticHeuristics.cpp
+++ b/src/hotspot/share/gc/shenandoah/heuristics/shenandoahStaticHeuristics.cpp
@@ -64,11 +64,17 @@ void ShenandoahStaticHeuristics::choose_collection_set_from_regiondata(Shenandoa
                                                                        RegionData* data, size_t size,
                                                                        size_t free) {
   size_t threshold = ShenandoahHeapRegion::region_size_bytes() * ShenandoahGarbageThreshold / 100;
+  size_t live_bytes_in_collection_set = 0;
+  size_t region_count = 0;
 
   for (size_t idx = 0; idx < size; idx++) {
     ShenandoahHeapRegion* r = data[idx]._region;
     if (r->garbage() > threshold) {
       cset->add_region(r);
+      region_count++;
+      live_bytes_in_collection_set += r->get_live_data_bytes();
     }
   }
+  cset->set_young_region_count(region_count);
+  cset->reserve_young_bytes_for_evacuation(live_bytes_in_collection_set);
 }

--- a/src/hotspot/share/gc/shenandoah/mode/shenandoahGenerationalMode.cpp
+++ b/src/hotspot/share/gc/shenandoah/mode/shenandoahGenerationalMode.cpp
@@ -58,6 +58,19 @@ const char* affiliation_name(oop ptr) {
   return affiliation_name(region->affiliation());
 }
 
+const char affiliation_code(ShenandoahRegionAffiliation type) {
+  switch(type) {
+    case ShenandoahRegionAffiliation::FREE:
+      return 'F';
+    case ShenandoahRegionAffiliation::YOUNG_GENERATION:
+      return 'Y';
+    case ShenandoahRegionAffiliation::OLD_GENERATION:
+      return 'O';
+    default:
+      ShouldNotReachHere();
+      return 'X';
+  }
+}
 
 const char* affiliation_name(ShenandoahRegionAffiliation type) {
   switch (type) {

--- a/src/hotspot/share/gc/shenandoah/mode/shenandoahGenerationalMode.hpp
+++ b/src/hotspot/share/gc/shenandoah/mode/shenandoahGenerationalMode.hpp
@@ -42,6 +42,7 @@ enum ShenandoahRegionAffiliation {
 
 const char* affiliation_name(oop ptr);
 const char* affiliation_name(ShenandoahRegionAffiliation type);
+const char affiliation_code(ShenandoahRegionAffiliation type);
 
 class ShenandoahGenerationalMode : public ShenandoahMode {
 public:

--- a/src/hotspot/share/gc/shenandoah/shenandoahCollectionSet.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahCollectionSet.cpp
@@ -87,6 +87,20 @@ void ShenandoahCollectionSet::add_region(ShenandoahHeapRegion* r) {
   assert(!r->is_humongous(), "Only add regular regions to the collection set");
 
   _cset_map[r->index()] = 1;
+
+  if (ShenandoahHeap::heap()->mode()->is_generational()) {
+    if (ShenandoahHeap::heap()->is_aging_cycle()) {
+      r->decrement_age();
+    }
+  }
+  if (r->affiliation() == YOUNG_GENERATION) {
+    _young_region_count++;
+    _young_bytes_to_evacuate += r->get_live_data_bytes();
+  } else if (r->affiliation() == OLD_GENERATION) {
+    _old_region_count++;
+    _old_bytes_to_evacuate += r->get_live_data_bytes();
+  }
+
   _region_count++;
   _has_old_regions |= r->is_old();
   _garbage += r->garbage();
@@ -110,6 +124,11 @@ void ShenandoahCollectionSet::clear() {
 
   _region_count = 0;
   _current_index = 0;
+
+  _young_region_count = 0;
+  _old_region_count = 0;
+  _young_bytes_to_evacuate = 0;
+  _old_bytes_to_evacuate = 0;
 
   _has_old_regions = false;
 }

--- a/src/hotspot/share/gc/shenandoah/shenandoahCollectionSet.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahCollectionSet.cpp
@@ -88,11 +88,6 @@ void ShenandoahCollectionSet::add_region(ShenandoahHeapRegion* r) {
 
   _cset_map[r->index()] = 1;
 
-  if (ShenandoahHeap::heap()->mode()->is_generational()) {
-    if (ShenandoahHeap::heap()->is_aging_cycle()) {
-      r->decrement_age();
-    }
-  }
   if (r->affiliation() == YOUNG_GENERATION) {
     _young_region_count++;
     _young_bytes_to_evacuate += r->get_live_data_bytes();

--- a/src/hotspot/share/gc/shenandoah/shenandoahCollectionSet.hpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahCollectionSet.hpp
@@ -102,10 +102,8 @@ public:
   inline size_t get_old_bytes_reserved_for_evacuation();
   inline void reserve_old_bytes_for_evacuation(size_t byte_count);
 
-  inline void set_old_region_count(size_t num_regions);
   inline size_t get_old_region_count();
 
-  inline void set_young_region_count(size_t num_regions);
   inline size_t get_young_region_count();
 
   bool has_old_regions() const { return _has_old_regions; }

--- a/src/hotspot/share/gc/shenandoah/shenandoahCollectionSet.hpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahCollectionSet.hpp
@@ -47,6 +47,15 @@ private:
   size_t                _garbage;
   size_t                _used;
   size_t                _region_count;
+  size_t                _immediate_trash;
+  size_t		_evacuation_reserve; // How many bytes reserved in generation for evacuation replicas.  This does
+                                             // not include bytes reserved for old-generation replicas.  The value is
+                                             // conservative in that memory may be reserved for objects that will be promoted.
+  size_t		_young_bytes_to_evacuate;
+  size_t                _old_bytes_to_evacuate;
+
+  size_t                _young_region_count;
+  size_t                _old_region_count;
 
   shenandoah_padding(0);
   volatile size_t       _current_index;
@@ -77,6 +86,27 @@ public:
   inline bool is_in_loc(void* loc)           const;
 
   void print_on(outputStream* out) const;
+
+  inline size_t get_immediate_trash();
+  inline void set_immediate_trash(size_t immediate_trash);
+
+  // This represents total amount of work to be performed by evacuation, including evacuations to young, to old,
+  // and promotions from young to old.  This equals get_young_bytes_reserved_for_evacuation() plus
+  // get_old_bytes_reserved_for_evacuation().
+  inline size_t get_bytes_reserved_for_evacuation();
+
+  // It is not known how many of these bytes will be promoted.
+  inline size_t get_young_bytes_reserved_for_evacuation();
+  inline void reserve_young_bytes_for_evacuation(size_t byte_count);
+
+  inline size_t get_old_bytes_reserved_for_evacuation();
+  inline void reserve_old_bytes_for_evacuation(size_t byte_count);
+
+  inline void set_old_region_count(size_t num_regions);
+  inline size_t get_old_region_count();
+
+  inline void set_young_region_count(size_t num_regions);
+  inline size_t get_young_region_count();
 
   bool has_old_regions() const { return _has_old_regions; }
   size_t used()          const { return _used; }

--- a/src/hotspot/share/gc/shenandoah/shenandoahCollectionSet.hpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahCollectionSet.hpp
@@ -48,7 +48,7 @@ private:
   size_t                _used;
   size_t                _region_count;
   size_t                _immediate_trash;
-  size_t		_evacuation_reserve; // How many bytes reserved in generation for evacuation replicas.  This does
+  size_t                _evacuation_reserve; // How many bytes reserved in generation for evacuation replicas.  This does
                                              // not include bytes reserved for old-generation replicas.  The value is
                                              // conservative in that memory may be reserved for objects that will be promoted.
   size_t		_young_bytes_to_evacuate;

--- a/src/hotspot/share/gc/shenandoah/shenandoahCollectionSet.hpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahCollectionSet.hpp
@@ -51,7 +51,7 @@ private:
   size_t                _evacuation_reserve; // How many bytes reserved in generation for evacuation replicas.  This does
                                              // not include bytes reserved for old-generation replicas.  The value is
                                              // conservative in that memory may be reserved for objects that will be promoted.
-  size_t		_young_bytes_to_evacuate;
+  size_t                _young_bytes_to_evacuate;
   size_t                _old_bytes_to_evacuate;
 
   size_t                _young_region_count;

--- a/src/hotspot/share/gc/shenandoah/shenandoahCollectionSet.inline.hpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahCollectionSet.inline.hpp
@@ -53,4 +53,48 @@ bool ShenandoahCollectionSet::is_in_loc(void* p) const {
   return _biased_cset_map[index] == 1;
 }
 
+void ShenandoahCollectionSet::set_immediate_trash(size_t immediate_trash) {
+  _immediate_trash = immediate_trash;
+}
+
+size_t ShenandoahCollectionSet::get_immediate_trash() {
+  return _immediate_trash;
+}
+
+void ShenandoahCollectionSet::reserve_young_bytes_for_evacuation(size_t live_bytes) {
+  _young_bytes_to_evacuate = live_bytes;
+}
+
+void ShenandoahCollectionSet::reserve_old_bytes_for_evacuation(size_t live_bytes) {
+  _old_bytes_to_evacuate = live_bytes;
+}
+
+size_t ShenandoahCollectionSet::get_old_bytes_reserved_for_evacuation() {
+  return _old_bytes_to_evacuate;
+}
+
+size_t ShenandoahCollectionSet::get_young_bytes_reserved_for_evacuation() {
+  return _young_bytes_to_evacuate;
+}
+
+size_t ShenandoahCollectionSet::get_bytes_reserved_for_evacuation() {
+  return _young_bytes_to_evacuate + _old_bytes_to_evacuate;
+}
+
+void ShenandoahCollectionSet::set_old_region_count(size_t num_regions) {
+  _old_region_count = num_regions;
+}
+
+void ShenandoahCollectionSet::set_young_region_count(size_t num_regions) {
+  _young_region_count = num_regions;
+}
+
+size_t ShenandoahCollectionSet::get_old_region_count() {
+  return _old_region_count;
+}
+
+size_t ShenandoahCollectionSet::get_young_region_count() {
+  return _young_region_count;
+}
+
 #endif // SHARE_GC_SHENANDOAH_SHENANDOAHCOLLECTIONSET_INLINE_HPP

--- a/src/hotspot/share/gc/shenandoah/shenandoahCollectionSet.inline.hpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahCollectionSet.inline.hpp
@@ -61,16 +61,6 @@ size_t ShenandoahCollectionSet::get_immediate_trash() {
   return _immediate_trash;
 }
 
-#ifdef KELVIN_VERBOSE
-void ShenandoahCollectionSet::reserve_young_bytes_for_evacuation(size_t live_bytes) {
-  _young_bytes_to_evacuate = live_bytes;
-}
-
-void ShenandoahCollectionSet::reserve_old_bytes_for_evacuation(size_t live_bytes) {
-  _old_bytes_to_evacuate = live_bytes;
-}
-#endif
-
 size_t ShenandoahCollectionSet::get_old_bytes_reserved_for_evacuation() {
   return _old_bytes_to_evacuate;
 }

--- a/src/hotspot/share/gc/shenandoah/shenandoahCollectionSet.inline.hpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahCollectionSet.inline.hpp
@@ -61,6 +61,7 @@ size_t ShenandoahCollectionSet::get_immediate_trash() {
   return _immediate_trash;
 }
 
+#ifdef KELVIN_VERBOSE
 void ShenandoahCollectionSet::reserve_young_bytes_for_evacuation(size_t live_bytes) {
   _young_bytes_to_evacuate = live_bytes;
 }
@@ -68,6 +69,7 @@ void ShenandoahCollectionSet::reserve_young_bytes_for_evacuation(size_t live_byt
 void ShenandoahCollectionSet::reserve_old_bytes_for_evacuation(size_t live_bytes) {
   _old_bytes_to_evacuate = live_bytes;
 }
+#endif
 
 size_t ShenandoahCollectionSet::get_old_bytes_reserved_for_evacuation() {
   return _old_bytes_to_evacuate;
@@ -79,14 +81,6 @@ size_t ShenandoahCollectionSet::get_young_bytes_reserved_for_evacuation() {
 
 size_t ShenandoahCollectionSet::get_bytes_reserved_for_evacuation() {
   return _young_bytes_to_evacuate + _old_bytes_to_evacuate;
-}
-
-void ShenandoahCollectionSet::set_old_region_count(size_t num_regions) {
-  _old_region_count = num_regions;
-}
-
-void ShenandoahCollectionSet::set_young_region_count(size_t num_regions) {
-  _young_region_count = num_regions;
 }
 
 size_t ShenandoahCollectionSet::get_old_region_count() {

--- a/src/hotspot/share/gc/shenandoah/shenandoahCollectorPolicy.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahCollectorPolicy.cpp
@@ -75,6 +75,7 @@ void ShenandoahCollectorPolicy::record_alloc_failure_to_degenerated(ShenandoahGC
 }
 
 void ShenandoahCollectorPolicy::record_degenerated_upgrade_to_full() {
+  ShenandoahHeap::heap()->record_upgrade_to_full();
   _alloc_failure_degenerated_upgrade_to_full++;
 }
 

--- a/src/hotspot/share/gc/shenandoah/shenandoahConcurrentGC.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahConcurrentGC.cpp
@@ -31,6 +31,8 @@
 #include "gc/shenandoah/shenandoahConcurrentGC.hpp"
 #include "gc/shenandoah/shenandoahFreeSet.hpp"
 #include "gc/shenandoah/shenandoahGeneration.hpp"
+#include "gc/shenandoah/shenandoahOldGeneration.hpp"
+#include "gc/shenandoah/shenandoahYoungGeneration.hpp"
 #include "gc/shenandoah/shenandoahLock.hpp"
 #include "gc/shenandoah/shenandoahMark.inline.hpp"
 #include "gc/shenandoah/shenandoahMonitoringSupport.hpp"
@@ -200,6 +202,34 @@ bool ShenandoahConcurrentGC::collect(GCCause::Cause cause) {
   } else {
     vmop_entry_final_roots();
   }
+  size_t old_available, young_available;
+  {
+    ShenandoahYoungGeneration* young_gen = heap->young_generation();
+    ShenandoahGeneration* old_gen = heap->old_generation();
+    ShenandoahHeapLocker locker(heap->lock());
+
+    size_t old_usage_before_evac = heap->capture_old_usage(0);
+    size_t old_usage_now = old_gen->used();
+    size_t promoted_bytes = old_usage_now - old_usage_before_evac;
+    heap->set_previous_promotion(promoted_bytes);
+
+    young_gen->unadjust_available();
+    old_gen->unadjust_available();
+    young_gen->increase_used(heap->get_young_evac_expended());
+    old_gen->increase_used(heap->get_old_evac_expended());
+
+    young_available = young_gen->adjusted_available();
+    old_available = old_gen->adjusted_available();
+
+
+    heap->set_alloc_supplement_reserve(0);
+    heap->set_young_evac_reserve(0);
+    heap->set_old_evac_reserve(0);
+    heap->set_promotion_reserve(0);
+  }
+  log_info(gc, ergo)("At end of concurrent GC, old_available: " SIZE_FORMAT "%s, young_available: " SIZE_FORMAT "%s",
+                     byte_size_in_proper_unit(old_available), proper_unit_for_byte_size(old_available),
+                     byte_size_in_proper_unit(young_available), proper_unit_for_byte_size(young_available));
 
   return true;
 }
@@ -631,7 +661,36 @@ void ShenandoahConcurrentGC::op_final_mark() {
     // Notify JVMTI that the tagmap table will need cleaning.
     JvmtiTagMap::set_needs_cleaning();
 
+    // The collection set is chosen by prepare_regions_and_collection_set().
+    //
+    // TODO: Under severe memory overload conditions that can be checked here, we may want to limit
+    // the inclusion of old-gen candidates within the collection set.  This would allow us to prioritize efforts on
+    // evacuating young-gen,  This remediation is most appropriate when old-gen availability is very high (so there
+    // are negligible negative impacts from delaying completion of old-gen evacuation) and when young-gen collections
+    // are "under duress" (as signalled by very low availability of memory within young-gen, indicating that/ young-gen
+    // collections are not triggering frequently enough).
     bool mixed_evac = _generation->prepare_regions_and_collection_set(true /*concurrent*/);
+
+    // Upon return from prepare_regions_and_collection_set(), certain parameters have been established to govern the
+    // evacuation efforts that are about to begin.  In particular:
+    //
+    // heap->get_promotion_reserve() represents the amount of memory within old-gen's available memory that has
+    //   been set aside to hold objects promoted from young-gen memory.  This represents an estimated percentage
+    //   of the live young-gen memory within the collection set.  If there is more data ready to be promoted than
+    //   can fit within this reserve, the promotion of some objects will be deferred until a subsequent evacuation
+    //   pass.
+    //
+    // heap->get_old_evac_reserve() represents the amount of memory within old-gen's available memory that has been
+    //  set aside to hold objects evacuated from the old-gen collection set.
+    //
+    // heap->get_young_evac_reserve() represents the amount of memory within young-gen's available memory that has
+    //  been set aside to hold objects evacuated from the young-gen collection set.  Conservatively, this value
+    //  equals the entire amount of live young-gen memory within the collection set, even though some of this memory
+    //  will likely be promoted.
+    //
+    // heap->get_alloc_supplement_reserve() represents the amount of old-gen memory that can be allocated during evacuation
+    // and update-refs phases of gc.  The young evacuation reserve has already been removed from this quantity.
+
     heap->set_mixed_evac(mixed_evac);
 
     // Has to be done after cset selection
@@ -658,6 +717,19 @@ void ShenandoahConcurrentGC::op_final_mark() {
 
       // Notify JVMTI that oops are changed.
       JvmtiTagMap::set_needs_rehashing();
+
+      if (heap->mode()->is_generational()) {
+        // Calculate the temporary evacuation allowance supplement to young-gen memory capacity.
+        size_t young_available = heap->young_generation()->adjust_available(heap->get_alloc_supplement_reserve());
+        size_t old_available = heap->old_generation()->adjust_available(-(heap->get_alloc_supplement_reserve() +
+                                                                          heap->get_young_evac_reserve() +
+                                                                          heap->get_old_evac_reserve()));
+
+        log_info(gc, ergo)("After generational memory budget adjustments, old avaiable: " SIZE_FORMAT
+                           "%s, young_available: " SIZE_FORMAT "%s",
+                           byte_size_in_proper_unit(old_available), proper_unit_for_byte_size(old_available),
+                           byte_size_in_proper_unit(young_available), proper_unit_for_byte_size(young_available));
+      }
 
       if (ShenandoahPacing) {
         heap->pacer()->setup_for_evac();

--- a/src/hotspot/share/gc/shenandoah/shenandoahConcurrentGC.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahConcurrentGC.cpp
@@ -51,6 +51,8 @@
 #include "runtime/vmThread.hpp"
 #include "utilities/events.hpp"
 
+#undef KELVIN_VERBOSE
+
 // Breakpoint support
 class ShenandoahBreakpointGCScope : public StackObj {
 public:
@@ -213,12 +215,23 @@ bool ShenandoahConcurrentGC::collect(GCCause::Cause cause) {
     size_t promoted_bytes = old_usage_now - old_usage_before_evac;
     heap->set_previous_promotion(promoted_bytes);
 
+#ifdef KELVIN_VERBOSE
+    printf("At end of concurrent GC, unadjusting old_gen and young_gen available\n");
+    printf("Before unadjustment: old_available: " SIZE_FORMAT ", young_available: " SIZE_FORMAT "\n",
+           old_gen->adjusted_available(), young_gen->adjusted_available());
+    printf("young_evac_expended accumulating into young_gen->used: " SIZE_FORMAT "\n",
+           heap->get_young_evac_expended());
+#endif
     young_gen->unadjust_available();
     old_gen->unadjust_available();
     young_gen->increase_used(heap->get_young_evac_expended());
 
     young_available = young_gen->adjusted_available();
     old_available = old_gen->adjusted_available();
+#ifdef KELVIN_VERBOSE
+    printf("After unadjustment: old_available: " SIZE_FORMAT ", young_available: " SIZE_FORMAT "\n",
+           old_gen->adjusted_available(), young_gen->adjusted_available());
+#endif
 
     heap->set_alloc_supplement_reserve(0);
     heap->set_young_evac_reserve(0);

--- a/src/hotspot/share/gc/shenandoah/shenandoahConcurrentGC.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahConcurrentGC.cpp
@@ -51,8 +51,6 @@
 #include "runtime/vmThread.hpp"
 #include "utilities/events.hpp"
 
-#undef KELVIN_VERBOSE
-
 // Breakpoint support
 class ShenandoahBreakpointGCScope : public StackObj {
 public:
@@ -216,13 +214,6 @@ bool ShenandoahConcurrentGC::collect(GCCause::Cause cause) {
     size_t promoted_bytes = old_usage_now - old_usage_before_evac;
     heap->set_previous_promotion(promoted_bytes);
 
-#ifdef KELVIN_VERBOSE
-    printf("At end of concurrent GC, unadjusting old_gen and young_gen available\n");
-    printf("Before unadjustment: old_available: " SIZE_FORMAT ", young_available: " SIZE_FORMAT "\n",
-           old_gen->adjusted_available(), young_gen->adjusted_available());
-    printf("young_evac_expended accumulating into young_gen->used: " SIZE_FORMAT "\n",
-           heap->get_young_evac_expended());
-#endif
     young_gen->unadjust_available();
     old_gen->unadjust_available();
     young_gen->increase_used(heap->get_young_evac_expended());
@@ -230,10 +221,6 @@ bool ShenandoahConcurrentGC::collect(GCCause::Cause cause) {
 
     young_available = young_gen->adjusted_available();
     old_available = old_gen->adjusted_available();
-#ifdef KELVIN_VERBOSE
-    printf("After unadjustment: old_available: " SIZE_FORMAT ", young_available: " SIZE_FORMAT "\n",
-           old_gen->adjusted_available(), young_gen->adjusted_available());
-#endif
 
     heap->set_alloc_supplement_reserve(0);
     heap->set_young_evac_reserve(0);

--- a/src/hotspot/share/gc/shenandoah/shenandoahConcurrentGC.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahConcurrentGC.cpp
@@ -90,6 +90,7 @@ ShenandoahGC::ShenandoahDegenPoint ShenandoahConcurrentGC::degen_point() const {
 
 bool ShenandoahConcurrentGC::collect(GCCause::Cause cause) {
   ShenandoahHeap* const heap = ShenandoahHeap::heap();
+  heap->start_conc_gc();
   if (cause == GCCause::_wb_breakpoint) {
     ShenandoahBreakpoint::start_gc();
   }

--- a/src/hotspot/share/gc/shenandoah/shenandoahConcurrentGC.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahConcurrentGC.cpp
@@ -225,6 +225,7 @@ bool ShenandoahConcurrentGC::collect(GCCause::Cause cause) {
     young_gen->unadjust_available();
     old_gen->unadjust_available();
     young_gen->increase_used(heap->get_young_evac_expended());
+    // No need to old_gen->increase_used().  That was done when plabs were allocated, accounting for both old evacs and promotions.
 
     young_available = young_gen->adjusted_available();
     old_available = old_gen->adjusted_available();
@@ -235,7 +236,9 @@ bool ShenandoahConcurrentGC::collect(GCCause::Cause cause) {
 
     heap->set_alloc_supplement_reserve(0);
     heap->set_young_evac_reserve(0);
+    heap->reset_young_evac_expended();
     heap->set_old_evac_reserve(0);
+    heap->reset_old_evac_expended();
     heap->set_promotion_reserve(0);
   }
   log_info(gc, ergo)("At end of concurrent GC, old_available: " SIZE_FORMAT "%s, young_available: " SIZE_FORMAT "%s",

--- a/src/hotspot/share/gc/shenandoah/shenandoahConcurrentGC.hpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahConcurrentGC.hpp
@@ -67,7 +67,7 @@ private:
 
 protected:
   void vmop_entry_final_mark();
-  void vmop_entry_final_roots();
+  void vmop_entry_final_roots(bool incr_region_ages);
 
 private:
   void vmop_entry_init_updaterefs();

--- a/src/hotspot/share/gc/shenandoah/shenandoahDegeneratedGC.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahDegeneratedGC.cpp
@@ -229,22 +229,10 @@ void ShenandoahDegenGC::op_degenerated() {
     // In case degeneration interrupted concurrent evacuation or update references, we need to clean up transient state.
     // Otherwise, these actions have no effect.
 
-#ifdef KELVIN_VERBOSE
-    printf("At end of degenerated GC, unadjusting old_gen and young_gen available\n");
-    printf("Before unadjustment: old_available: " SIZE_FORMAT ", young_available: " SIZE_FORMAT "\n",
-           heap->old_generation()->adjusted_available(), heap->young_generation()->adjusted_available());
-    printf("young_evac_expended accumulating into young_gen->used: " SIZE_FORMAT "\n",
-           heap->get_young_evac_expended());
-#endif
     heap->young_generation()->unadjust_available();
     heap->old_generation()->unadjust_available();
     heap->young_generation()->increase_used(heap->get_young_evac_expended());
     // No need to old_gen->increase_used().  That was done when plabs were allocated, accounting for both old evacs and promotions.
-
-#ifdef KELVIN_VERBOSE
-    printf("After unadjustment: old_available: " SIZE_FORMAT ", young_available: " SIZE_FORMAT "\n",
-           heap->old_generation()->adjusted_available(), heap->young_generation()->adjusted_available());
-#endif
 
     heap->set_alloc_supplement_reserve(0);
     heap->set_young_evac_reserve(0);

--- a/src/hotspot/share/gc/shenandoah/shenandoahDegeneratedGC.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahDegeneratedGC.cpp
@@ -38,6 +38,7 @@
 #include "gc/shenandoah/shenandoahSTWMark.hpp"
 #include "gc/shenandoah/shenandoahUtils.hpp"
 #include "gc/shenandoah/shenandoahVerifier.hpp"
+#include "gc/shenandoah/shenandoahYoungGeneration.hpp"
 #include "gc/shenandoah/shenandoahWorkerPolicy.hpp"
 #include "gc/shenandoah/shenandoahVMOperations.hpp"
 #include "runtime/vmThread.hpp"
@@ -222,6 +223,36 @@ void ShenandoahDegenGC::op_degenerated() {
       break;
     default:
       ShouldNotReachHere();
+  }
+
+  if (heap->mode()->is_generational()) {
+    // In case degeneration interrupted concurrent evacuation or update references, we need to clean up transient state.
+    // Otherwise, these actions have no effect.
+
+#ifdef KELVIN_VERBOSE
+    printf("At end of degenerated GC, unadjusting old_gen and young_gen available\n");
+    printf("Before unadjustment: old_available: " SIZE_FORMAT ", young_available: " SIZE_FORMAT "\n",
+           heap->old_generation()->adjusted_available(), heap->young_generation()->adjusted_available());
+    printf("young_evac_expended accumulating into young_gen->used: " SIZE_FORMAT "\n",
+           heap->get_young_evac_expended());
+#endif
+    heap->young_generation()->unadjust_available();
+    heap->old_generation()->unadjust_available();
+    heap->young_generation()->increase_used(heap->get_young_evac_expended());
+    // No need to old_gen->increase_used().  That was done when plabs were allocated, accounting for both old evacs and promotions.
+
+#ifdef KELVIN_VERBOSE
+    printf("After unadjustment: old_available: " SIZE_FORMAT ", young_available: " SIZE_FORMAT "\n",
+           heap->old_generation()->adjusted_available(), heap->young_generation()->adjusted_available());
+#endif
+
+    heap->set_alloc_supplement_reserve(0);
+    heap->set_young_evac_reserve(0);
+    heap->reset_young_evac_expended();
+    heap->set_old_evac_reserve(0);
+    heap->reset_old_evac_expended();
+    heap->set_promotion_reserve(0);
+
   }
 
   if (ShenandoahVerify) {

--- a/src/hotspot/share/gc/shenandoah/shenandoahFreeSet.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahFreeSet.cpp
@@ -165,6 +165,7 @@ HeapWord* ShenandoahFreeSet::allocate_single(ShenandoahAllocRequest& req, bool& 
   return NULL;
 }
 
+// is_gclab denotes this is for evacuation, not promotion.
 HeapWord* ShenandoahFreeSet::try_allocate_in(ShenandoahHeapRegion* r, ShenandoahAllocRequest& req, bool& in_new_region,
                                              bool is_gclab) {
   assert (!has_no_alloc_capacity(r), "Performance: should avoid full regions on this path: " SIZE_FORMAT, r->index());
@@ -290,6 +291,10 @@ HeapWord* ShenandoahFreeSet::try_allocate_in(ShenandoahHeapRegion* r, Shenandoah
         _heap->young_generation()->increase_used(size * HeapWordSize);
       }
     } else if (r->affiliation() == ShenandoahRegionAffiliation::OLD_GENERATION) {
+      assert(!is_gclab, "old-gen allocations use PLAB or shared allocation");
+      
+      // KELVIN OJO: THIS NEEDS WORK: should deal with plab budgets here.
+
       if (is_gclab) {
         _heap->expend_old_evac(size * HeapWordSize);
       } else {

--- a/src/hotspot/share/gc/shenandoah/shenandoahFreeSet.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahFreeSet.cpp
@@ -120,7 +120,7 @@ HeapWord* ShenandoahFreeSet::allocate_single(ShenandoahAllocRequest& req, bool& 
       allocating_gclab = true;
 
     case ShenandoahAllocRequest::_alloc_plab:
-      // PLABs always reside in old-gen and are only allocated during evacuation phase.  
+      // PLABs always reside in old-gen and are only allocated during evacuation phase.
 
     case ShenandoahAllocRequest::_alloc_shared_gc: {
       // First try to fit into a region that is already in use in the same generation.

--- a/src/hotspot/share/gc/shenandoah/shenandoahFreeSet.hpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahFreeSet.hpp
@@ -48,9 +48,8 @@ private:
   bool is_mutator_free(size_t idx) const;
   bool is_collector_free(size_t idx) const;
 
-  HeapWord* try_allocate_in(ShenandoahHeapRegion* region, ShenandoahAllocRequest& req, bool& in_new_region, bool is_gclab);
-  HeapWord* allocate_with_affiliation(ShenandoahRegionAffiliation affiliation, ShenandoahAllocRequest& req,
-                                      bool& in_new_region, bool is_gclab);
+  HeapWord* try_allocate_in(ShenandoahHeapRegion* region, ShenandoahAllocRequest& req, bool& in_new_region);
+  HeapWord* allocate_with_affiliation(ShenandoahRegionAffiliation affiliation, ShenandoahAllocRequest& req, bool& in_new_region);
 
   // While holding the heap lock, allocate memory for a single object which is to be entirely contained
   // within a single HeapRegion as characterized by req.  The req.size() value is known to be less than or
@@ -79,10 +78,10 @@ private:
 public:
   ShenandoahFreeSet(ShenandoahHeap* heap, size_t max_regions);
 
-  // How many regions dedicated to GC allocations (for evacuation or promotion) are currently free?
+  // Number of regions dedicated to GC allocations (for evacuation or promotion) that are currently free
   size_t collector_count() const { return _collector_free_bitmap.count_one_bits(); }
 
-  // How many regions dedicated to mutator allocations are currently free?
+  // Number of regions dedicated to mutator allocations that are currently free
   size_t mutator_count()   const { return _mutator_free_bitmap.count_one_bits();   }
 
   void clear();

--- a/src/hotspot/share/gc/shenandoah/shenandoahFreeSet.hpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahFreeSet.hpp
@@ -49,7 +49,8 @@ private:
   bool is_collector_free(size_t idx) const;
 
   HeapWord* try_allocate_in(ShenandoahHeapRegion* region, ShenandoahAllocRequest& req, bool& in_new_region, bool is_gclab);
-  HeapWord* allocate_with_affiliation(ShenandoahRegionAffiliation affiliation, ShenandoahAllocRequest& req, bool& in_new_region);
+  HeapWord* allocate_with_affiliation(ShenandoahRegionAffiliation affiliation, ShenandoahAllocRequest& req,
+                                      bool& in_new_region, bool is_gclab);
 
   // While holding the heap lock, allocate memory for a single object which is to be entirely contained
   // within a single HeapRegion as characterized by req.  The req.size() value is known to be less than or

--- a/src/hotspot/share/gc/shenandoah/shenandoahFreeSet.hpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahFreeSet.hpp
@@ -48,7 +48,7 @@ private:
   bool is_mutator_free(size_t idx) const;
   bool is_collector_free(size_t idx) const;
 
-  HeapWord* try_allocate_in(ShenandoahHeapRegion* region, ShenandoahAllocRequest& req, bool& in_new_region);
+  HeapWord* try_allocate_in(ShenandoahHeapRegion* region, ShenandoahAllocRequest& req, bool& in_new_region, bool is_gclab);
   HeapWord* allocate_with_affiliation(ShenandoahRegionAffiliation affiliation, ShenandoahAllocRequest& req, bool& in_new_region);
 
   // While holding the heap lock, allocate memory for a single object which is to be entirely contained
@@ -69,9 +69,6 @@ private:
   void increase_used(size_t amount);
   void clear_internal();
 
-  size_t collector_count() const { return _collector_free_bitmap.count_one_bits(); }
-  size_t mutator_count()   const { return _mutator_free_bitmap.count_one_bits();   }
-
   void try_recycle_trashed(ShenandoahHeapRegion *r);
 
   bool can_allocate_from(ShenandoahHeapRegion *r);
@@ -80,6 +77,12 @@ private:
 
 public:
   ShenandoahFreeSet(ShenandoahHeap* heap, size_t max_regions);
+
+  // How many regions dedicated to GC allocations (for evacuation or promotion) are currently free?
+  size_t collector_count() const { return _collector_free_bitmap.count_one_bits(); }
+
+  // How many regions dedicated to mutator allocations are currently free?
+  size_t mutator_count()   const { return _mutator_free_bitmap.count_one_bits();   }
 
   void clear();
   void rebuild();

--- a/src/hotspot/share/gc/shenandoah/shenandoahFullGC.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahFullGC.cpp
@@ -181,6 +181,17 @@ void ShenandoahFullGC::do_it(GCCause::Cause gc_cause) {
   // Since we may arrive here from degenerated GC failure of either young or old, establish generation as GLOBAL.
   heap->set_gc_generation(heap->global_generation());
 
+  // There will be no concurrent allocations during full GC so reset these coordination variables.
+  heap->young_generation()->unadjust_available();
+  heap->old_generation()->unadjust_available();
+
+  heap->set_alloc_supplement_reserve(0);
+  heap->set_young_evac_reserve(0);
+  heap->reset_young_evac_expended();
+  heap->set_old_evac_reserve(0);
+  heap->reset_old_evac_expended();
+  heap->set_promotion_reserve(0);
+
   if (ShenandoahVerify) {
     heap->verifier()->verify_before_fullgc();
   }

--- a/src/hotspot/share/gc/shenandoah/shenandoahFullGC.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahFullGC.cpp
@@ -402,6 +402,10 @@ private:
   ShenandoahPrepareForCompactionTask* _compactor;
   PreservedMarks*          const _preserved_marks;
   ShenandoahHeap*          const _heap;
+
+  // _empty_regions is a thread-local list of heap regions that have been completely emptied by this worker thread's
+  // compaction efforts.  The worker thread that drives these efforts adds compacted regions to this list if the
+  // region has not been compacted onto itself.
   GrowableArray<ShenandoahHeapRegion*>& _empty_regions;
   int _empty_regions_pos;
   ShenandoahHeapRegion*          _old_to_region;
@@ -488,8 +492,34 @@ public:
     assert(!_heap->complete_marking_context()->allocated_after_mark_start(p), "must be truly marked");
 
     size_t obj_size = p->size();
-    if (_from_affiliation == ShenandoahRegionAffiliation::OLD_GENERATION) {
-      assert(_old_to_region != nullptr, "_old_to_region should not be NULL when compacting OLD _from_region");
+    uint from_region_age = _from_region->age();
+    uint object_age = p->age();
+    
+    bool promote_object = false;
+    if ((_from_affiliation == ShenandoahRegionAffiliation::YOUNG_GENERATION) &&
+        (from_region_age + object_age > InitialTenuringThreshold)) {
+      if ((_old_to_region != nullptr) && (_old_compact_point + obj_size > _old_to_region->end())) {
+        finish_old_region();
+        _old_to_region = nullptr;
+      }
+      if (_old_to_region == nullptr) {
+        if (_empty_regions_pos < _empty_regions.length()) {
+          ShenandoahHeapRegion* new_to_region = _empty_regions.at(_empty_regions_pos);
+          _empty_regions_pos++;
+          new_to_region->set_affiliation(OLD_GENERATION);
+          _old_to_region = new_to_region;
+          _old_compact_point = _old_to_region->bottom();
+          promote_object = true;
+        }
+        // Else this worker thread does not yet have any empty regions into which this aged object can be promoted so
+        // we leave promote_object as false, deferring the promotion.
+      } else {
+        promote_object = true;
+      }
+    }
+
+    if (promote_object || (_from_affiliation == ShenandoahRegionAffiliation::OLD_GENERATION)) {
+      assert(_old_to_region != nullptr, "_old_to_region should not be NULL when evacuating to OLD region");
       if (_old_compact_point + obj_size > _old_to_region->end()) {
         ShenandoahHeapRegion* new_to_region;
 
@@ -525,11 +555,14 @@ public:
     } else {
       assert(_from_affiliation == ShenandoahRegionAffiliation::YOUNG_GENERATION,
              "_from_region must be OLD_GENERATION or YOUNG_GENERATION");
-
       assert(_young_to_region != nullptr, "_young_to_region should not be NULL when compacting YOUNG _from_region");
+
+      // After full gc compaction, all regions have age 0.  Embed the region's age into the object's age in order to preserve
+      // tenuring progress.
+      _heap->increase_object_age(p, from_region_age + 1);
+
       if (_young_compact_point + obj_size > _young_to_region->end()) {
         ShenandoahHeapRegion* new_to_region;
-
 
         log_debug(gc)("Worker %u finishing young region " SIZE_FORMAT ", compact_point: " PTR_FORMAT ", obj_size: " SIZE_FORMAT
                       ", &compact_point[obj_size]: " PTR_FORMAT ", region end: " PTR_FORMAT,  _worker_id, _young_to_region->index(),

--- a/src/hotspot/share/gc/shenandoah/shenandoahFullGC.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahFullGC.cpp
@@ -184,6 +184,8 @@ void ShenandoahFullGC::do_it(GCCause::Cause gc_cause) {
   // There will be no concurrent allocations during full GC so reset these coordination variables.
   heap->young_generation()->unadjust_available();
   heap->old_generation()->unadjust_available();
+  heap->young_generation()->increase_used(heap->get_young_evac_expended());
+  // No need to old_gen->increase_used().  That was done when plabs were allocated, accounting for both old evacs and promotions.
 
   heap->set_alloc_supplement_reserve(0);
   heap->set_young_evac_reserve(0);

--- a/src/hotspot/share/gc/shenandoah/shenandoahFullGC.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahFullGC.cpp
@@ -507,7 +507,7 @@ public:
     size_t obj_size = p->size();
     uint from_region_age = _from_region->age();
     uint object_age = p->age();
-    
+
     bool promote_object = false;
     if ((_from_affiliation == ShenandoahRegionAffiliation::YOUNG_GENERATION) &&
         (from_region_age + object_age > InitialTenuringThreshold)) {

--- a/src/hotspot/share/gc/shenandoah/shenandoahGeneration.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahGeneration.cpp
@@ -287,7 +287,7 @@ bool ShenandoahGeneration::prepare_regions_and_collection_set(bool concurrent) {
       if (max_young_evacuation < promotion_reserve) {
         promotion_reserve = max_young_evacuation;
       }
-      
+
       size_t previously_promoted = heap->get_previous_promotion();
       if (previously_promoted == 0) {
         // Very conservatively, assume linear population decay (rather than more typical exponential) and assume all of
@@ -310,7 +310,7 @@ bool ShenandoahGeneration::prepare_regions_and_collection_set(bool concurrent) {
       //       1. old_gen->available() - PromotionReserve
       //       2. (young_gen->capacity() scaled by ShenandoahEvacReserve) scaled by ShenandoahOldEvacRatio
 
-      // Don't reserve for old_evac any more than the memory that is available in old_gen.  
+      // Don't reserve for old_evac any more than the memory that is available in old_gen.
       size_t old_evacuation_reserve = old_generation->available() - promotion_reserve;
 
       // Make sure old evacuation is no more than ShenandoahOldEvacRatio of the total evacuation budget.

--- a/src/hotspot/share/gc/shenandoah/shenandoahGeneration.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahGeneration.cpp
@@ -534,10 +534,18 @@ size_t ShenandoahGeneration::available() const {
 
 size_t ShenandoahGeneration::adjust_available(intptr_t adjustment) {
   _adjusted_capacity = soft_max_capacity() + adjustment;
+#ifdef KELVIN_VERBOSE
+  printf("%s adjusting available by " SIZE_FORMAT " to new value " SIZE_FORMAT " from capacity: " SIZE_FORMAT "\n",
+         adjustment, _adjusted_capacity, soft_max_capacity());
+#endif
   return _adjusted_capacity;
 }
 
 size_t ShenandoahGeneration::unadjust_available() {
+#ifdef KELVIN_VERBOSE
+  printf("%s unadjusting available from " SIZE_FORMAT " to capacity " SIZE_FORMAT "\n",
+         _adjusted_capacity, soft_max_capacity());
+#endif
   _adjusted_capacity = soft_max_capacity();
   return _adjusted_capacity;
 }

--- a/src/hotspot/share/gc/shenandoah/shenandoahGeneration.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahGeneration.cpp
@@ -33,7 +33,10 @@
 #include "gc/shenandoah/shenandoahTaskqueue.inline.hpp"
 #include "gc/shenandoah/shenandoahUtils.hpp"
 #include "gc/shenandoah/shenandoahVerifier.hpp"
+#include "gc/shenandoah/shenandoahYoungGeneration.hpp"
 #include "gc/shenandoah/heuristics/shenandoahHeuristics.hpp"
+
+#undef KELVIN_VERBOSE
 
 class ShenandoahResetUpdateRegionStateClosure : public ShenandoahHeapRegionClosure {
  private:
@@ -246,7 +249,132 @@ bool ShenandoahGeneration::prepare_regions_and_collection_set(bool concurrent) {
                             ShenandoahPhaseTimings::degen_gc_choose_cset);
     ShenandoahHeapLocker locker(heap->lock());
     heap->collection_set()->clear();
+
+
+    if (heap->mode()->is_generational()) {
+
+      // During initialization and phase changes, it is more likely that fewer objects die young and old-gen
+      // memory is not yet full (or is in the process of being replaced).  During these tiems especially, it
+      // is beneficial to loan memory from old-gen to young-gen during the evacuation and update-refs phases
+      // of execution.
+
+      //  PromotionReserve for old generation: how much memory are we reserving to hold the results of
+      //     promoting young-gen objects that have reached tenure age?  This value is not "critical".  If we
+      //     underestimate, certain promotions will simply be deferred.  The basis of this estimate is
+      //     historical precedent.  Conservatively, budget this value to be twice the amount of memory
+      //     promoted in previous GC pass.  Whenever the amount promoted during previous GC is zero,
+      //     including initial passes before any objects have reached tenure age, use live memory within
+      //     young-gen memory divided by (ShenandoahTenureAge multiplied by InitialTenuringThreshold) as the
+      //     the very conservative value of this parameter.  Note that during initialization, there is
+      //     typically plentiful old-gen memory so it's ok to be conservative with the initial estimates
+      //     of this value.  But PromotionReserve can be no larger than available memory.  In summary, we
+      //     compute PromotionReserve as the smaller of:
+      //      1. old_gen->available
+      //      2. young_gen->capacity() * ShenandoahEvacReserve
+      //      3. (bytes promoted by previous promotion) * 2 if (bytes promoted by previous promotion) is not zero
+      //      4. if (bytes promoted by previous promotion) is zero, divide young_gen->used()
+      //         by (ShenandoahTenureAge * InitialTenuringThreshold)
+      //
+      //     We don't yet know how much live memory.  Inside choose_collection_set(), after it computes live memory,
+      //     the PromotionReserve may be further reduced.
+      //
+      //      5. live bytes in young-gen divided by (ShenandoahTenureAge * InitialTenuringThreshold
+      //         if the number of bytes promoted by previous promotion is zero
+      //
+      ShenandoahGeneration* old_generation = heap->old_generation();
+      ShenandoahYoungGeneration* young_generation = heap->young_generation();
+      size_t promotion_reserve = old_generation->available();
+
+#ifdef KELVIN_VERBOSE
+      printf("Initial value of promotion_reserve based on old_gen available: " SIZE_FORMAT "\n", promotion_reserve);
+#endif
+      size_t max_young_evacuation = (young_generation->soft_max_capacity() * ShenandoahOldEvacReserve) / 100;
+      if (max_young_evacuation < promotion_reserve) {
+        promotion_reserve = max_young_evacuation;
+#ifdef KELVIN_VERBOSE
+        printf("  promotion_reserve scaled by ShenandoahEvacReserve: " SIZE_FORMAT "\n", promotion_reserve);
+#endif
+      }
+      
+      size_t previously_promoted = heap->get_previous_promotion();
+      if (previously_promoted == 0) {
+        // Very conservatively, assume linear population decay (rather than more typical exponential) and assume all of
+        // used is live.
+        size_t proposed_reserve = young_generation->used() / (ShenandoahAgingCyclePeriod * InitialTenuringThreshold);
+        if (promotion_reserve > proposed_reserve) {
+          promotion_reserve = proposed_reserve;
+#ifdef KELVIN_VERBOSE
+          printf("  promotion_reserve scaled by young used / TenureAge: " SIZE_FORMAT "\n", promotion_reserve);
+#endif
+        }
+      } else if (previously_promoted * 2 < promotion_reserve) {
+        promotion_reserve = previously_promoted * 2;
+#ifdef KELVIN_VERBOSE
+        printf("  promotion_reserve scaled by previously_promoted times two: " SIZE_FORMAT "\n", promotion_reserve);
+#endif
+      }
+
+      heap->set_promotion_reserve(promotion_reserve);
+      heap->capture_old_usage(old_generation->used());
+
+      //  OldEvacuationReserve for old generation: how much memory are we reserving to hold the results of
+      //     evacuating old-gen heap regions?  In order to sustain a consistent pace of young-gen collections,
+      //     the goal is to maintain a consistent value for this parameter (when the candidate set is not
+      //     empty).  This value is the minimum of:
+      //       1. old_gen->available() - PromotionReserve
+      //       2. (young_gen->capacity() scaled by ShenandoahEvacReserve) scaled by ShenandoahOldEvacRatio
+
+      // Don't reserve for old_evac any more than the memory that is available in old_gen.  
+      size_t old_evacuation_reserve = old_generation->available() - promotion_reserve;
+#ifdef KELVIN_VERBOSE
+      printf("  old_evac_reserve initially (old available - promotion reserve): " SIZE_FORMAT "\n", old_evacuation_reserve);
+#endif
+
+      // Make sure old evacuation is no more than ShenandoahOldEvacRatio of the total evacuation budget.
+      size_t max_total_evac = (young_generation->soft_max_capacity() * ShenandoahEvacReserve) / 100;
+      size_t max_old_evac_portion = (max_total_evac * ShenandoahOldEvacRatioPer128) / 128;
+#ifdef KELVIN_VERBOSE
+      printf("  max_total_evac: " SIZE_FORMAT ", max_old_evac_portion: " SIZE_FORMAT "\n",
+             max_total_evac, max_old_evac_portion);
+#endif
+
+      if (old_evacuation_reserve > max_old_evac_portion) {
+        old_evacuation_reserve = max_old_evac_portion;
+#ifdef KELVIN_VERBOSE
+        printf("  old_evac_reserve scaled by ShenandoahOldEvacRatioPer128: " SIZE_FORMAT "\n", old_evacuation_reserve);
+#endif
+      }
+
+      heap->set_old_evac_reserve(old_evacuation_reserve);
+      heap->reset_old_evac_expended();
+
+      // Compute YoungEvacuationReserve after we prime the collection set with old-gen candidates.  This depends
+      // on how much memory old-gen wants to evacuate.  This is done within _heuristics->choose_collection_set().
+
+      // There's no need to pass this information to ShenandoahFreeSet::rebuild().  The GC allocator automatically borrows
+      // memory from mutator regions when necessary.
+    }
+
+    // The heuristics may consult and/or change the values of PromotionReserved, OldEvacuationReserved, and
+    // YoungEvacuationReserved, all of which are represented in the shared ShenandoahHeap data structure.
     result = _heuristics->choose_collection_set(heap->collection_set(), heap->old_heuristics());
+
+    //  EvacuationAllocationSupplement: This represents memory that can be allocated in excess of young_gen->available()
+    //     during evacuation and update-refs.  This memory can be temporarily borrowed from old-gen allotment, then
+    //     repaid at the end of update-refs from the recycled collection set.  After we have computed the collection set
+    //     based on the parameters established above, we can make additional calculates based on our knowledge of the
+    //     collection set to determine how much allocation we can allow during the evacuation and update-refs phases
+    //     of execution.  With full awareness of collection set, we can shrink the values of PromotionReserve,
+    //     OldEvacuationReserve, and YoungEvacuationReserve.  Then, we can compute EvacuationAllocationReserve as the
+    //     minimum of:
+    //       1. old_gen->available - (PromotionReserve + OldEvacuationReserve)
+    //       2. The replenishment budget (number of regions in collection set - the number of regions already
+    //          under lien for the YoungEvacuationReserve)
+    //
+
+    // The possibly revised values are also consulted by the ShenandoahPacer when it establishes pacing parameters
+    // for evacuation and update-refs.
+
   }
 
   {
@@ -310,7 +438,7 @@ ShenandoahGeneration::ShenandoahGeneration(GenerationMode generation_mode,
   _ref_processor(new ShenandoahReferenceProcessor(MAX2(max_workers, 1U))),
   _affiliated_region_count(0), _used(0), _bytes_allocated_since_gc_start(0),
   _max_capacity(max_capacity), _soft_max_capacity(soft_max_capacity),
-  _heuristics(nullptr) {
+  _adjusted_capacity(soft_max_capacity), _heuristics(nullptr) {
   _is_marking_complete.set();
   assert(max_workers > 0, "At least one queue");
   for (uint i = 0; i < max_workers; ++i) {
@@ -371,6 +499,14 @@ void ShenandoahGeneration::decrease_used(size_t bytes) {
   Atomic::sub(&_used, bytes);
 }
 
+size_t ShenandoahGeneration::used_regions() const {
+  return _affiliated_region_count;
+}
+
+size_t ShenandoahGeneration::free_regions() const {
+  return soft_max_capacity() / ShenandoahHeapRegion::region_size_bytes() - _affiliated_region_count;
+}
+
 size_t ShenandoahGeneration::used_regions_size() const {
   return _affiliated_region_count * ShenandoahHeapRegion::region_size_bytes();
 }
@@ -379,4 +515,20 @@ size_t ShenandoahGeneration::available() const {
   size_t in_use = used();
   size_t soft_capacity = soft_max_capacity();
   return in_use > soft_capacity ? 0 : soft_capacity - in_use;
+}
+
+size_t ShenandoahGeneration::adjust_available(intptr_t adjustment) {
+  _adjusted_capacity = soft_max_capacity() + adjustment;
+  return _adjusted_capacity;
+}
+
+size_t ShenandoahGeneration::unadjust_available() {
+  _adjusted_capacity = soft_max_capacity();
+  return _adjusted_capacity;
+}
+
+size_t ShenandoahGeneration::adjusted_available() const {
+  size_t in_use = used();
+  size_t capacity = _adjusted_capacity;
+  return in_use > capacity ? 0 : capacity - in_use;
 }

--- a/src/hotspot/share/gc/shenandoah/shenandoahGeneration.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahGeneration.cpp
@@ -308,14 +308,14 @@ bool ShenandoahGeneration::prepare_regions_and_collection_set(bool concurrent) {
       //     the goal is to maintain a consistent value for this parameter (when the candidate set is not
       //     empty).  This value is the minimum of:
       //       1. old_gen->available() - PromotionReserve
-      //       2. (young_gen->capacity() scaled by ShenandoahEvacReserve) scaled by ShenandoahOldEvacRatio
+      //       2. (young_gen->capacity() scaled by ShenandoahEvacReserve) scaled by ShenandoahOldEvacRatioPercent
 
       // Don't reserve for old_evac any more than the memory that is available in old_gen.
       size_t old_evacuation_reserve = old_generation->available() - promotion_reserve;
 
-      // Make sure old evacuation is no more than ShenandoahOldEvacRatio of the total evacuation budget.
+      // Make sure old evacuation is no more than ShenandoahOldEvacRatioPercent of the total evacuation budget.
       size_t max_total_evac = (young_generation->soft_max_capacity() * ShenandoahEvacReserve) / 100;
-      size_t max_old_evac_portion = (max_total_evac * ShenandoahOldEvacRatioPer128) / 128;
+      size_t max_old_evac_portion = (max_total_evac * ShenandoahOldEvacRatioPercent) / 100;
 
       if (old_evacuation_reserve > max_old_evac_portion) {
         old_evacuation_reserve = max_old_evac_portion;

--- a/src/hotspot/share/gc/shenandoah/shenandoahGeneration.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahGeneration.cpp
@@ -536,7 +536,7 @@ size_t ShenandoahGeneration::adjust_available(intptr_t adjustment) {
   _adjusted_capacity = soft_max_capacity() + adjustment;
 #ifdef KELVIN_VERBOSE
   printf("%s adjusting available by " SIZE_FORMAT " to new value " SIZE_FORMAT " from capacity: " SIZE_FORMAT "\n",
-         adjustment, _adjusted_capacity, soft_max_capacity());
+         name(), adjustment, _adjusted_capacity, soft_max_capacity());
 #endif
   return _adjusted_capacity;
 }
@@ -544,7 +544,7 @@ size_t ShenandoahGeneration::adjust_available(intptr_t adjustment) {
 size_t ShenandoahGeneration::unadjust_available() {
 #ifdef KELVIN_VERBOSE
   printf("%s unadjusting available from " SIZE_FORMAT " to capacity " SIZE_FORMAT "\n",
-         _adjusted_capacity, soft_max_capacity());
+         name(), _adjusted_capacity, soft_max_capacity());
 #endif
   _adjusted_capacity = soft_max_capacity();
   return _adjusted_capacity;

--- a/src/hotspot/share/gc/shenandoah/shenandoahGeneration.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahGeneration.cpp
@@ -347,6 +347,10 @@ bool ShenandoahGeneration::prepare_regions_and_collection_set(bool concurrent) {
 
       heap->set_old_evac_reserve(old_evacuation_reserve);
       heap->reset_old_evac_expended();
+#ifdef KELVIN_VERBOSE
+      printf(" resetting old_evac_expended, setting old_evac reserved: " SIZE_FORMAT "\n",
+             old_evacuation_reserve);
+#endif
 
       // Compute YoungEvacuationReserve after we prime the collection set with old-gen candidates.  This depends
       // on how much memory old-gen wants to evacuate.  This is done within _heuristics->choose_collection_set().

--- a/src/hotspot/share/gc/shenandoah/shenandoahGeneration.hpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahGeneration.hpp
@@ -53,6 +53,8 @@ protected:
   size_t _max_capacity;
   size_t _soft_max_capacity;
 
+  size_t _adjusted_capacity;
+
   ShenandoahHeuristics* _heuristics;
  public:
   ShenandoahGeneration(GenerationMode generation_mode, uint max_workers, size_t max_capacity, size_t soft_max_capacity);
@@ -70,9 +72,22 @@ protected:
 
   virtual size_t soft_max_capacity() const { return _soft_max_capacity; }
   virtual size_t max_capacity() const      { return _max_capacity; }
+  virtual size_t used_regions() const;
   virtual size_t used_regions_size() const;
+  virtual size_t free_regions() const;
   virtual size_t used() const { return _used; }
   virtual size_t available() const;
+
+  // During evacuation and update-refs, some memory memory may be shifted between generations.  In particular, memory
+  // may be loaned by old-gen to young-gen based on the promise the loan will be promptly repaid from the memory reclaimed
+  // when the current collection set is recycled.  The capacity adjustment also takes into consideration memory that is
+  // set aside within each generation to hold the results of evacuation, but not promotion, into that region.  Promotions
+  // into old-gen are bounded by adjusted_available() whereas evacuations into old-gen are pre-committed.
+  virtual size_t adjusted_available() const;
+
+  // Both of following return new value of available
+  virtual size_t adjust_available(intptr_t adjustment);
+  virtual size_t unadjust_available();
 
   size_t bytes_allocated_since_gc_start();
   void reset_bytes_allocated_since_gc_start();

--- a/src/hotspot/share/gc/shenandoah/shenandoahGeneration.hpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahGeneration.hpp
@@ -74,11 +74,11 @@ protected:
   virtual size_t max_capacity() const      { return _max_capacity; }
   virtual size_t used_regions() const;
   virtual size_t used_regions_size() const;
-  virtual size_t free_regions() const;
+  virtual size_t free_unaffiliated_regions() const;
   virtual size_t used() const { return _used; }
   virtual size_t available() const;
 
-  // During evacuation and update-refs, some memory memory may be shifted between generations.  In particular, memory
+  // During evacuation and update-refs, some memory may be shifted between generations.  In particular, memory
   // may be loaned by old-gen to young-gen based on the promise the loan will be promptly repaid from the memory reclaimed
   // when the current collection set is recycled.  The capacity adjustment also takes into consideration memory that is
   // set aside within each generation to hold the results of evacuation, but not promotion, into that region.  Promotions

--- a/src/hotspot/share/gc/shenandoah/shenandoahGeneration.hpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahGeneration.hpp
@@ -158,8 +158,6 @@ protected:
   void decrease_used(size_t bytes);
 
   virtual bool is_concurrent_mark_in_progress() = 0;
-
-private:
   void confirm_heuristics_mode();
 };
 

--- a/src/hotspot/share/gc/shenandoah/shenandoahHeap.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahHeap.cpp
@@ -98,6 +98,8 @@
 #include "utilities/events.hpp"
 #include "utilities/powerOfTwo.hpp"
 
+#undef KELVIN_VERBOSE
+
 class ShenandoahPretouchHeapTask : public AbstractGangTask {
 private:
   ShenandoahRegionIterator _regions;
@@ -859,6 +861,9 @@ HeapWord* ShenandoahHeap::allocate_from_gclab_slow(Thread* thread, size_t size) 
   new_size = MIN2(new_size, PLAB::max_size());
   new_size = MAX2(new_size, PLAB::min_size());
 
+#ifdef KELVIN_VERBOSE
+  printf("allocate_from_gclab_slow(" PTR_FORMAT ", " SIZE_FORMAT "), gclab size: " SIZE_FORMAT "\n", p2i(thread), size, new_size);
+#endif
   // Record new heuristic value even if we take any shortcut. This captures
   // the case when moderately-sized objects always take a shortcut. At some point,
   // heuristics should catch up with them.
@@ -867,6 +872,9 @@ HeapWord* ShenandoahHeap::allocate_from_gclab_slow(Thread* thread, size_t size) 
   if (new_size < size) {
     // New size still does not fit the object. Fall back to shared allocation.
     // This avoids retiring perfectly good GCLABs, when we encounter a large object.
+#ifdef KELVIN_VERBOSE
+    printf("  abandoning allocate_from_gclab_slow() because new_size < size\n");
+#endif
     return NULL;
   }
 
@@ -877,6 +885,9 @@ HeapWord* ShenandoahHeap::allocate_from_gclab_slow(Thread* thread, size_t size) 
   size_t actual_size = 0;
   HeapWord* gclab_buf = allocate_new_gclab(min_size, new_size, &actual_size);
   if (gclab_buf == NULL) {
+#ifdef KELVIN_VERBOSE
+    printf("  abandoning allocate_from_gclab_slow() because new_gclab_buf is NULL\n");
+#endif
     return NULL;
   }
 
@@ -961,6 +972,10 @@ HeapWord* ShenandoahHeap::allocate_from_plab_slow(Thread* thread, size_t size, b
   return plab->allocate(size);
 }
 
+// TODO: It is probably most efficient to register all objects (both promotions and evacuations) that were allocated within
+// this plab at the time we retire the plab.  A tight registration loop will run within both code and data caches.  This change
+// would allow smaller and faster in-line implementation of alloc_from_plab().  Since plabs are aligned on card-table boundaries,
+// this object registration loop can be performed without acquiring a lock.
 void ShenandoahHeap::retire_plab(PLAB* plab) {
   if (!mode()->is_generational()) {
     plab->retire();
@@ -971,8 +986,8 @@ void ShenandoahHeap::retire_plab(PLAB* plab) {
     expend_old_evac(evacuated);
     size_t waste = plab->waste();
 #ifdef KELVIN_VERBOSE
-    printf("plab.retire thread " SIZE_FORMAT ", evacuated: " SIZE_FORMAT ", promoted: " SIZE_FORMAT ", waste: " SIZE_FORMAT "\n"
-           thread->id(), evacuated, ShenandoahThreadLocalData::get_lab_promooted(thread), waste);
+    printf("plab.retire thread %s, evacuated: " SIZE_FORMAT ", promoted: " SIZE_FORMAT ", waste: " SIZE_FORMAT "\n",
+           thread->name(), evacuated, ShenandoahThreadLocalData::get_plab_promoted(thread), waste);
 #endif
     HeapWord* top = plab->top();
     plab->retire();
@@ -1056,6 +1071,8 @@ HeapWord* ShenandoahHeap::allocate_new_plab(size_t min_size,
   return res;
 }
 
+// is_promotion is true iff this allocation is known for sure to hold the result of young-gen evacuation
+// to old-gen.  plab allocates arre not known as such, since they may hold old-gen evacuations.
 HeapWord* ShenandoahHeap::allocate_memory(ShenandoahAllocRequest& req, bool is_promotion) {
   intptr_t pacer_epoch = 0;
   bool in_new_region = false;
@@ -1136,32 +1153,56 @@ HeapWord* ShenandoahHeap::allocate_memory(ShenandoahAllocRequest& req, bool is_p
 }
 
 HeapWord* ShenandoahHeap::allocate_memory_under_lock(ShenandoahAllocRequest& req, bool& in_new_region, bool is_promotion) {
+  size_t requested_bytes = req.size() * HeapWordSize;
+
   ShenandoahHeapLocker locker(lock());
+#ifdef KELVIN_VERBOSE
+  printf("alloc_mem_under_lock(req.byte_size: " SIZE_FORMAT ", is_gc_alloc: %s, is_promotion: %s\n",
+         req.size() * HeapWordSize, req.is_gc_alloc()? "Y": "N", is_promotion? "Y": "N");
+#endif
   if (mode()->is_generational()) {
     if (req.affiliation() == YOUNG_GENERATION) {
       if (req.type() == ShenandoahAllocRequest::_alloc_gclab) {
-        if (req.size() + get_young_evac_expended() > get_young_evac_reserve()) {
+        if (requested_bytes + get_young_evac_expended() > get_young_evac_reserve()) {
           // This should only happen if evacuation waste is too low.  Rejecting one thread's request for GCLAB does not
-          // necessarily result in failure of the evacuation effort.  A different thread may be able to copy the requested
-          // object.
+          // necessarily result in failure of the evacuation effort.  A different thread may be able to copy from-space object.
+
+          // TODO: Should we really fail here in the case that there is sufficient memory to allow us to allocate a gclab
+          // beyond the young_evac_reserve?  Seems it would be better to take away from mutator allocation budget if this
+          // prevents fall-back to full GC in order to recover from failed evacuation.
 #ifdef KELVIN_VERBOSE
-          printf("Reject GCLAB because req.size: " SIZE_FORMAT "  + expended: " SIZE_FORMAT " exceeds reserve: " SIZE_FORMAT "\n",
-                 req.size(), get_young_evac_expended(), get_young_evac_reserve);
+          printf(" alloc_mem_under_lock rejects GCLAB because requested bytes: " SIZE_FORMAT "  + expended: " SIZE_FORMAT " exceeds reserve: " SIZE_FORMAT "\n",
+                 requested_bytes, get_young_evac_expended(), get_young_evac_reserve());
 #endif
           return nullptr;
         }
-      } else if (req.size() >= young_generation()->adjusted_available()) {
+        // else, there is sufficient memory to allocate this GCLAB so do nothing here.
+      } else if (req.is_gc_alloc()) {
+        // This is a shared alloc for purposes of evacuation.
+        if (requested_bytes + get_young_evac_expended() > get_young_evac_reserve()) {
+          // TODO: Should we really fail here in the case that there is sufficient memory to allow us to allocate a gclab
+          // beyond the young_evac_reserve?  Seems it would be better to take away from mutator allocation budget if this
+          // prevents fall-back to full GC in order to recover from failed evacuation.
+#ifdef KELVIN_VERBOSE
+          printf(" alloc_mem_under_lock rejects shared evac allocation because requested bytes: " SIZE_FORMAT "  + expended: " SIZE_FORMAT " exceeds reserve: " SIZE_FORMAT "\n",
+                 requested_bytes, get_young_evac_expended(), get_young_evac_reserve());
+#endif
+
+          return nullptr;
+        } else {
+          // There is sufficient memory to allocate this shared evacuation object.
+        }
+      }  else if (requested_bytes >= young_generation()->adjusted_available()) {
         // We know this is not a GCLAB.  This must be a TLAB or a shared allocation.  Reject the allocation request if
         // exceeds established capacity limits.
 #ifdef KELVIN_VERBOSE
-          printf("Reject other young alloc because req.size: " SIZE_FORMAT " exceeds adjusted avaiable: " SIZE_FORMAT "\n",
-                 req.size(), young_generation()->adjusetd_available());
+          printf(" alloc_mem_under_lock rejects other young alloc because requested bytes: " SIZE_FORMAT " exceeds adjusted avaiable: " SIZE_FORMAT "\n",
+                 requested_bytes, young_generation()->adjusted_available());
 #endif
         return nullptr;
       }
     } else {                    // reg.affiliation() == OLD_GENERATION
       assert(req.type() != ShenandoahAllocRequest::_alloc_gclab, "GCLAB pertains only to young-gen memory");
-
 
       if (req.type() ==  ShenandoahAllocRequest::_alloc_plab) {
         // We've already retired this thread's previously exhausted PLAB and have accounted for how that PLAB's
@@ -1173,31 +1214,32 @@ HeapWord* ShenandoahHeap::allocate_memory_under_lock(ShenandoahAllocRequest& req
         // Conservatively, assume this entire PLAB will be used for promotion.  Act as if we need to serve the
         // rest of evacuation need from as-yet unallocated old-gen memory.
         size_t remaining_evac_need = get_old_evac_reserve() - get_old_evac_expended();
-        size_t evac_available = old_generation()->adjusted_available() - req.size();;
+        size_t evac_available = old_generation()->adjusted_available() - requested_bytes;
         if (remaining_evac_need >= evac_available) {
 #ifdef KELVIN_VERBOSE
-          printf("Disabling promotions for thread " SIZE_FORMAT ": remaining_evac_need: " SIZE_FORMAT ", evac available: "
-                 SIZE_FORMAT "\n", thread->id(), remaining_evac_need, evac_available);
+          printf(" alloc_mem_under_lock disables promotions for thread %s: remaining_evac_need: " SIZE_FORMAT ", evac available: "
+                 SIZE_FORMAT "\n", thread->name(), remaining_evac_need, evac_available);
 #endif
           // Disable promotions within this thread because the entirety of this PLAB must be available to hold
           // old-gen evacuations.
           ShenandoahThreadLocalData::disable_plab_promotions(thread);
         } else {
 #ifdef KELVIN_VERBOSE
-          printf("Enabling promotions for thread " SIZE_FORMAT ": remaining_evac_need: " SIZE_FORMAT ", evac available: "
-                 SIZE_FORMAT "\n", thread->id(), remaining_evac_need, evac_available);
+          printf(" alloc_mem_under_lock enables promotions for thread %s: remaining_evac_need: " SIZE_FORMAT ", evac available: "
+                 SIZE_FORMAT "\n", thread->name(), remaining_evac_need, evac_available);
 #endif
           ShenandoahThreadLocalData::enable_plab_promotions(thread);
         }
       } else if (is_promotion) {
         // This is a shared alloc for promotion
+        Thread* thread = Thread::current();
         size_t remaining_evac_need = get_old_evac_reserve() - get_old_evac_expended();
-        size_t evac_available = old_generation()->adjusted_available() - req.size();;
+        size_t evac_available = old_generation()->adjusted_available() - requested_bytes;
         if (remaining_evac_need >= evac_available) {
 #ifdef KELVIN_VERBOSE
-          printf("Rejecting shared promotion of size " SIZE_FORMAT " for thread " SIZE_FORMAT
-                 ": remaining_evac_need: " SIZE_FORMAT ", evac available: " SIZE_FORMAT "\n",
-                 req.size(), thread->id(), remaining_evac_need, evac_available);
+          printf(" alloc_mem_under_lock rejects shared promotion of size " SIZE_FORMAT " for thread %s: remaining_evac_need: "
+                 SIZE_FORMAT ", evac available: " SIZE_FORMAT "\n",
+                 req.size(), thread->name(), remaining_evac_need, evac_available);
 #endif
           return nullptr;       // We need to reserve the remaining memory for evacuation so defer the promotion
         }
@@ -1205,33 +1247,34 @@ HeapWord* ShenandoahHeap::allocate_memory_under_lock(ShenandoahAllocRequest& req
       } else {
         // This is a shared allocation for evacuation.  Memory has already been reserved for this purpose.
 #ifdef KELVIN_VERBOSE
-        printf("Expending old_evac for a shared allocation of size: " SIZE_FORMAT "\n", req.size() * HeapWordSize);
+        printf(" alloc_mem_under_lock expends old_evac for a shared allocation of size: " SIZE_FORMAT "\n", requested_bytes);
 #endif
-        expend_old_evac(req.size() * HeapWordSize);
       }
     }
   }
 
   HeapWord* result = _free_set->allocate(req, in_new_region);
-  if (result != NULL && req.affiliation() == ShenandoahRegionAffiliation::OLD_GENERATION) {
-    // Register the newly allocated object while we're holding the global lock since there's no synchronization
-    // built in to the implementation of register_object().  There are potential races when multiple independent
-    // threads are allocating objects, some of which might span the same card region.  For example, consider
-    // a card table's memory region within which three objects are being allocated by three different threads:
-    //
-    // objects being "concurrently" allocated:
-    //    [-----a------][-----b-----][--------------c------------------]
-    //            [---- card table memory range --------------]
-    //
-    // Before any objects are allocated, this card's memory range holds no objects.  Note that:
-    //   allocation of object a wants to set the has-object, first-start, and last-start attributes of the preceding card region.
-    //   allocation of object b wants to set the has-object, first-start, and last-start attributes of this card region.
-    //   allocation of object c also wants to set the has-object, first-start, and last-start attributes of this card region.
-    //
-    // The thread allocating b and the thread allocating c can "race" in various ways, resulting in confusion, such as last-start
-    // representing object b while first-start represents object c.  This is why we need to require all register_object()
-    // invocations to be "mutually exclusive" with respect to each card's memory range.
-    ShenandoahHeap::heap()->card_scan()->register_object(result);
+  if (result != NULL) {
+    if (req.affiliation() == ShenandoahRegionAffiliation::OLD_GENERATION) {
+      // Register the newly allocated object while we're holding the global lock since there's no synchronization
+      // built in to the implementation of register_object().  There are potential races when multiple independent
+      // threads are allocating objects, some of which might span the same card region.  For example, consider
+      // a card table's memory region within which three objects are being allocated by three different threads:
+      //
+      // objects being "concurrently" allocated:
+      //    [-----a------][-----b-----][--------------c------------------]
+      //            [---- card table memory range --------------]
+      //
+      // Before any objects are allocated, this card's memory range holds no objects.  Note that:
+      //   allocation of object a wants to set the has-object, first-start, and last-start attributes of the preceding card region.
+      //   allocation of object b wants to set the has-object, first-start, and last-start attributes of this card region.
+      //   allocation of object c also wants to set the has-object, first-start, and last-start attributes of this card region.
+      //
+      // The thread allocating b and the thread allocating c can "race" in various ways, resulting in confusion, such as last-start
+      // representing object b while first-start represents object c.  This is why we need to require all register_object()
+      // invocations to be "mutually exclusive" with respect to each card's memory range.
+      ShenandoahHeap::heap()->card_scan()->register_object(result);
+    }
   }
   return result;
 }

--- a/src/hotspot/share/gc/shenandoah/shenandoahHeap.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahHeap.cpp
@@ -2189,6 +2189,9 @@ void ShenandoahHeap::cancel_gc(GCCause::Cause cause) {
     log_info(gc)("%s", msg.buffer());
     Events::log(Thread::current(), "%s", msg.buffer());
     _cancel_requested_time = os::elapsedTime();
+    if (cause == GCCause::_shenandoah_upgrade_to_full_gc) {
+      _upgraded_to_full = true;
+    }
   }
 }
 

--- a/src/hotspot/share/gc/shenandoah/shenandoahHeap.hpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahHeap.hpp
@@ -359,7 +359,8 @@ private:
   //
   // At the end of update references, we perform the following bookkeeping activities:
   //
-  // 1. Unadjust the capacity within young-gen and old-gen
+  // 1. Unadjust the capacity within young-gen and old-gen to undo the effects of borrowing memory from old-gen.  Note that
+  //    the entirety of the collection set is now available, so allocation capacity naturally increase at this time.
   // 2. Increase young_gen->used() by _young_evac_expended.  This represents memory consumed by evacutions from young-gen.
   // 3. Clear (reset to zero) _alloc_supplement_reserve, _young_evac_reserve, _old_evac_reserve, and _promotion_reserve
   //
@@ -382,10 +383,10 @@ private:
 
 
   size_t _old_evac_reserve;            // Bytes reserved within old-gen to hold evacuated objects from old-gen collection set
-  size_t _old_evac_expended;           // Bytes of old-gen memory expended on old-gen evacuations?
+  size_t _old_evac_expended;           // Bytes of old-gen memory expended on old-gen evacuations
 
   size_t _young_evac_reserve;          // Bytes reserved within young-gen to hold evacuated objects from young-gen collection set
-  size_t _young_evac_expended;         // Bytes old-gen memory has been expended on young-gen evacuations?
+  size_t _young_evac_expended;         // Bytes old-gen memory has been expended on young-gen evacuations
 
   size_t _captured_old_usage;          // What was old usage (bytes) when last captured?
 

--- a/src/hotspot/share/gc/shenandoah/shenandoahHeap.hpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahHeap.hpp
@@ -150,8 +150,11 @@ class ShenandoahHeap : public CollectedHeap {
 private:
   ShenandoahHeapLock _lock;
   ShenandoahGeneration* _gc_generation;
-  bool _mixed_evac;             // true iff most recent evac included at least one old-gen HeapRegion
+
+  bool _mixed_evac;                      // true iff most recent evac included at least one old-gen HeapRegion
   bool _prep_for_mixed_evac_in_progress; // true iff we are concurrently coalescing and filling old-gen HeapRegions
+
+  size_t _evacuation_allowance;          // amount by which young-gen usage may temporarily exceed young-gen capacity
 
 public:
   ShenandoahHeapLock* lock() {
@@ -335,8 +338,67 @@ private:
   ShenandoahSharedFlag   _progress_last_gc;
   ShenandoahSharedFlag   _concurrent_strong_root_in_progress;
 
+  // _alloc_supplement_reserve is a supplemental budget for new_memory allocations.  During evacuation and update-references,
+  // mutator allocation requests are "authorized" iff young_gen->available() plus _alloc_supplement_reserve minus
+  // _young_evac_reserve is greater than request size.  The values of _alloc_supplement_reserve and _young_evac_reserve
+  // are zero except during evacuation and update-reference phases of GC.  Both of these values are established at
+  // the start of evacuation, and they remain constant throughout the duration of these two phases of GC.  Since these
+  // two values are constant throughout each GC phases, we introduce a new service into ShenandoahGeneration.  This service
+  // provides adjusted_available() based on an adjusted capacity.  At the start of evacuation, we adjust young capacity by
+  // adding the amount to be borrowed from old-gen and subtracting the _young_evac_reserve, we adjust old capacity by
+  // subtracting the amount to be loaned to young-gen and subtracting the _old_evac_reserve.  At the end of update-refs, we
+  // unadjust the capacity of each generation, add _young_evac_expended to young-gen used, and _old_evac_expended to
+  // old-gen used.
+  //
+  // We always use adjusted capacities to determine permission to allocate within young and to promote into old.  Note
+  // that adjusted capacities equal traditional capacities except during evacuation and update refs.
+  //
+  // During evacuation, we assure that _young_evac_expended does not exceed _young_evac_reserve and that _old_evac_expended
+  // does not exceed _old_evac_reserve.  GCLAB allocations do not immediately affect used within the respective generations
+  // since the adjusted capacity within each generation already accounts for the entire evacuation reserve.  Each GCLAB
+  // allocations increments _young_evac_expended or _old_evac_expended rather than incrementing the affiliated generation's
+  // used value.
+  //
+  // At the end of update references, we perform the following bookkeeping activities:
+  //
+  // 1. Unadjust the capacity within young-gen and old-gen
+  // 2. Increase young_gen->used() by _young_evac_expended.  This represents memory consumed by evacutions from young-gen.
+  // 3. Increase old_gen->used() by _old_evac_expended.  This represents memory consumed by evacuations from old-gen.
+  // 4. Clear (reset to zero) _alloc_supplement_reserve, _young_evac_reserve, _old_evac_reserve, and _promotion_reserve
+  //
+  // _young_evac_reserve and _old_evac_reserve are only non-zero during evacuation and update-references.
+  //
+  // Allocation of young GCLABs assures that _young_evac_expended + request-size < _young_evac_reserved.  If the allocation
+  //  is authorized, increment _young_evac_expended by request size.  This allocation ignores young_gen->available().
+  //
+  // Allocation of old GCLABs assures that _old_evac_expended + request-size < _old_evac_reserved.  If the allocation
+  //  is authorized, increment _old_evac_expended by request size.  This allocation ignores old_gen->available().
+  //
+  // Note that the typical total expenditure on evacuation is less than the associated evacuation reserve because we generally
+  // reserve ShenandoahEvacWaste (> 1.0) times the anticipated evacuation need.  In the case that there is an excessive amount
+  // of waste, it may be that one thread fails to grab a new GCLAB, this does not necessarily doom the associated evacuation
+  // effort.  If this happens, the requesting thread blocks until some other thread manages to evacuate the offending object.
+  // Only after "all" threads fail to evacuate an object do we consider the evacuation effort to have failed.
+
+  intptr_t _alloc_supplement_reserve;  // Supplemental memory reserved for young allocations during evac and update refs
+  size_t _promotion_reserve;           // How much memory is reserved within old-gen to hold the results of promotion?
+
+
+  size_t _old_evac_reserve;            // Memory reserved within old-gen to hold evacuated objects from old-gen collection set
+  size_t _old_evac_expended;           // How much old-gen memory has been expended on old-gen evacuations?
+
+  size_t _young_evac_reserve;          // Memory reserved within young-gen to hold evacuated objects from young-gen collection set
+  size_t _young_evac_expended;         // How much old-gen memory has been expended on young-gen evacuations?
+
+  size_t _captured_old_usage;          // What was old usage when last captured?
+
+  size_t _previous_promotion;          // Bytes promoted during previous evacuation
+
+
   void set_gc_state_all_threads(char state);
   void set_gc_state_mask(uint mask, bool value);
+
+
 
 public:
   char gc_state() const;
@@ -372,6 +434,35 @@ public:
   inline bool is_concurrent_weak_root_in_progress() const;
   bool is_concurrent_prep_for_mixed_evacuation_in_progress();
   inline bool is_aging_cycle() const;
+
+  inline size_t capture_old_usage(size_t usage);
+  inline void set_previous_promotion(size_t promoted_bytes);
+  inline size_t get_previous_promotion() const;
+
+  // Returns previous value
+  inline size_t set_promotion_reserve(size_t new_val);
+  inline size_t get_promotion_reserve() const;
+
+  // Returns previous value
+  inline size_t set_old_evac_reserve(size_t new_val);
+  inline size_t get_old_evac_reserve() const;
+
+  inline void reset_old_evac_expended();
+  inline size_t expend_old_evac(size_t increment);
+  inline size_t get_old_evac_expended() const;
+
+  // Returns previous value
+  inline size_t set_young_evac_reserve(size_t new_val);
+  inline size_t get_young_evac_reserve() const;
+
+  inline void reset_young_evac_expended();
+  inline size_t expend_young_evac(size_t increment);
+  inline size_t get_young_evac_expended() const;
+
+  // Returns previous value.  This is a signed value because it is the amount borrowed minus the amount reserved for
+  // young-gen evacuation.  In case we cannot borrow much, this value might be negative.
+  inline intptr_t set_alloc_supplement_reserve(intptr_t new_val);
+  inline intptr_t get_alloc_supplement_reserve() const;
 
 private:
   void manage_satb_barrier(bool active);

--- a/src/hotspot/share/gc/shenandoah/shenandoahHeap.hpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahHeap.hpp
@@ -346,25 +346,22 @@ private:
   // two values are constant throughout each GC phases, we introduce a new service into ShenandoahGeneration.  This service
   // provides adjusted_available() based on an adjusted capacity.  At the start of evacuation, we adjust young capacity by
   // adding the amount to be borrowed from old-gen and subtracting the _young_evac_reserve, we adjust old capacity by
-  // subtracting the amount to be loaned to young-gen and subtracting the _old_evac_reserve.  At the end of update-refs, we
-  // unadjust the capacity of each generation, add _young_evac_expended to young-gen used, and _old_evac_expended to
-  // old-gen used.
+  // subtracting the amount to be loaned to young-gen.  At the end of update-refs, we unadjust the capacity of each generation,
+  // and add _young_evac_expended to young-gen used.
   //
   // We always use adjusted capacities to determine permission to allocate within young and to promote into old.  Note
   // that adjusted capacities equal traditional capacities except during evacuation and update refs.
   //
   // During evacuation, we assure that _young_evac_expended does not exceed _young_evac_reserve and that _old_evac_expended
-  // does not exceed _old_evac_reserve.  GCLAB allocations do not immediately affect used within the respective generations
-  // since the adjusted capacity within each generation already accounts for the entire evacuation reserve.  Each GCLAB
-  // allocations increments _young_evac_expended or _old_evac_expended rather than incrementing the affiliated generation's
-  // used value.
+  // does not exceed _old_evac_reserve.  GCLAB allocations do not immediately affect used within the young generation
+  // since the adjusted capacity already accounts for the entire evacuation reserve.  Each GCLAB allocations increments
+  // _young_evac_expended rather than incrementing the affiliated generation's used value.
   //
   // At the end of update references, we perform the following bookkeeping activities:
   //
   // 1. Unadjust the capacity within young-gen and old-gen
   // 2. Increase young_gen->used() by _young_evac_expended.  This represents memory consumed by evacutions from young-gen.
-  // 3. Increase old_gen->used() by _old_evac_expended.  This represents memory consumed by evacuations from old-gen.
-  // 4. Clear (reset to zero) _alloc_supplement_reserve, _young_evac_reserve, _old_evac_reserve, and _promotion_reserve
+  // 3. Clear (reset to zero) _alloc_supplement_reserve, _young_evac_reserve, _old_evac_reserve, and _promotion_reserve
   //
   // _young_evac_reserve and _old_evac_reserve are only non-zero during evacuation and update-references.
   //

--- a/src/hotspot/share/gc/shenandoah/shenandoahHeap.hpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahHeap.hpp
@@ -380,17 +380,17 @@ private:
   // effort.  If this happens, the requesting thread blocks until some other thread manages to evacuate the offending object.
   // Only after "all" threads fail to evacuate an object do we consider the evacuation effort to have failed.
 
-  intptr_t _alloc_supplement_reserve;  // Supplemental memory reserved for young allocations during evac and update refs
-  size_t _promotion_reserve;           // How much memory is reserved within old-gen to hold the results of promotion?
+  intptr_t _alloc_supplement_reserve;  // Bytes reserved for young allocations during evac and update refs
+  size_t _promotion_reserve;           // Bytes reserved within old-gen to hold the results of promotion
 
 
-  size_t _old_evac_reserve;            // Memory reserved within old-gen to hold evacuated objects from old-gen collection set
-  size_t _old_evac_expended;           // How much old-gen memory has been expended on old-gen evacuations?
+  size_t _old_evac_reserve;            // Bytes reserved within old-gen to hold evacuated objects from old-gen collection set
+  size_t _old_evac_expended;           // Bytes of old-gen memory expended on old-gen evacuations?
 
-  size_t _young_evac_reserve;          // Memory reserved within young-gen to hold evacuated objects from young-gen collection set
-  size_t _young_evac_expended;         // How much old-gen memory has been expended on young-gen evacuations?
+  size_t _young_evac_reserve;          // Bytes reserved within young-gen to hold evacuated objects from young-gen collection set
+  size_t _young_evac_expended;         // Bytes old-gen memory has been expended on young-gen evacuations?
 
-  size_t _captured_old_usage;          // What was old usage when last captured?
+  size_t _captured_old_usage;          // What was old usage (bytes) when last captured?
 
   size_t _previous_promotion;          // Bytes promoted during previous evacuation
 
@@ -682,18 +682,18 @@ public:
 // ---------- Allocation support
 //
 private:
-  HeapWord* allocate_memory_under_lock(ShenandoahAllocRequest& request, bool& in_new_region);
+  HeapWord* allocate_memory_under_lock(ShenandoahAllocRequest& request, bool& in_new_region, bool is_promotion);
 
   inline HeapWord* allocate_from_gclab(Thread* thread, size_t size);
   HeapWord* allocate_from_gclab_slow(Thread* thread, size_t size);
   HeapWord* allocate_new_gclab(size_t min_size, size_t word_size, size_t* actual_size);
 
-  inline HeapWord* allocate_from_plab(Thread* thread, size_t size);
-  HeapWord* allocate_from_plab_slow(Thread* thread, size_t size);
+  inline HeapWord* allocate_from_plab(Thread* thread, size_t size, bool is_promotion);
+  HeapWord* allocate_from_plab_slow(Thread* thread, size_t size, bool is_promotion);
   HeapWord* allocate_new_plab(size_t min_size, size_t word_size, size_t* actual_size);
 
 public:
-  HeapWord* allocate_memory(ShenandoahAllocRequest& request);
+  HeapWord* allocate_memory(ShenandoahAllocRequest& request, bool is_promotion);
   HeapWord* mem_allocate(size_t size, bool* what);
   MetaWord* satisfy_failed_metadata_allocation(ClassLoaderData* loader_data,
                                                size_t size,

--- a/src/hotspot/share/gc/shenandoah/shenandoahHeap.hpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahHeap.hpp
@@ -391,6 +391,7 @@ private:
 
   size_t _previous_promotion;          // Bytes promoted during previous evacuation
 
+  bool _upgraded_to_full;
 
   void set_gc_state_all_threads(char state);
   void set_gc_state_mask(uint mask, bool value);
@@ -431,6 +432,9 @@ public:
   inline bool is_concurrent_weak_root_in_progress() const;
   bool is_concurrent_prep_for_mixed_evacuation_in_progress();
   inline bool is_aging_cycle() const;
+  inline bool upgraded_to_full() { return _upgraded_to_full; }
+  inline void start_conc_gc() { _upgraded_to_full = false; }
+  inline void record_upgrade_to_full() { _upgraded_to_full = true; }
 
   inline size_t capture_old_usage(size_t usage);
   inline void set_previous_promotion(size_t promoted_bytes);

--- a/src/hotspot/share/gc/shenandoah/shenandoahHeap.inline.hpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahHeap.inline.hpp
@@ -406,9 +406,6 @@ inline oop ShenandoahHeap::try_evacuate_object(oop p, Thread* thread, Shenandoah
   if (copy == NULL) {
     if (target_gen == OLD_GENERATION) {
       assert(mode()->is_generational(), "Should only be here in generational mode.");
-
-      // OJO: AROUND HERE IS WHERE KELVIN NEEDS TO ACCOUNT FOR CONSUMPTION OF OLD EVACUATION AND PROMOTION BUDGETS
-
       if (from_region->is_young()) {
         // Signal that promotion failed. Will evacuate this old object somewhere in young gen.
         handle_promotion_failure();

--- a/src/hotspot/share/gc/shenandoah/shenandoahHeap.inline.hpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahHeap.inline.hpp
@@ -386,12 +386,12 @@ inline oop ShenandoahHeap::try_evacuate_object(oop p, Thread* thread, Shenandoah
         }
         case OLD_GENERATION: {
            if (ShenandoahUsePLAB) {
-             copy = allocate_from_plab(thread, size, is_promotion);;
+             copy = allocate_from_plab(thread, size, is_promotion);
              if ((copy == nullptr) && (size < ShenandoahThreadLocalData::plab_size(thread))) {
                // PLAB allocation failed because we are bumping up against the limit on old evacuation reserve.  Try resetting
                // the desired PLAB size and retry PLAB allocation to avoid cascading of shared memory allocations.
                ShenandoahThreadLocalData::set_plab_size(thread, PLAB::min_size());
-               copy = allocate_from_gclab(thread, size);
+               copy = allocate_from_plab(thread, size, is_promotion);
                // If we still get nullptr, we'll try a shared allocation below.
              }
            }

--- a/src/hotspot/share/gc/shenandoah/shenandoahHeap.inline.hpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahHeap.inline.hpp
@@ -291,15 +291,6 @@ inline HeapWord* ShenandoahHeap::allocate_from_gclab(Thread* thread, size_t size
     return NULL;
   }
   HeapWord* obj = gclab->allocate(size);
-#undef KELVIN_VERBOSE_INLINE
-#ifdef KELVIN_VERBOSE_INLINE
-  if (obj != NULL) {
-    ShenandoahHeapRegion* r = heap_region_containing(obj);
-    if (r->age() > 0) {
-      printf("Oops!  allocate_from_gclab evacuating to young region " SIZE_FORMAT " with non-zero age %u\n", r->index(), r->age());
-    }
-  }
-#endif
   if (obj != NULL) {
     return obj;
   }
@@ -417,11 +408,6 @@ inline oop ShenandoahHeap::try_evacuate_object(oop p, Thread* thread, Shenandoah
       // If we failed to allocated in LAB, we'll try a shared allocation.
       ShenandoahAllocRequest req = ShenandoahAllocRequest::for_shared_gc(size, target_gen);
       copy = allocate_memory(req, is_promotion);
-#undef KELVIN_VERBOSE_SEEME
-#ifdef KELVIN_VERBOSE_SEEME
-      printf("shared allocation @ " PTR_FORMAT " after LAB allocation failed, size: " SIZE_FORMAT ", is_promotion: %d\n",
-             p2i(copy), size, is_promotion);
-#endif
       alloc_from_lab = false;
     }
 #ifdef ASSERT
@@ -460,10 +446,6 @@ inline oop ShenandoahHeap::try_evacuate_object(oop p, Thread* thread, Shenandoah
     // Successfully evacuated. Our copy is now the public one!
     if (mode()->is_generational()) {
       if (target_gen == OLD_GENERATION) {
-#ifdef KELVIN_VERBOSE_INLINE
-        printf("SH::teo(" PTR_FORMAT ") R:" SIZE_FORMAT " W:" SIZE_FORMAT " %s\n",
-               p2i(p), from_region->index(), size, from_region->is_young()? "P":"E");
-#endif
         handle_old_evacuation(copy, size, from_region->is_young());
       } else if (target_gen == YOUNG_GENERATION) {
         if (is_aging_cycle()) {

--- a/src/hotspot/share/gc/shenandoah/shenandoahHeap.inline.hpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahHeap.inline.hpp
@@ -561,6 +561,87 @@ inline bool ShenandoahHeap::is_aging_cycle() const {
   return _is_aging_cycle.is_set();
 }
 
+inline size_t ShenandoahHeap::set_promotion_reserve(size_t new_val) {
+  size_t orig = _promotion_reserve;
+  _promotion_reserve = new_val;
+  return orig;
+}
+
+inline size_t ShenandoahHeap::get_promotion_reserve() const {
+  return _promotion_reserve;
+}
+
+// returns previous value
+size_t ShenandoahHeap::capture_old_usage(size_t old_usage) {
+  size_t previous_value = _captured_old_usage;
+  _captured_old_usage = old_usage;
+  return previous_value;
+}
+
+void ShenandoahHeap::set_previous_promotion(size_t promoted_bytes) {
+  _previous_promotion = promoted_bytes;
+}
+
+size_t ShenandoahHeap::get_previous_promotion() const {
+  return _previous_promotion;
+}
+
+inline size_t ShenandoahHeap::set_old_evac_reserve(size_t new_val) {
+  size_t orig = _old_evac_reserve;
+  _old_evac_reserve = new_val;
+  return orig;
+}
+
+inline size_t ShenandoahHeap::get_old_evac_reserve() const {
+  return _old_evac_reserve;
+}
+
+inline void ShenandoahHeap::reset_old_evac_expended() {
+  _old_evac_expended = 0;
+}
+
+inline size_t ShenandoahHeap::expend_old_evac(size_t increment) {
+  _old_evac_expended += increment;
+  return _old_evac_expended;
+}
+
+inline size_t ShenandoahHeap::get_old_evac_expended() const {
+  return _old_evac_expended;
+}
+
+inline size_t ShenandoahHeap::set_young_evac_reserve(size_t new_val) {
+  size_t orig = _young_evac_reserve;
+  _young_evac_reserve = new_val;
+  return orig;
+}
+
+inline size_t ShenandoahHeap::get_young_evac_reserve() const {
+  return _young_evac_reserve;
+}
+
+inline void ShenandoahHeap::reset_young_evac_expended() {
+  _young_evac_expended = 0;
+}
+
+inline size_t ShenandoahHeap::expend_young_evac(size_t increment) {
+  _young_evac_expended += increment;
+  return _young_evac_expended;
+}
+
+inline size_t ShenandoahHeap::get_young_evac_expended() const {
+  return _young_evac_expended;
+}
+
+inline intptr_t ShenandoahHeap::set_alloc_supplement_reserve(intptr_t new_val) {
+  intptr_t orig = _alloc_supplement_reserve;
+  _alloc_supplement_reserve = new_val;
+  return orig;
+}
+
+inline intptr_t ShenandoahHeap::get_alloc_supplement_reserve() const {
+  return _alloc_supplement_reserve;
+}
+
 template<class T>
 inline void ShenandoahHeap::marked_object_iterate(ShenandoahHeapRegion* region, T* cl) {
   marked_object_iterate(region, cl, region->top());

--- a/src/hotspot/share/gc/shenandoah/shenandoahHeapRegion.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahHeapRegion.cpp
@@ -250,7 +250,7 @@ void ShenandoahHeapRegion::make_unpinned() {
 
 void ShenandoahHeapRegion::make_cset() {
   shenandoah_assert_heaplocked();
-  reset_age();
+  // Leave age untouched.  We need to consult the age when we are deciding whether to promote evacuated objects.
   switch (_state) {
     case _regular:
       set_state(_cset);

--- a/src/hotspot/share/gc/shenandoah/shenandoahHeapRegion.hpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahHeapRegion.hpp
@@ -438,6 +438,7 @@ public:
 
   uint age()           { return _age; }
   void increment_age() { _age++; }
+  void decrement_age() { if (_age-- == 0) { _age = 0; } }
   void reset_age()     { _age = 0; }
 
   // Sets all remembered set cards to dirty.  Returns the number of regions spanned by the associated humongous object.

--- a/src/hotspot/share/gc/shenandoah/shenandoahHeapRegion.hpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahHeapRegion.hpp
@@ -437,7 +437,7 @@ public:
   void set_affiliation(ShenandoahRegionAffiliation new_affiliation);
 
   uint age()           { return _age; }
-  void increment_age() { if (_age < markWord::max_age) { _age++; } }
+  void increment_age() { _age++; }
   void reset_age()     { _age = 0; }
 
   // Sets all remembered set cards to dirty.  Returns the number of regions spanned by the associated humongous object.

--- a/src/hotspot/share/gc/shenandoah/shenandoahHeapRegion.inline.hpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahHeapRegion.inline.hpp
@@ -33,10 +33,12 @@
 
 // If next available memory is not aligned on address that is multiple of alignment, fill the empty space
 // so that returned object is aligned on an address that is a multiple of alignment_in_words.  Requested
-// size is in words.
+// size is in words.  It is assumed that this->is_old().  A pad object is allocated, filled, and registered
+// if necessary to assure the new allocation is properly aligned.
 HeapWord* ShenandoahHeapRegion::allocate_aligned(size_t size, ShenandoahAllocRequest req, size_t alignment_in_bytes) {
   shenandoah_assert_heaplocked_or_safepoint();
   assert(is_object_aligned(size), "alloc size breaks alignment: " SIZE_FORMAT, size);
+  assert(is_old(), "aligned allocations are only taken from OLD regions to support PLABs");
 
   HeapWord* obj = top();
   uintptr_t addr_as_int = (uintptr_t) obj;

--- a/src/hotspot/share/gc/shenandoah/shenandoahMarkClosures.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahMarkClosures.cpp
@@ -60,21 +60,6 @@ void ShenandoahFinalMarkUpdateRegionStateClosure::heap_region_do(ShenandoahHeapR
       }
     }
 
-    if (ShenandoahHeap::heap()->mode()->is_generational()) {
-      // Allocations move the watermark when top moves, however compacting
-      // objects will sometimes lower top beneath the watermark, after which,
-      // attempts to read the watermark will assert out (watermark should not be
-      // higher than top). The right way™ to check for new allocations is to compare
-      // top with the TAMS as is done earlier in this function.
-      if (top > tams) {
-        // There have been allocations in this region since the start of the cycle.
-        // Any objects new to this region must not assimilate elevated age.
-        r->reset_age();
-      } else if (ShenandoahHeap::heap()->is_aging_cycle()) {
-        r->increment_age();
-      }
-    }
-
     // Remember limit for updating refs. It's guaranteed that we get no
     // from-space-refs written from here on.
     r->set_update_watermark_at_safepoint(r->top());

--- a/src/hotspot/share/gc/shenandoah/shenandoahOldGC.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahOldGC.cpp
@@ -193,7 +193,7 @@ bool ShenandoahOldGC::collect(GCCause::Cause cause) {
 
   assert(!heap->is_concurrent_strong_root_in_progress(), "No evacuations during old gc.");
 
-  vmop_entry_final_roots();
+  vmop_entry_final_roots(false);
 
   if (heap->is_concurrent_prep_for_mixed_evacuation_in_progress()) {
     if (!entry_coalesce_and_fill()) {

--- a/src/hotspot/share/gc/shenandoah/shenandoahThreadLocalData.hpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahThreadLocalData.hpp
@@ -174,7 +174,7 @@ public:
   }
 
   static void disable_plab_promotions(Thread* thread) {
-    data(thread)->_plab_allows_promotion = true;
+    data(thread)->_plab_allows_promotion = false;
   }
 
   static bool allow_plab_promotions(Thread* thread) {

--- a/src/hotspot/share/gc/shenandoah/shenandoahThreadLocalData.hpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahThreadLocalData.hpp
@@ -200,19 +200,19 @@ public:
   static void reset_plab_promoted(Thread* thread) {
     data(thread)->_plab_promoted = 0;
   }
-  
+
   static void add_to_plab_promoted(Thread* thread, size_t increment) {
     data(thread)->_plab_promoted += increment;
   }
-  
+
   static void subtract_from_plab_promoted(Thread* thread, size_t increment) {
     data(thread)->_plab_promoted -= increment;
   }
-  
+
   static size_t get_plab_promoted(Thread* thread) {
     return data(thread)->_plab_promoted;
   }
-  
+
   static void add_paced_time(Thread* thread, double v) {
     data(thread)->_paced_time += v;
   }

--- a/src/hotspot/share/gc/shenandoah/shenandoahThreadLocalData.hpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahThreadLocalData.hpp
@@ -75,6 +75,8 @@ private:
     _gclab_size(0),
     _plab(NULL),
     _plab_size(0),
+    _plab_evacuated(0),
+    _plab_promoted(0),
     _worker_id(INVALID_WORKER_ID),
     _disarmed_value(0),
     _paced_time(0) {
@@ -89,6 +91,7 @@ private:
       delete _gclab;
     }
     if (_plab != NULL) {
+      ShenandoahHeap::heap()->retire_plab(_plab);
       delete _plab;
     }
   }
@@ -186,6 +189,10 @@ public:
     data(thread)->_plab_evacuated += increment;
   }
 
+  static void subtract_from_plab_evacuated(Thread* thread, size_t increment) {
+    data(thread)->_plab_evacuated -= increment;
+  }
+
   static size_t get_plab_evacuated(Thread* thread) {
     return data(thread)->_plab_evacuated;
   }
@@ -196,6 +203,10 @@ public:
   
   static void add_to_plab_promoted(Thread* thread, size_t increment) {
     data(thread)->_plab_promoted += increment;
+  }
+  
+  static void subtract_from_plab_promoted(Thread* thread, size_t increment) {
+    data(thread)->_plab_promoted -= increment;
   }
   
   static size_t get_plab_promoted(Thread* thread) {

--- a/src/hotspot/share/gc/shenandoah/shenandoahThreadLocalData.hpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahThreadLocalData.hpp
@@ -166,6 +166,42 @@ public:
     data(thread)->_plab_size = v;
   }
 
+  static void enable_plab_promotions(Thread* thread) {
+    data(thread)->_plab_allows_promotion = true;
+  }
+
+  static void disable_plab_promotions(Thread* thread) {
+    data(thread)->_plab_allows_promotion = true;
+  }
+
+  static bool allow_plab_promotions(Thread* thread) {
+    return data(thread)->_plab_allows_promotion;
+  }
+
+  static void reset_plab_evacuated(Thread* thread) {
+    data(thread)->_plab_evacuated = 0;
+  }
+
+  static void add_to_plab_evacuated(Thread* thread, size_t increment) {
+    data(thread)->_plab_evacuated += increment;
+  }
+
+  static size_t get_plab_evacuated(Thread* thread) {
+    return data(thread)->_plab_evacuated;
+  }
+
+  static void reset_plab_promoted(Thread* thread) {
+    data(thread)->_plab_promoted = 0;
+  }
+  
+  static void add_to_plab_promoted(Thread* thread, size_t increment) {
+    data(thread)->_plab_promoted += increment;
+  }
+  
+  static size_t get_plab_promoted(Thread* thread) {
+    return data(thread)->_plab_promoted;
+  }
+  
   static void add_paced_time(Thread* thread, double v) {
     data(thread)->_paced_time += v;
   }

--- a/src/hotspot/share/gc/shenandoah/shenandoahThreadLocalData.hpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahThreadLocalData.hpp
@@ -44,7 +44,7 @@ private:
   // Evacuation OOM state
   uint8_t                 _oom_scope_nesting_level;
   bool                    _oom_during_evac;
-  bool	                  _plab_allows_promotion; // If false, no more promotion by this thread during this evacuation phase.
+  bool                    _plab_allows_promotion; // If false, no more promotion by this thread during this evacuation phase.
   SATBMarkQueue           _satb_mark_queue;
 
   // Thread-local allocation buffer for object evacuations.

--- a/src/hotspot/share/gc/shenandoah/shenandoahThreadLocalData.hpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahThreadLocalData.hpp
@@ -44,6 +44,7 @@ private:
   // Evacuation OOM state
   uint8_t                 _oom_scope_nesting_level;
   bool                    _oom_during_evac;
+  bool	                  _plab_allows_promotion; // If false, no more promotion by this thread during this evacuation phase.
   SATBMarkQueue           _satb_mark_queue;
 
   // Thread-local allocation buffer for object evacuations.
@@ -57,6 +58,9 @@ private:
   // for promotions from the young generation into the old generation.
   PLAB* _plab;
   size_t _plab_size;
+
+  size_t _plab_evacuated;
+  size_t _plab_promoted;
 
   uint  _worker_id;
   int  _disarmed_value;

--- a/src/hotspot/share/gc/shenandoah/shenandoahUtils.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahUtils.cpp
@@ -35,6 +35,7 @@
 #include "gc/shenandoah/shenandoahHeap.inline.hpp"
 #include "gc/shenandoah/shenandoahReferenceProcessor.hpp"
 #include "gc/shenandoah/shenandoahUtils.hpp"
+#include "gc/shenandoah/shenandoahYoungGeneration.hpp"
 #include "utilities/debug.hpp"
 
 ShenandoahPhaseTimings::Phase ShenandoahTimingsTracker::_current_phase = ShenandoahPhaseTimings::_invalid_phase;
@@ -68,7 +69,21 @@ ShenandoahGCSession::ShenandoahGCSession(GCCause::Cause cause, ShenandoahGenerat
 
 
 ShenandoahGCSession::~ShenandoahGCSession() {
+  
   _generation->heuristics()->record_cycle_end();
+#define KELVIN_VERBOSE
+#ifdef KELVIN_VERBOSE
+  printf("Destructing ShenandoahGCSession: upgraded to full? %s\n", _heap->upgraded_to_full()? "yes": "no");
+#endif
+  if (_heap->mode()->is_generational() &&
+      ((_generation->generation_mode() == GLOBAL) || _heap->upgraded_to_full())) {
+    // If we just completed a GLOBAL GC, claim credit for completion of young-gen and old-gen GC as well
+    _heap->young_generation()->heuristics()->record_cycle_end();
+    _heap->old_generation()->heuristics()->record_cycle_end();
+#ifdef KELVIN_VERBOSE
+    printf("At end of GLOBAL GC, claiming credit for completion of young-gen and old-gen GC as well\n");
+#endif
+  }
   _timer->register_gc_end();
   _heap->trace_heap_after_gc(_tracer);
   _tracer->report_gc_reference_stats(_generation->ref_processor()->reference_process_stats());

--- a/src/hotspot/share/gc/shenandoah/shenandoahUtils.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahUtils.cpp
@@ -69,7 +69,7 @@ ShenandoahGCSession::ShenandoahGCSession(GCCause::Cause cause, ShenandoahGenerat
 
 
 ShenandoahGCSession::~ShenandoahGCSession() {
-  
+
   _generation->heuristics()->record_cycle_end();
   if (_heap->mode()->is_generational() &&
       ((_generation->generation_mode() == GLOBAL) || _heap->upgraded_to_full())) {

--- a/src/hotspot/share/gc/shenandoah/shenandoahUtils.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahUtils.cpp
@@ -71,18 +71,11 @@ ShenandoahGCSession::ShenandoahGCSession(GCCause::Cause cause, ShenandoahGenerat
 ShenandoahGCSession::~ShenandoahGCSession() {
   
   _generation->heuristics()->record_cycle_end();
-#undef KELVIN_VERBOSE
-#ifdef KELVIN_VERBOSE
-  printf("Destructing ShenandoahGCSession: upgraded to full? %s\n", _heap->upgraded_to_full()? "yes": "no");
-#endif
   if (_heap->mode()->is_generational() &&
       ((_generation->generation_mode() == GLOBAL) || _heap->upgraded_to_full())) {
     // If we just completed a GLOBAL GC, claim credit for completion of young-gen and old-gen GC as well
     _heap->young_generation()->heuristics()->record_cycle_end();
     _heap->old_generation()->heuristics()->record_cycle_end();
-#ifdef KELVIN_VERBOSE
-    printf("At end of GLOBAL GC, claiming credit for completion of young-gen and old-gen GC as well\n");
-#endif
   }
   _timer->register_gc_end();
   _heap->trace_heap_after_gc(_tracer);

--- a/src/hotspot/share/gc/shenandoah/shenandoahUtils.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahUtils.cpp
@@ -71,7 +71,7 @@ ShenandoahGCSession::ShenandoahGCSession(GCCause::Cause cause, ShenandoahGenerat
 ShenandoahGCSession::~ShenandoahGCSession() {
   
   _generation->heuristics()->record_cycle_end();
-#define KELVIN_VERBOSE
+#undef KELVIN_VERBOSE
 #ifdef KELVIN_VERBOSE
   printf("Destructing ShenandoahGCSession: upgraded to full? %s\n", _heap->upgraded_to_full()? "yes": "no");
 #endif

--- a/src/hotspot/share/gc/shenandoah/shenandoahVMOperations.hpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahVMOperations.hpp
@@ -134,10 +134,11 @@ public:
 
 class VM_ShenandoahFinalRoots: public VM_ShenandoahOperation {
   ShenandoahConcurrentGC* const _gc;
+  bool _incr_region_ages;
 public:
-  VM_ShenandoahFinalRoots(ShenandoahConcurrentGC* gc) :
+  VM_ShenandoahFinalRoots(ShenandoahConcurrentGC* gc, bool incr_region_ages) :
     VM_ShenandoahOperation(),
-    _gc(gc) {};
+    _gc(gc), _incr_region_ages(incr_region_ages) {};
   VM_Operation::VMOp_Type type() const { return VMOp_ShenandoahFinalRoots; }
   const char* name()             const { return "Shenandoah Final Roots"; }
   virtual void doit();

--- a/src/hotspot/share/gc/shenandoah/shenandoahVerifier.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahVerifier.cpp
@@ -398,7 +398,7 @@ class ShenandoahGenerationStatsClosure : public ShenandoahHeapRegionClosure {
       generation_used = generation->used();
     }
 
-#define KELVIN_VERBOSE
+#undef KELVIN_VERBOSE
 #ifdef KELVIN_VERBOSE
     if (stats.used() != generation_used) {
       printf("Generation name: %s\n", generation->name());
@@ -814,7 +814,7 @@ void ShenandoahVerifier::verify_at_safepoint(const char* label,
 
     size_t heap_used = _heap->used();
 
-#define KELVIN_VERBOSE
+#undef KELVIN_VERBOSE
 #ifdef KELVIN_VERBOSE
     if (cl.used() != heap_used) {
       printf("Heap usage guarantee at risk\n");

--- a/src/hotspot/share/gc/shenandoah/shenandoahVerifier.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahVerifier.cpp
@@ -398,35 +398,6 @@ class ShenandoahGenerationStatsClosure : public ShenandoahHeapRegionClosure {
       generation_used = generation->used();
     }
 
-#undef KELVIN_VERBOSE
-#ifdef KELVIN_VERBOSE
-    if (stats.used() != generation_used) {
-      printf("Generation name: %s\n", generation->name());
-      printf("Verification failure: %s, young_evac_expended: " SIZE_FORMAT "\n",
-             label, ShenandoahHeap::heap()->get_young_evac_expended());
-      printf("  generation->used(): " SIZE_FORMAT ", stats.used: " SIZE_FORMAT "\n",
-             generation->used(), stats.used());
-
-      size_t total_young_used = 0;
-      size_t total_old_used = 0;
-      for (size_t index = 0; index < ShenandoahHeapRegion::region_count(); index++) {
-        ShenandoahHeapRegion* r = ShenandoahHeap::heap()->get_region(index);
-        if (r->is_young()) {
-          total_young_used += r->used();
-        } else if (r->is_old()) {
-          total_old_used += r->used();
-        }
-        printf("Region " SIZE_FORMAT " (%s) bottom: " PTR_FORMAT ", top: " PTR_FORMAT ", live: " SIZE_FORMAT
-               ", garbage: " SIZE_FORMAT ", used: " SIZE_FORMAT "\n", index,
-               r->is_young()? "YOUNG": "OLD", p2i(r->bottom()), p2i(r->top()), r->get_live_data_bytes(), r->garbage(), r->used());
-        fflush(stdout);
-      }
-      printf("Total young used: " SIZE_FORMAT "\n", total_young_used);
-      printf("  Total old used: " SIZE_FORMAT "\n", total_old_used);
-      fflush(stdout);
-    }
-#endif
-
     guarantee(stats.used() == generation_used,
               "%s: generation (%s) used size must be consistent: generation-used = " SIZE_FORMAT "%s, regions-used = " SIZE_FORMAT "%s",
               label, generation->name(),
@@ -813,35 +784,6 @@ void ShenandoahVerifier::verify_at_safepoint(const char* label,
     _heap->heap_region_iterate(&cl);
 
     size_t heap_used = _heap->used();
-
-#undef KELVIN_VERBOSE
-#ifdef KELVIN_VERBOSE
-    if (cl.used() != heap_used) {
-      printf("Heap usage guarantee at risk\n");
-      printf("Verification failure: %s, young_evac_expended: " SIZE_FORMAT "\n",
-             label, ShenandoahHeap::heap()->get_young_evac_expended());
-      printf("  heap_used: " SIZE_FORMAT ", cl.used(): " SIZE_FORMAT "\n",
-             heap_used, cl.used());
-
-      size_t total_young_used = 0;
-      size_t total_old_used = 0;
-      for (size_t index = 0; index < ShenandoahHeapRegion::region_count(); index++) {
-        ShenandoahHeapRegion* r = ShenandoahHeap::heap()->get_region(index);
-        if (r->is_young()) {
-          total_young_used += r->used();
-        } else if (r->is_old()) {
-          total_old_used += r->used();
-        }
-        printf("Region " SIZE_FORMAT " (%s) bottom: " PTR_FORMAT ", top: " PTR_FORMAT ", live: " SIZE_FORMAT
-               ", garbage: " SIZE_FORMAT ", used: " SIZE_FORMAT "\n", index,
-               r->is_young()? "YOUNG": "OLD", p2i(r->bottom()), p2i(r->top()), r->get_live_data_bytes(), r->garbage(), r->used());
-        fflush(stdout);
-      }
-      printf("Total young used: " SIZE_FORMAT "\n", total_young_used);
-      printf("  Total old used: " SIZE_FORMAT "\n", total_old_used);
-      fflush(stdout);
-    }
-#endif
 
     guarantee(cl.used() == heap_used,
               "%s: heap used size must be consistent: heap-used = " SIZE_FORMAT "%s, regions-used = " SIZE_FORMAT "%s",

--- a/src/hotspot/share/gc/shenandoah/shenandoahVerifier.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahVerifier.cpp
@@ -398,12 +398,13 @@ class ShenandoahGenerationStatsClosure : public ShenandoahHeapRegionClosure {
       generation_used = generation->used();
     }
 
-#undef KELVIN_VERBOSE
+#define KELVIN_VERBOSE
 #ifdef KELVIN_VERBOSE
     if (stats.used() != generation_used) {
+      printf("Generation name: %s\n", generation->name());
       printf("Verification failure: %s, young_evac_expended: " SIZE_FORMAT "\n",
              label, ShenandoahHeap::heap()->get_young_evac_expended());
-      printf("  generation_used: " SIZE_FORMAT ", stats.used: " SIZE_FORMAT "\n",
+      printf("  generation->used(): " SIZE_FORMAT ", stats.used: " SIZE_FORMAT "\n",
              generation->used(), stats.used());
 
       size_t total_young_used = 0;
@@ -812,6 +813,36 @@ void ShenandoahVerifier::verify_at_safepoint(const char* label,
     _heap->heap_region_iterate(&cl);
 
     size_t heap_used = _heap->used();
+
+#define KELVIN_VERBOSE
+#ifdef KELVIN_VERBOSE
+    if (cl.used() != heap_used) {
+      printf("Heap usage guarantee at risk\n");
+      printf("Verification failure: %s, young_evac_expended: " SIZE_FORMAT "\n",
+             label, ShenandoahHeap::heap()->get_young_evac_expended());
+      printf("  heap_used: " SIZE_FORMAT ", cl.used(): " SIZE_FORMAT "\n",
+             heap_used, cl.used());
+
+      size_t total_young_used = 0;
+      size_t total_old_used = 0;
+      for (size_t index = 0; index < ShenandoahHeapRegion::region_count(); index++) {
+        ShenandoahHeapRegion* r = ShenandoahHeap::heap()->get_region(index);
+        if (r->is_young()) {
+          total_young_used += r->used();
+        } else if (r->is_old()) {
+          total_old_used += r->used();
+        }
+        printf("Region " SIZE_FORMAT " (%s) bottom: " PTR_FORMAT ", top: " PTR_FORMAT ", live: " SIZE_FORMAT
+               ", garbage: " SIZE_FORMAT ", used: " SIZE_FORMAT "\n", index,
+               r->is_young()? "YOUNG": "OLD", p2i(r->bottom()), p2i(r->top()), r->get_live_data_bytes(), r->garbage(), r->used());
+        fflush(stdout);
+      }
+      printf("Total young used: " SIZE_FORMAT "\n", total_young_used);
+      printf("  Total old used: " SIZE_FORMAT "\n", total_old_used);
+      fflush(stdout);
+    }
+#endif
+
     guarantee(cl.used() == heap_used,
               "%s: heap used size must be consistent: heap-used = " SIZE_FORMAT "%s, regions-used = " SIZE_FORMAT "%s",
               label,

--- a/src/hotspot/share/gc/shenandoah/shenandoahYoungGeneration.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahYoungGeneration.cpp
@@ -82,3 +82,10 @@ void ShenandoahYoungGeneration::reserve_task_queues(uint workers) {
 bool ShenandoahYoungGeneration::contains(oop obj) const {
   return ShenandoahHeap::heap()->is_in_young(obj);
 }
+
+ShenandoahHeuristics* ShenandoahYoungGeneration::initialize_heuristics(ShenandoahMode* gc_mode) {
+  _heuristics = gc_mode->initialize_heuristics(this);
+  _heuristics->set_guaranteed_gc_interval(ShenandoahGuaranteedYoungGCInterval);
+  confirm_heuristics_mode();
+  return _heuristics;
+}

--- a/src/hotspot/share/gc/shenandoah/shenandoahYoungGeneration.hpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahYoungGeneration.hpp
@@ -54,12 +54,9 @@ public:
 
   void reserve_task_queues(uint workers) override;
 
-<<<<<< HEAD
-=======
   virtual ShenandoahHeuristics* initialize_heuristics(ShenandoahMode* gc_mode) override;
 
- protected:
->>>>>>> 4b1bbc36308 (Multiple improvements)
+protected:
   bool is_concurrent_mark_in_progress() override;
 
 };

--- a/src/hotspot/share/gc/shenandoah/shenandoahYoungGeneration.hpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahYoungGeneration.hpp
@@ -54,7 +54,14 @@ public:
 
   void reserve_task_queues(uint workers) override;
 
+<<<<<< HEAD
+=======
+  virtual ShenandoahHeuristics* initialize_heuristics(ShenandoahMode* gc_mode) override;
+
+ protected:
+>>>>>>> 4b1bbc36308 (Multiple improvements)
   bool is_concurrent_mark_in_progress() override;
+
 };
 
 #endif // SHARE_VM_GC_SHENANDOAH_SHENANDOAHYOUNGGENERATION_HPP

--- a/src/hotspot/share/gc/shenandoah/shenandoah_globals.hpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoah_globals.hpp
@@ -102,10 +102,12 @@
           range(0,100)                                                      \
                                                                             \
   product(uintx, ShenandoahInitFreeThreshold, 70, EXPERIMENTAL,             \
-          "How much heap should be free before some heuristics trigger the "\
-          "initial (learning) cycles. Affects cycle frequency on startup "  \
-          "and after drastic state changes, e.g. after degenerated/full "   \
-          "GC cycles. In percents of (soft) max heap size.")                \
+          "When less than this amount of memory is free within the"         \
+          "heap or generation, trigger a learning cycle if we are "         \
+          "in learning mode.  Learning mode happens during initialization " \
+          "and following a drastic state change, such as following a "      \
+          "degenerated or Full GC cycle.  In percents of soft max "         \
+          "heap size.")                                                     \
           range(0,100)                                                      \
                                                                             \
   product(uintx, ShenandoahMinFreeThreshold, 10, EXPERIMENTAL,              \
@@ -296,7 +298,7 @@
           "heap size.")                                                     \
           range(1,100)                                                      \
                                                                             \
-  product(uintx, ShenandoahOldEvacRatioPer128, 16, EXPERIMENTAL,                  \
+  product(uintx, ShenandoahOldEvacRatioPer128, 16, EXPERIMENTAL,            \
           "The maximum proportion of evacuation from old-gen memory, as "   \
           "a ratio with 128.  The default value 16 denotes that no more "   \
           "than one eighth (16/128) of the collection set evacuation "      \
@@ -440,22 +442,21 @@
           "Fix references with load reference barrier. Disabling this "     \
           "might degrade performance.")                                     \
                                                                             \
-  product(uintx, ShenandoahTenuredRegionUsageBias, 192, EXPERIMENTAL,       \
+  product(uintx, ShenandoahTenuredRegionUsageBias, 16, EXPERIMENTAL,        \
           "The collection set is comprised of heap regions that contain "   \
           "the greatest amount of garbage.  "                               \
           "For purposes of selecting regions to be included in the "        \
           "collection set, regions that have reached the tenure age will "  \
-          "be treated as if their contained garbage is the actual "         \
-          "contained garbage multiplied by "                                \
-          "(ShenandoahTenuredRegionUsageBias / 128 (e.g. 150% for the "     \
-          "default value) as many times as the region's age meets or "      \
-          "exceeds the tenure age.  For example, if tenure age is 7, "      \
+          "be treated as if their contained garbage is the contained "      \
+          "garbage multiplied by ShenandoahTenuredRegionUsageBias as "      \
+          "many times as the age of the region meets or exceeds "           \
+          "tenure age.  For example, if tenure age is 7, "                  \
           "the region age is 9, ShenandoahTenuredRegionUsageBias is "       \
-          "192, and the region is 12.5% garbage, this region "              \
+          "16, and the region is 12.5% garbage, this region "               \
           "will by treated as if its garbage content is "                   \
-          "1/8 * 27/8 = 42.2% when comparing this region to untenured "     \
-          "regions.")                                                       \
-          range(128, 256)                                                   \
+          "12.5% * 16 * 16 * 16 = 51,200% when comparing this region "      \
+          " to untenured regions.")                                         \
+          range(1,128)                                                      \
                                                                             \
   product(uintx, ShenandoahBorrowPer128, 40, EXPERIMENTAL,                  \
           "During evacuation and reference updating in generational "       \
@@ -485,8 +486,5 @@
           "With generational mode, increment the age of objects and"        \
           "regions each time this many young-gen GC cycles are completed.")
  // end of GC_SHENANDOAH_FLAGS
-
-// 2^ShenandoahTenuredRegionUsageBiasLogBase2 is 128
-#define ShenandoahTenuredRegionUsageBiasLogBase2 7
 
 #endif // SHARE_GC_SHENANDOAH_SHENANDOAH_GLOBALS_HPP

--- a/src/hotspot/share/gc/shenandoah/shenandoah_globals.hpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoah_globals.hpp
@@ -182,6 +182,11 @@
           "Heuristics may trigger collections more frequently. Time is in " \
           "milliseconds. Setting this to 0 disables the feature.")          \
                                                                             \
+  product(uintx, ShenandoahGuaranteedYoungGCInterval, 5*60*1000,  EXPERIMENTAL,  \
+          "Run a collection of the young generation at least this often. "    \
+          "Heuristics may trigger collections more frequently. Time is in " \
+          "milliseconds. Setting this to 0 disables the feature.")          \
+                                                                            \
   product(bool, ShenandoahAlwaysClearSoftRefs, false, EXPERIMENTAL,         \
           "Unconditionally clear soft references, instead of using any "    \
           "other cleanup policy. This minimizes footprint at expense of"    \
@@ -275,7 +280,10 @@
           "How much waste evacuations produce within the reserved space. "  \
           "Larger values make evacuations more resilient against "          \
           "evacuation conflicts, at expense of evacuating less on each "    \
-          "GC cycle.")                                                      \
+          "GC cycle.  Smaller values increase the risk of evacuation "      \
+          "failures, which will trigger stop-the-world Full GC passes.  "   \
+          "A minimum value of 1.6 is recommended for Generational "         \
+          "mode of Shenandoah.")                                            \
           range(1.0,100.0)                                                  \
                                                                             \
   product(bool, ShenandoahEvacReserveOverflow, true, EXPERIMENTAL,          \

--- a/src/hotspot/share/gc/shenandoah/shenandoah_globals.hpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoah_globals.hpp
@@ -302,19 +302,19 @@
           "regions included in the collecdtion set is the smaller "         \
           "of the quantities specified by this parameter and the "          \
           "size of ShenandoahEvacReserve as adjusted by the value of "      \
-          "ShenandoahOldEvacRatio.  In percents of total old-generation "   \
-          "heap size.")                                                     \
+          "ShenandoahOldEvacRatioPercent.  In percents of total "           \
+          "old-generation heap size.")                                      \
           range(1,100)                                                      \
                                                                             \
-  product(uintx, ShenandoahOldEvacRatioPer128, 16, EXPERIMENTAL,            \
+  product(uintx, ShenandoahOldEvacRatioPercent, 12, EXPERIMENTAL,           \
           "The maximum proportion of evacuation from old-gen memory, as "   \
-          "a ratio with 128.  The default value 16 denotes that no more "   \
-          "than one eighth (16/128) of the collection set evacuation "      \
+          "a percent ratio.  The default value 12 denotes that no more "    \
+          "than one eighth (12%) of the collection set evacuation "         \
           "workload may be comprised of old-gen heap regions.  A larger "   \
           "value allows a smaller number of mixed evacuations to process "  \
           "the entire list of old-gen collection candidates at the cost "   \
           "of an increased disruption of the normal cadence of young-gen "  \
-          "collections.  A value of 128 allows a mixed evacuation to "      \
+          "collections.  A value of 100 allows a mixed evacuation to "      \
           "focus entirely on old-gen memory, allowing no young-gen "        \
           "regions to be collected, likely resulting in subsequent "        \
           "allocation failures because the allocation pool is not "         \
@@ -323,7 +323,7 @@
           "regions to be collected, likely resulting in subsequent "        \
           "promotion failures and triggering of stop-the-world full GC "    \
           "events.")                                                        \
-          range(0,128)                                                      \
+          range(0,100)                                                      \
                                                                             \
   product(bool, ShenandoahPacing, true, EXPERIMENTAL,                       \
           "Pace application allocations to give GC chance to start "        \
@@ -466,21 +466,19 @@
           " to untenured regions.")                                         \
           range(1,128)                                                      \
                                                                             \
-  product(uintx, ShenandoahBorrowPer128, 40, EXPERIMENTAL,                  \
+  product(uintx, ShenandoahBorrowPercent, 30, EXPERIMENTAL,                 \
           "During evacuation and reference updating in generational "       \
           "mode, new allocations are allowed to borrow from old-gen "       \
-          "memory up to ShenandoahBorrowPer128 / 128 amount of the "        \
+          "memory up to ShenandoahBorrowPercent / 100 amount of the "       \
           "young-generation content of the current collection set.  "       \
           "Any memory borrowed from old-gen during evacuation and "         \
           "update-references phases of GC will be repaid from the "         \
           "abundance of young-gen memory produced when the collection "     \
-          "set is recycled at the end of updating references.  Note "       \
-          "that the default value of 40 represents approximately 30% "      \
-          "of the young-gen memory within the collection set.  This "       \
-          "reserves roughly 70% of the to-be-reclaimed young "              \
-          "collection set memory to be allocated during the subsequent "    \
-          "concurrent mark phase of GC.")                                   \
-          range(0, 128)                                                     \
+          "set is recycled at the end of updating references.  The "        \
+          "default value of 30 reserves 70% of the to-be-reclaimed "        \
+          "young collection set memory to be allocated during the "         \
+          "subsequent concurrent mark phase of GC.")                        \
+          range(0, 100)                                                     \
                                                                             \
   product(bool, ShenandoahPromoteTenuredObjects, true, DIAGNOSTIC,          \
           "Turn on/off evacuating individual tenured young objects "        \


### PR DESCRIPTION
This commit represents multiple months of incremental performance improvements to allow generational shenandoah to run more efficiently, especially with larger heap sizes and high memory utilization.

Specific improvements are described in individual commit log messages.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

### Reviewers
 * [William Kemper](https://openjdk.java.net/census#wkemper) (@earthling-amzn - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/shenandoah pull/110/head:pull/110` \
`$ git checkout pull/110`

Update a local copy of the PR: \
`$ git checkout pull/110` \
`$ git pull https://git.openjdk.java.net/shenandoah pull/110/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 110`

View PR using the GUI difftool: \
`$ git pr show -t 110`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/shenandoah/pull/110.diff">https://git.openjdk.java.net/shenandoah/pull/110.diff</a>

</details>
