### PR TITLE
Revert "Mutator may fail to evacuate"

### DIFF
--- a/src/hotspot/share/gc/shenandoah/shenandoahHeap.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahHeap.cpp
@@ -2111,18 +2111,10 @@ bool ShenandoahHeap::try_cancel_gc() {
     assert(prev == NOT_CANCELLED, "must be NOT_CANCELLED");
     Thread* thread = Thread::current();
     if (thread->is_Java_thread()) {
-      JavaThread* java_thread = JavaThread::cast(thread);
-      if (java_thread->thread_state() == _thread_in_Java) {
-        // ThreadBlockInVM requires thread state to be _thread_in_vm.  If we are in Java, safely transition thread state.
-        ThreadInVMfromJava transition(java_thread);
-        // We need to provide a safepoint here.  Otherwise we might spin forever if a SP is pending.
-        ThreadBlockInVM sp(JavaThread::cast(thread));
-        SpinPause();
-      } else {
-        // We need to provide a safepoint here.  Otherwise we might spin forever if a SP is pending.
-        ThreadBlockInVM sp(JavaThread::cast(thread));
-        SpinPause();
-      }
+      // We need to provide a safepoint here, otherwise we might
+      // spin forever if a SP is pending.
+      ThreadBlockInVM sp(JavaThread::cast(thread));
+      SpinPause();
     }
   }
 }


### PR DESCRIPTION
This reverts commit 2132a6d151e4c46b71a220100fa478a8be676f13.

We found that the solution implemented in this commit is insufficient to address the problem.  We need to redesign the OOM protocol for evacuation allocation failures.  This is being explored by other engineers.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

### Reviewers
 * [William Kemper](https://openjdk.java.net/census#wkemper) (@earthling-amzn - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/shenandoah pull/123/head:pull/123` \
`$ git checkout pull/123`

Update a local copy of the PR: \
`$ git checkout pull/123` \
`$ git pull https://git.openjdk.java.net/shenandoah pull/123/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 123`

View PR using the GUI difftool: \
`$ git pr show -t 123`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/shenandoah/pull/123.diff">https://git.openjdk.java.net/shenandoah/pull/123.diff</a>

</details>
