### PR TITLE
Remove young generation access to old generation mark queues earlier

### DIFF
--- a/src/hotspot/share/gc/shenandoah/shenandoahControlThread.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahControlThread.cpp
@@ -525,9 +525,6 @@ void ShenandoahControlThread::resume_concurrent_old_cycle(ShenandoahGeneration* 
   // is allowed to cancel a GC.
   ShenandoahOldGC gc(generation, _allow_old_preemption);
   if (gc.collect(cause)) {
-    // Old collection is complete, the young generation no longer needs this
-    // reference to the old concurrent mark so clean it up.
-    heap->young_generation()->set_old_gen_task_queues(NULL);
     generation->heuristics()->record_success_concurrent();
     heap->shenandoah_policy()->record_success_concurrent();
   }

--- a/src/hotspot/share/gc/shenandoah/shenandoahOldGC.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahOldGC.cpp
@@ -30,6 +30,7 @@
 #include "gc/shenandoah/shenandoahOldGC.hpp"
 #include "gc/shenandoah/shenandoahOopClosures.inline.hpp"
 #include "gc/shenandoah/shenandoahGeneration.hpp"
+#include "gc/shenandoah/shenandoahYoungGeneration.hpp"
 #include "gc/shenandoah/heuristics/shenandoahHeuristics.hpp"
 #include "gc/shenandoah/shenandoahWorkerPolicy.hpp"
 #include "prims/jvmtiTagMap.hpp"
@@ -104,6 +105,10 @@ void ShenandoahOldGC::op_final_mark() {
     assert(_mark.generation()->generation_mode() == OLD, "Generation of Old-Gen GC should be OLD");
     _mark.finish_mark();
     assert(!heap->cancelled_gc(), "STW mark cannot OOM");
+
+    // Old collection is complete, the young generation no longer needs this
+    // reference to the old concurrent mark so clean it up.
+    heap->young_generation()->set_old_gen_task_queues(NULL);
 
     // We need to do this because weak root cleaning reports the number of dead handles
     JvmtiTagMap::set_needs_cleaning();


### PR DESCRIPTION
Prior to this change, we removed access to the old generation mark queues if (and only if) the old generation cycle completed. However, in some cases, the old generation cycle may be interrupted _after_ it has finished marking but _before_ it has finished preparing for mixed collections. This error may cause young generation cycles to enqueue old objects into the old generation mark queues that may become invalid as mixed collections execute. With this change, we remove access to old generation mark queues as soon as old generation marking is complete.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

### Reviewers
 * [Kelvin Nilsen](https://openjdk.java.net/census#kdnilsen) (@kdnilsen - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/shenandoah pull/120/head:pull/120` \
`$ git checkout pull/120`

Update a local copy of the PR: \
`$ git checkout pull/120` \
`$ git pull https://git.openjdk.java.net/shenandoah pull/120/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 120`

View PR using the GUI difftool: \
`$ git pr show -t 120`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/shenandoah/pull/120.diff">https://git.openjdk.java.net/shenandoah/pull/120.diff</a>

</details>
