### PR TITLE
Use active generation, rather than young exclusively when preparing for update refs

### DIFF
--- a/src/hotspot/share/gc/shenandoah/shenandoahHeap.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahHeap.cpp
@@ -2590,7 +2590,7 @@ void ShenandoahHeap::update_heap_region_states(bool concurrent) {
     ShenandoahGCPhase phase(concurrent ?
                             ShenandoahPhaseTimings::final_update_refs_update_region_states :
                             ShenandoahPhaseTimings::degen_gc_final_update_refs_update_region_states);
-    ShenandoahFinalUpdateRefsUpdateRegionStateClosure cl (young_generation()->complete_marking_context());
+    ShenandoahFinalUpdateRefsUpdateRegionStateClosure cl (active_generation()->complete_marking_context());
     parallel_heap_region_iterate(&cl);
 
     assert_pinned_region_status();


### PR DESCRIPTION
Without this code, global collections will not function correctly.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

### Reviewers
 * [Kelvin Nilsen](https://openjdk.java.net/census#kdnilsen) (@kdnilsen - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/shenandoah pull/113/head:pull/113` \
`$ git checkout pull/113`

Update a local copy of the PR: \
`$ git checkout pull/113` \
`$ git pull https://git.openjdk.java.net/shenandoah pull/113/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 113`

View PR using the GUI difftool: \
`$ git pr show -t 113`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/shenandoah/pull/113.diff">https://git.openjdk.java.net/shenandoah/pull/113.diff</a>

</details>
