### PR TITLE
Relax evacuation budget

### DIFF
--- a/src/hotspot/share/gc/shenandoah/shenandoahConcurrentGC.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahConcurrentGC.cpp
@@ -228,7 +228,6 @@ bool ShenandoahConcurrentGC::collect(GCCause::Cause cause) {
 
     young_gen->unadjust_available();
     old_gen->unadjust_available();
-    young_gen->increase_used(heap->get_young_evac_expended());
     // No need to old_gen->increase_used().  That was done when plabs were allocated, accounting for both old evacs and promotions.
 
     young_available = young_gen->adjusted_available();
@@ -236,7 +235,6 @@ bool ShenandoahConcurrentGC::collect(GCCause::Cause cause) {
 
     heap->set_alloc_supplement_reserve(0);
     heap->set_young_evac_reserve(0);
-    heap->reset_young_evac_expended();
     heap->set_old_evac_reserve(0);
     heap->reset_old_evac_expended();
     heap->set_promotion_reserve(0);

--- a/src/hotspot/share/gc/shenandoah/shenandoahDegeneratedGC.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahDegeneratedGC.cpp
@@ -280,12 +280,10 @@ void ShenandoahDegenGC::op_degenerated() {
 
     heap->young_generation()->unadjust_available();
     heap->old_generation()->unadjust_available();
-    heap->young_generation()->increase_used(heap->get_young_evac_expended());
     // No need to old_gen->increase_used().  That was done when plabs were allocated, accounting for both old evacs and promotions.
 
     heap->set_alloc_supplement_reserve(0);
     heap->set_young_evac_reserve(0);
-    heap->reset_young_evac_expended();
     heap->set_old_evac_reserve(0);
     heap->reset_old_evac_expended();
     heap->set_promotion_reserve(0);

--- a/src/hotspot/share/gc/shenandoah/shenandoahFreeSet.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahFreeSet.cpp
@@ -293,18 +293,9 @@ HeapWord* ShenandoahFreeSet::try_allocate_in(ShenandoahHeapRegion* r, Shenandoah
       r->set_update_watermark(r->top());
 
       if (r->affiliation() == ShenandoahRegionAffiliation::YOUNG_GENERATION) {
-        // This is either a GCLAB or it is a shared evacuation allocation.  In either case, we expend young evac.
-        // At end of update refs, we'll add expended young evac into young_gen->used.  We hide this usage
-        // from current accounting because memory reserved for evacuation is not part of adjusted capacity.
-        if (_heap->mode()->is_generational()) {
-          _heap->expend_young_evac(size * HeapWordSize);
-        } else {
-          // If we are not in generational mode, we still need to count this allocation as used memory.
-          _heap->young_generation()->increase_used(size * HeapWordSize);
-        }
+        _heap->young_generation()->increase_used(size * HeapWordSize);
       } else {
         assert(r->affiliation() == ShenandoahRegionAffiliation::OLD_GENERATION, "GC Alloc was not YOUNG so must be OLD");
-
         assert(req.type() != ShenandoahAllocRequest::_alloc_gclab, "old-gen allocations use PLAB or shared allocation");
         _heap->old_generation()->increase_used(size * HeapWordSize);
         // for plabs, we'll sort the difference between evac and promotion usage when we retire the plab

--- a/src/hotspot/share/gc/shenandoah/shenandoahFullGC.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahFullGC.cpp
@@ -185,12 +185,10 @@ void ShenandoahFullGC::do_it(GCCause::Cause gc_cause) {
   // There will be no concurrent allocations during full GC so reset these coordination variables.
   heap->young_generation()->unadjust_available();
   heap->old_generation()->unadjust_available();
-  heap->young_generation()->increase_used(heap->get_young_evac_expended());
   // No need to old_gen->increase_used().  That was done when plabs were allocated, accounting for both old evacs and promotions.
 
   heap->set_alloc_supplement_reserve(0);
   heap->set_young_evac_reserve(0);
-  heap->reset_young_evac_expended();
   heap->set_old_evac_reserve(0);
   heap->reset_old_evac_expended();
   heap->set_promotion_reserve(0);

--- a/src/hotspot/share/gc/shenandoah/shenandoahGeneration.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahGeneration.cpp
@@ -396,6 +396,7 @@ ShenandoahMarkingContext* ShenandoahGeneration::complete_marking_context() {
 }
 
 void ShenandoahGeneration::cancel_marking() {
+  log_info(gc)("Cancel marking: %s", name());
   if (is_concurrent_mark_in_progress()) {
     set_mark_incomplete();
   }

--- a/src/hotspot/share/gc/shenandoah/shenandoahHeap.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahHeap.cpp
@@ -1167,26 +1167,15 @@ HeapWord* ShenandoahHeap::allocate_memory_under_lock(ShenandoahAllocRequest& req
   ShenandoahHeapLocker locker(lock());
   if (mode()->is_generational()) {
     if (req.affiliation() == YOUNG_GENERATION) {
-      if (req.type() == ShenandoahAllocRequest::_alloc_gclab) {
-        if (requested_bytes + get_young_evac_expended() > get_young_evac_reserve()) {
-          // This should only happen if evacuation waste is too low.  Rejecting one thread's request for GCLAB does not
-          // necessarily result in failure of the evacuation effort.  A different thread may be able to copy from-space object.
-
-          // TODO: Should we really fail here in the case that there is sufficient memory to allow us to allocate a gclab
-          // beyond the young_evac_reserve?  Seems it would be better to take away from mutator allocation budget if this
-          // prevents fall-back to full GC in order to recover from failed evacuation.
-          return nullptr;
-        }
-        // else, there is sufficient memory to allocate this GCLAB so do nothing here.
-      } else if (req.is_gc_alloc()) {
+      if (req.is_gc_alloc()) {
         // This is a shared alloc for purposes of evacuation.
-        if (requested_bytes + get_young_evac_expended() > get_young_evac_reserve()) {
-          // TODO: Should we really fail here in the case that there is sufficient memory to allow us to allocate a gclab
-          // beyond the young_evac_reserve?  Seems it would be better to take away from mutator allocation budget if this
-          // prevents fall-back to full GC in order to recover from failed evacuation.
-          return nullptr;
-        } else {
-          // There is sufficient memory to allocate this shared evacuation object.
+        size_t expended = get_young_evac_expended();
+        size_t reserved = get_young_evac_reserve();
+        if (requested_bytes + expended > reserved) {
+          // Expended may exceed budget because of GCLAB size growth.
+          log_info(gc)("Evacuation expended (" SIZE_FORMAT "%s) has exceeded budget (" SIZE_FORMAT "%s)",
+                       byte_size_in_proper_unit(expended), proper_unit_for_byte_size(expended),
+                       byte_size_in_proper_unit(reserved), proper_unit_for_byte_size(reserved));
         }
       }  else if (requested_bytes >= young_generation()->adjusted_available()) {
         // We know this is not a GCLAB.  This must be a TLAB or a shared allocation.  Reject the allocation request if

--- a/src/hotspot/share/gc/shenandoah/shenandoahHeap.inline.hpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahHeap.inline.hpp
@@ -646,19 +646,6 @@ inline size_t ShenandoahHeap::get_young_evac_reserve() const {
   return _young_evac_reserve;
 }
 
-inline void ShenandoahHeap::reset_young_evac_expended() {
-  _young_evac_expended = 0;
-}
-
-inline size_t ShenandoahHeap::expend_young_evac(size_t increment) {
-  _young_evac_expended += increment;
-  return _young_evac_expended;
-}
-
-inline size_t ShenandoahHeap::get_young_evac_expended() const {
-  return _young_evac_expended;
-}
-
 inline intptr_t ShenandoahHeap::set_alloc_supplement_reserve(intptr_t new_val) {
   intptr_t orig = _alloc_supplement_reserve;
   _alloc_supplement_reserve = new_val;

--- a/src/hotspot/share/gc/shenandoah/shenandoahOldGeneration.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahOldGeneration.cpp
@@ -158,6 +158,7 @@ bool ShenandoahOldGeneration::is_concurrent_mark_in_progress() {
 
 void ShenandoahOldGeneration::cancel_marking() {
   if (is_concurrent_mark_in_progress()) {
+    log_info(gc)("Abandon satb buffers.");
     ShenandoahBarrierSet::satb_mark_queue_set().abandon_partial_marking();
   }
 
@@ -165,10 +166,10 @@ void ShenandoahOldGeneration::cancel_marking() {
 }
 
 void ShenandoahOldGeneration::transfer_pointers_from_satb() {
-  ShenandoahHeap *heap = ShenandoahHeap::heap();
+  ShenandoahHeap* heap = ShenandoahHeap::heap();
   shenandoah_assert_safepoint();
   assert(heap->is_concurrent_old_mark_in_progress(), "Only necessary during old marking.");
-
+  log_info(gc)("Transfer satb buffers.");
   uint nworkers = heap->workers()->active_workers();
   StrongRootsScope scope(nworkers);
 

--- a/src/hotspot/share/gc/shenandoah/shenandoahVerifier.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahVerifier.cpp
@@ -388,16 +388,7 @@ class ShenandoahGenerationStatsClosure : public ShenandoahHeapRegionClosure {
   }
 
   static void validate_usage(const char* label, ShenandoahGeneration* generation, ShenandoahCalculateRegionStatsClosure& stats) {
-    size_t generation_used;
-    if (generation->generation_mode() == YOUNG) {
-      // young_evac_expended is "usually zero".  If it is non-zero, this means we are doing evacuation or updating references
-      // and young-gen memory that holds the results of evacuation is being temporarily hidden from the usage accounting,
-      // so we add it back in here to make verification happy.
-      generation_used = generation->used() + ShenandoahHeap::heap()->get_young_evac_expended();
-    } else {
-      generation_used = generation->used();
-    }
-
+    size_t generation_used = generation->used();
     guarantee(stats.used() == generation_used,
               "%s: generation (%s) used size must be consistent: generation-used = " SIZE_FORMAT "%s, regions-used = " SIZE_FORMAT "%s",
               label, generation->name(),


### PR DESCRIPTION
Allow evacuating threads to allocate beyond what was expected when cset was selected. Growth in GCLABs may cause evacuation threads to use more memory than was anticipated when the cset was selected.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [ ] Change must be properly reviewed

### Error
&nbsp;⚠️ OCA signatory status must be verified

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/shenandoah pull/128/head:pull/128` \
`$ git checkout pull/128`

Update a local copy of the PR: \
`$ git checkout pull/128` \
`$ git pull https://git.openjdk.java.net/shenandoah pull/128/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 128`

View PR using the GUI difftool: \
`$ git pr show -t 128`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/shenandoah/pull/128.diff">https://git.openjdk.java.net/shenandoah/pull/128.diff</a>

</details>
