### PR TITLE
Improved timing reports

### DIFF
--- a/src/hotspot/share/gc/shenandoah/shenandoahCollectorPolicy.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahCollectorPolicy.cpp
@@ -31,6 +31,8 @@
 
 ShenandoahCollectorPolicy::ShenandoahCollectorPolicy() :
   _success_concurrent_gcs(0),
+  _success_old_gcs(0),
+  _interrupted_old_gcs(0),
   _success_degenerated_gcs(0),
   _success_full_gcs(0),
   _alloc_failure_degenerated(0),
@@ -83,6 +85,14 @@ void ShenandoahCollectorPolicy::record_success_concurrent() {
   _success_concurrent_gcs++;
 }
 
+void ShenandoahCollectorPolicy::record_success_old() {
+  _success_old_gcs++;
+}
+
+void ShenandoahCollectorPolicy::record_interrupted_old() {
+  _interrupted_old_gcs++;
+}
+
 void ShenandoahCollectorPolicy::record_success_degenerated() {
   _success_degenerated_gcs++;
 }
@@ -114,9 +124,13 @@ void ShenandoahCollectorPolicy::print_gc_stats(outputStream* out) const {
   out->print_cr("to avoid Degenerated and Full GC cycles.");
   out->cr();
 
-  out->print_cr(SIZE_FORMAT_W(5) " successful concurrent GCs",         _success_concurrent_gcs);
+  out->print_cr(SIZE_FORMAT_W(5) " Successful Concurrent GCs",         _success_concurrent_gcs);
   out->print_cr("  " SIZE_FORMAT_W(5) " invoked explicitly",           _explicit_concurrent);
   out->print_cr("  " SIZE_FORMAT_W(5) " invoked implicitly",           _implicit_concurrent);
+  out->cr();
+
+  out->print_cr(SIZE_FORMAT_W(5) " Completed Old GCs",                 _success_old_gcs);
+  out->print_cr("  " SIZE_FORMAT_W(5) " interruptions",                _interrupted_old_gcs);
   out->cr();
 
   out->print_cr(SIZE_FORMAT_W(5) " Degenerated GCs",                   _success_degenerated_gcs);

--- a/src/hotspot/share/gc/shenandoah/shenandoahCollectorPolicy.hpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahCollectorPolicy.hpp
@@ -39,6 +39,8 @@ public:
 class ShenandoahCollectorPolicy : public CHeapObj<mtGC> {
 private:
   size_t _success_concurrent_gcs;
+  size_t _success_old_gcs;
+  size_t _interrupted_old_gcs;
   size_t _success_degenerated_gcs;
   size_t _success_full_gcs;
   size_t _alloc_failure_degenerated;
@@ -64,6 +66,8 @@ public:
   void record_cycle_start();
 
   void record_success_concurrent();
+  void record_success_old();
+  void record_interrupted_old();
   void record_success_degenerated();
   void record_success_full();
   void record_alloc_failure_to_degenerated(ShenandoahGC::ShenandoahDegenPoint point);

--- a/src/hotspot/share/gc/shenandoah/shenandoahConcurrentGC.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahConcurrentGC.cpp
@@ -603,7 +603,8 @@ void ShenandoahConcurrentGC::op_init_mark() {
       // The current implementation of swap_remembered_set() copies the write-card-table
       // to the read-card-table. The remembered sets are also swapped for GLOBAL collections
       // so that the verifier works with the correct copy of the card table when verifying.
-      _generation->swap_remembered_set();
+        ShenandoahGCPhase phase(ShenandoahPhaseTimings::init_swap_rset);
+        _generation->swap_remembered_set();
     }
 
     if (_generation->generation_mode() == GLOBAL) {
@@ -612,6 +613,7 @@ void ShenandoahConcurrentGC::op_init_mark() {
       // Purge the SATB buffers, transferring any valid, old pointers to the
       // old generation mark queue. Any pointers in a young region will be
       // abandoned.
+      ShenandoahGCPhase phase(ShenandoahPhaseTimings::init_transfer_satb);
       heap->transfer_old_pointers_from_satb();
     }
   }

--- a/src/hotspot/share/gc/shenandoah/shenandoahControlThread.hpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahControlThread.hpp
@@ -132,6 +132,8 @@ private:
 
   bool check_soft_max_changed() const;
 
+  void process_phase_timings(const ShenandoahHeap* heap);
+
 public:
   // Constructor
   ShenandoahControlThread();

--- a/src/hotspot/share/gc/shenandoah/shenandoahPhaseTimings.hpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahPhaseTimings.hpp
@@ -53,6 +53,8 @@ class outputStream;
   f(init_mark_gross,                                "Pause Init Mark (G)")             \
   f(init_mark,                                      "Pause Init Mark (N)")             \
   f(init_manage_tlabs,                              "  Manage TLABs")                  \
+  f(init_swap_rset,                                 "  Swap Remembered Set")           \
+  f(init_transfer_satb,                             "  Transfer Old From SATB")        \
   f(init_update_region_states,                      "  Update Region States")          \
                                                                                        \
   f(init_scan_rset,                                 "Concurrent Scan Remembered Set")  \

--- a/src/hotspot/share/gc/shenandoah/shenandoahPhaseTimings.hpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahPhaseTimings.hpp
@@ -66,8 +66,6 @@ class outputStream;
   f(final_mark,                                     "Pause Final Mark (N)")            \
   f(finish_mark,                                    "  Finish Mark")                   \
   SHENANDOAH_PAR_PHASE_DO(finish_mark_,             "    FM: ", f)                     \
-  f(coalesce_and_fill,                              "Coalesce and Fill Old Dead")      \
-  SHENANDOAH_PAR_PHASE_DO(coalesce_and_fill_,       "    CFOD: ", f)                   \
   f(purge,                                          "  System Purge")                  \
   SHENANDOAH_PAR_PHASE_DO(purge_cu_par_,            "      CU: ", f)                   \
   f(purge_weak_par,                                 "    Weak Roots")                  \
@@ -100,6 +98,8 @@ class outputStream;
   f(conc_class_unload_purge_ec,                     "    Exception Caches")            \
   f(conc_strong_roots,                              "Concurrent Strong Roots")         \
   SHENANDOAH_PAR_PHASE_DO(conc_strong_roots_,       "  CSR: ", f)                      \
+  f(coalesce_and_fill,                              "Coalesce and Fill Old Dead")      \
+  SHENANDOAH_PAR_PHASE_DO(coalesce_and_fill_,       "    CFOD: ", f)                   \
   f(conc_evac,                                      "Concurrent Evacuation")           \
                                                                                        \
   f(final_roots_gross,                              "Pause Final Roots (G)")           \


### PR DESCRIPTION
This is a bundle of a few minor changes to the cycle and global timing reports:
* Render coalescing phase closer to where it happens in the cycle
* Include timing for remembered set swap and satb management during init mark pause
* Emit a cycle report for old generation's bootstrap cycle
* Track old GC cycles completed and interrupted for global report

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

### Reviewers
 * [Kelvin Nilsen](https://openjdk.java.net/census#kdnilsen) (@kdnilsen - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/shenandoah pull/131/head:pull/131` \
`$ git checkout pull/131`

Update a local copy of the PR: \
`$ git checkout pull/131` \
`$ git pull https://git.openjdk.java.net/shenandoah pull/131/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 131`

View PR using the GUI difftool: \
`$ git pr show -t 131`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/shenandoah/pull/131.diff">https://git.openjdk.java.net/shenandoah/pull/131.diff</a>

</details>
