### PR TITLE
Coalesce dead objects in pinned old regions during full gc

### DIFF
--- a/src/hotspot/share/gc/shenandoah/shenandoahFullGC.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahFullGC.cpp
@@ -1243,6 +1243,11 @@ public:
     // pinned regions.
     if (!r->is_pinned()) {
       _heap->complete_marking_context()->reset_top_at_mark_start(r);
+    } else {
+      if (r->is_old() && r->is_active() && !r->is_humongous()) {
+        r->begin_preemptible_coalesce_and_fill();
+        r->oop_fill_and_coalesce();
+      }
     }
 
     size_t live = r->used();


### PR DESCRIPTION
Pinned regions are not compacted during a full gc. For old regions, this may leave references in unmarked objects pointing into relocated or reclaimed memory. These unmarked objects need to be filled in to prevent the remembered set scan from following bad pointers.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

### Reviewers
 * [Kelvin Nilsen](https://openjdk.java.net/census#kdnilsen) (@kdnilsen - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/shenandoah pull/116/head:pull/116` \
`$ git checkout pull/116`

Update a local copy of the PR: \
`$ git checkout pull/116` \
`$ git pull https://git.openjdk.java.net/shenandoah pull/116/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 116`

View PR using the GUI difftool: \
`$ git pr show -t 116`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/shenandoah/pull/116.diff">https://git.openjdk.java.net/shenandoah/pull/116.diff</a>

</details>
