### PR TITLE
Reset update watermark for cycles degenerated during evacuation

### DIFF
--- a/src/hotspot/share/gc/shenandoah/shenandoahDegeneratedGC.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahDegeneratedGC.cpp
@@ -176,7 +176,9 @@ void ShenandoahDegenGC::op_degenerated() {
           // it will not have TAMS or UWM updated. Such a region is effectively
           // skipped during update references which can lead to crashes and corruption
           // if the from-space reference is accessed.
-          heap->labs_make_parsable();
+          if (UseTLAB) {
+            heap->labs_make_parsable();
+          }
 
           for (size_t i = 0; i < heap->num_regions(); i++) {
             ShenandoahHeapRegion* r = heap->get_region(i);

--- a/src/hotspot/share/gc/shenandoah/shenandoahDegeneratedGC.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahDegeneratedGC.cpp
@@ -167,6 +167,25 @@ void ShenandoahDegenGC::op_degenerated() {
       // and we can do evacuation. Otherwise, it would be the shortcut cycle.
       if (heap->is_evacuation_in_progress()) {
 
+        if (_degen_point == _degenerated_evac) {
+          // Degeneration under oom-evac protocol allows the mutator LRB to expose
+          // references to from-space objects. This is okay, in theory, because we
+          // will come to the safepoint here to complete the evacuations and update
+          // the references. However, if the from-space reference is written to a
+          // region that was EC during final mark or was recycled after final mark
+          // it will not have TAMS or UWM updated. Such a region is effectively
+          // skipped during update references which can lead to crashes and corruption
+          // if the from-space reference is accessed.
+          heap->labs_make_parsable();
+
+          for (size_t i = 0; i < heap->num_regions(); i++) {
+            ShenandoahHeapRegion* r = heap->get_region(i);
+            if (r->is_active() && r->top() > r->get_update_watermark()) {
+              r->set_update_watermark_at_safepoint(r->top());
+            }
+          }
+        }
+
         // Degeneration under oom-evac protocol might have left some objects in
         // collection set un-evacuated. Restart evacuation from the beginning to
         // capture all objects. For all the objects that are already evacuated,


### PR DESCRIPTION
When an out of memory error occurs during concurrent evacuation the load reference barrier (LRB) stops trying to evacuate objects (this appears to be by design). As the collector transitions to a degenerated cycle, mutators may load references to objects in the collection set. If one of these references is written into a region that was `empty committed` after final mark, the region will have its top at mark start (TAMS) and update watermark (UWM) equal to the bottom of the region. Such regions are effectively skipped during the update reference phase. The degenerated cycle completes with live references to reclaimed memory in the heap, resulting in crashes or corruption.

Rather than re-engineer the oom-during-evac protocol, upon entering a degenerated evacuation phase we again make thread local allocation buffers (TLABs) parsable and reset the UWM for active regions. Now, if the degenerated evacuation phase succeeds, the from-space pointers will be fixed in the update reference phase.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

### Reviewers
 * [Kelvin Nilsen](https://openjdk.java.net/census#kdnilsen) (@kdnilsen - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/shenandoah pull/121/head:pull/121` \
`$ git checkout pull/121`

Update a local copy of the PR: \
`$ git checkout pull/121` \
`$ git pull https://git.openjdk.java.net/shenandoah pull/121/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 121`

View PR using the GUI difftool: \
`$ git pr show -t 121`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/shenandoah/pull/121.diff">https://git.openjdk.java.net/shenandoah/pull/121.diff</a>

</details>
