### PR TITLE
Global mark is not old mark

### DIFF
--- a/src/hotspot/share/gc/shenandoah/shenandoahGlobalGeneration.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahGlobalGeneration.cpp
@@ -67,7 +67,6 @@ void ShenandoahGlobalGeneration::set_concurrent_mark_in_progress(bool in_progres
   }
 
   heap->set_concurrent_young_mark_in_progress(in_progress);
-  heap->set_concurrent_old_mark_in_progress(in_progress);
 }
 
 bool ShenandoahGlobalGeneration::contains(ShenandoahHeapRegion* region) const {

--- a/src/hotspot/share/gc/shenandoah/shenandoahHeap.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahHeap.cpp
@@ -2111,18 +2111,10 @@ bool ShenandoahHeap::try_cancel_gc() {
     assert(prev == NOT_CANCELLED, "must be NOT_CANCELLED");
     Thread* thread = Thread::current();
     if (thread->is_Java_thread()) {
-      JavaThread* java_thread = JavaThread::cast(thread);
-      if (java_thread->thread_state() == _thread_in_Java) {
-        // ThreadBlockInVM requires thread state to be _thread_in_vm.  If we are in Java, safely transition thread state.
-        ThreadInVMfromJava transition(java_thread);
-        // We need to provide a safepoint here.  Otherwise we might spin forever if a SP is pending.
-        ThreadBlockInVM sp(JavaThread::cast(thread));
-        SpinPause();
-      } else {
-        // We need to provide a safepoint here.  Otherwise we might spin forever if a SP is pending.
-        ThreadBlockInVM sp(JavaThread::cast(thread));
-        SpinPause();
-      }
+      // We need to provide a safepoint here, otherwise we might
+      // spin forever if a SP is pending.
+      ThreadBlockInVM sp(JavaThread::cast(thread));
+      SpinPause();
     }
   }
 }


### PR DESCRIPTION
Starting a global mark does not need to set old mark as in-progress and just confuses things.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

### Reviewers
 * [Kelvin Nilsen](https://openjdk.java.net/census#kdnilsen) (@kdnilsen - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/shenandoah pull/125/head:pull/125` \
`$ git checkout pull/125`

Update a local copy of the PR: \
`$ git checkout pull/125` \
`$ git pull https://git.openjdk.java.net/shenandoah pull/125/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 125`

View PR using the GUI difftool: \
`$ git pr show -t 125`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/shenandoah/pull/125.diff">https://git.openjdk.java.net/shenandoah/pull/125.diff</a>

</details>
