### PR TITLE
Coalesce and fill dead objects after class unloading

### DIFF
--- a/src/hotspot/share/gc/shenandoah/shenandoahConcurrentGC.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahConcurrentGC.cpp
@@ -136,12 +136,6 @@ bool ShenandoahConcurrentGC::collect(GCCause::Cause cause) {
     return false;
   }
 
-  // Global marking has completed. We need to fill in any unmarked objects in the old generation
-  // so that subsequent remembered set scans will not walk pointers into reclaimed memory.
-  if (!heap->cancelled_gc() && heap->mode()->is_generational() && _generation->generation_mode() == GLOBAL) {
-    entry_global_coalesce_and_fill();
-  }
-
   // Concurrent stack processing
   if (heap->is_evacuation_in_progress()) {
     entry_thread_roots();
@@ -174,6 +168,12 @@ bool ShenandoahConcurrentGC::collect(GCCause::Cause cause) {
   // If so, strong_root_in_progress would be unset.
   if (heap->is_concurrent_strong_root_in_progress()) {
     entry_strong_roots();
+  }
+
+  // Global marking has completed. We need to fill in any unmarked objects in the old generation
+  // so that subsequent remembered set scans will not walk pointers into reclaimed memory.
+  if (!heap->cancelled_gc() && heap->mode()->is_generational() && _generation->generation_mode() == GLOBAL) {
+    entry_global_coalesce_and_fill();
   }
 
   // Continue the cycle with evacuation and optional update-refs.

--- a/src/hotspot/share/gc/shenandoah/shenandoahDegeneratedGC.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahDegeneratedGC.cpp
@@ -154,11 +154,12 @@ void ShenandoahDegenGC::op_degenerated() {
 
       op_cleanup_early();
 
+    case _degenerated_evac:
+
       if (heap->mode()->is_generational() && _generation->generation_mode() == GLOBAL) {
         op_global_coalesce_and_fill();
       }
 
-    case _degenerated_evac:
       // If heuristics thinks we should do the cycle, this flag would be set,
       // and we can do evacuation. Otherwise, it would be the shortcut cycle.
       if (heap->is_evacuation_in_progress()) {


### PR DESCRIPTION
This reverts a recent change to coalesce and fill dead objects immediately after final mark. These objects cannot be filled until after class unloading to support a use case where the LRB needs to access from-space objects. So, rather than coalesce and fill during the concurrent mark phase, we move it to the evacuation phase of a degenerated cycle.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

### Reviewers
 * [Kelvin Nilsen](https://openjdk.java.net/census#kdnilsen) (@kdnilsen - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/shenandoah pull/111/head:pull/111` \
`$ git checkout pull/111`

Update a local copy of the PR: \
`$ git checkout pull/111` \
`$ git pull https://git.openjdk.java.net/shenandoah pull/111/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 111`

View PR using the GUI difftool: \
`$ git pr show -t 111`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/shenandoah/pull/111.diff">https://git.openjdk.java.net/shenandoah/pull/111.diff</a>

</details>
