### PR TITLE
Fixes for running in non-generational modes

### DIFF
--- a/src/hotspot/share/gc/shenandoah/shenandoahDegeneratedGC.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahDegeneratedGC.cpp
@@ -118,7 +118,7 @@ void ShenandoahDegenGC::op_degenerated() {
       // changing the cycle parameters mid-cycle during concurrent -> degenerated handover.
       heap->set_unload_classes((!heap->mode()->is_generational() || _generation->generation_mode() == GLOBAL) && _generation->heuristics()->can_unload_classes());
 
-      if (_generation->generation_mode() == YOUNG || (_generation->generation_mode() == GLOBAL && ShenandoahVerify)) {
+      if (heap->mode()->is_generational() && (_generation->generation_mode() == YOUNG || (_generation->generation_mode() == GLOBAL && ShenandoahVerify))) {
         // Swap remembered sets for young, or if the verifier will run during a global collect
         _generation->swap_remembered_set();
       }

--- a/src/hotspot/share/gc/shenandoah/shenandoahFreeSet.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahFreeSet.cpp
@@ -295,7 +295,12 @@ HeapWord* ShenandoahFreeSet::try_allocate_in(ShenandoahHeapRegion* r, Shenandoah
         // This is either a GCLAB or it is a shared evacuation allocation.  In either case, we expend young evac.
         // At end of update refs, we'll add expended young evac into young_gen->used.  We hide this usage
         // from current accounting because memory reserved for evacuation is not part of adjusted capacity.
-        _heap->expend_young_evac(size * HeapWordSize);
+        if (_heap->mode()->is_generational()) {
+          _heap->expend_young_evac(size * HeapWordSize);
+        } else {
+          // If we are not in generational mode, we still need to count this allocation as used memory.
+          _heap->young_generation()->increase_used(size * HeapWordSize);
+        }
       } else {
         assert(r->affiliation() == ShenandoahRegionAffiliation::OLD_GENERATION, "GC Alloc was not YOUNG so must be OLD");
 


### PR DESCRIPTION
A couple of spots that need to be guarded with a check for generational mode.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

### Reviewers
 * [Kelvin Nilsen](https://openjdk.java.net/census#kdnilsen) (@kdnilsen - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/shenandoah pull/114/head:pull/114` \
`$ git checkout pull/114`

Update a local copy of the PR: \
`$ git checkout pull/114` \
`$ git pull https://git.openjdk.java.net/shenandoah pull/114/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 114`

View PR using the GUI difftool: \
`$ git pr show -t 114`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/shenandoah/pull/114.diff">https://git.openjdk.java.net/shenandoah/pull/114.diff</a>

</details>
