### PR TITLE
Clear cards for old regions when they are put into service

### DIFF
--- a/src/hotspot/share/gc/shenandoah/shenandoahFreeSet.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahFreeSet.cpp
@@ -177,16 +177,17 @@ HeapWord* ShenandoahFreeSet::try_allocate_in(ShenandoahHeapRegion* r, Shenandoah
     ShenandoahMarkingContext* const ctx = _heap->complete_marking_context();
 
     r->set_affiliation(req.affiliation());
-    r->set_update_watermark(r->bottom());
 
-    // Any OLD region allocated during concurrent coalesce-and-fill does not need to be coalesced and filled because
-    // all objects allocated within this region are above TAMS (and thus are implicitly marked).  In case this is an
-    // OLD region and concurrent preparation for mixed evacuations visits this region before the start of the next
-    // old-gen concurrent mark (i.e. this region is allocated following the start of old-gen concurrent mark but before
-    // concurrent preparations for mixed evacuations are completed), we mark this region as not requiring any
-    // coalesce-and-fill processing.  This code is only necessary if req.affiliation() is OLD, but harmless if not.
-    r->end_preemptible_coalesce_and_fill();
-    ctx->capture_top_at_mark_start(r);
+    if (r->is_old()) {
+      // Any OLD region allocated during concurrent coalesce-and-fill does not need to be coalesced and filled because
+      // all objects allocated within this region are above TAMS (and thus are implicitly marked).  In case this is an
+      // OLD region and concurrent preparation for mixed evacuations visits this region before the start of the next
+      // old-gen concurrent mark (i.e. this region is allocated following the start of old-gen concurrent mark but before
+      // concurrent preparations for mixed evacuations are completed), we mark this region as not requiring any
+      // coalesce-and-fill processing.
+      r->end_preemptible_coalesce_and_fill();
+      _heap->clear_cards_for(r);
+    }
 
     assert(ctx->top_at_mark_start(r) == r->bottom(), "Newly established allocation region starts with TAMS equal to bottom");
     assert(ctx->is_bitmap_clear_range(ctx->top_bitmap(r), r->end()), "Bitmap above top_bitmap() must be clear");
@@ -508,7 +509,7 @@ void ShenandoahFreeSet::try_recycle_trashed(ShenandoahHeapRegion *r) {
 void ShenandoahFreeSet::recycle_trash() {
   // lock is not reentrable, check we don't have it
   shenandoah_assert_not_heaplocked();
-
+  RTGC_TIME_BLOCK;
   for (size_t i = 0; i < _heap->num_regions(); i++) {
     ShenandoahHeapRegion* r = _heap->get_region(i);
     if (r->is_trash()) {

--- a/src/hotspot/share/gc/shenandoah/shenandoahFreeSet.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahFreeSet.cpp
@@ -509,7 +509,6 @@ void ShenandoahFreeSet::try_recycle_trashed(ShenandoahHeapRegion *r) {
 void ShenandoahFreeSet::recycle_trash() {
   // lock is not reentrable, check we don't have it
   shenandoah_assert_not_heaplocked();
-  RTGC_TIME_BLOCK;
   for (size_t i = 0; i < _heap->num_regions(); i++) {
     ShenandoahHeapRegion* r = _heap->get_region(i);
     if (r->is_trash()) {

--- a/src/hotspot/share/gc/shenandoah/shenandoahHeapRegion.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahHeapRegion.cpp
@@ -550,7 +550,6 @@ ShenandoahHeapRegion* ShenandoahHeapRegion::humongous_start_region() const {
 }
 
 void ShenandoahHeapRegion::recycle() {
-  RTGC_TIME_BLOCK
   ShenandoahHeap* heap = ShenandoahHeap::heap();
 
   if (affiliation() == YOUNG_GENERATION) {

--- a/src/hotspot/share/gc/shenandoah/shenandoahHeapRegion.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahHeapRegion.cpp
@@ -550,6 +550,7 @@ ShenandoahHeapRegion* ShenandoahHeapRegion::humongous_start_region() const {
 }
 
 void ShenandoahHeapRegion::recycle() {
+  RTGC_TIME_BLOCK
   ShenandoahHeap* heap = ShenandoahHeap::heap();
 
   if (affiliation() == YOUNG_GENERATION) {
@@ -568,8 +569,6 @@ void ShenandoahHeapRegion::recycle() {
 
   make_empty();
   set_affiliation(FREE);
-
-  heap->clear_cards_for(this);
 
   if (ZapUnusedHeapArea) {
     SpaceMangler::mangle_region(MemRegion(bottom(), end()));


### PR DESCRIPTION
Preemptively clearing cards during recycle for every region adds considerable overhead to the concurrent clean up phase. Moving card clearing transfers the cost of card clearing to the evacuation phase and reduces the cost to only those regions that will be used by the old generation.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

### Reviewers
 * [Kelvin Nilsen](https://openjdk.java.net/census#kdnilsen) (@kdnilsen - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/shenandoah pull/119/head:pull/119` \
`$ git checkout pull/119`

Update a local copy of the PR: \
`$ git checkout pull/119` \
`$ git pull https://git.openjdk.java.net/shenandoah pull/119/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 119`

View PR using the GUI difftool: \
`$ git pr show -t 119`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/shenandoah/pull/119.diff">https://git.openjdk.java.net/shenandoah/pull/119.diff</a>

</details>
