### PR TITLE
Use state from collection set to know if mixed collection is in progress

### DIFF
--- a/src/hotspot/share/gc/shenandoah/heuristics/shenandoahHeuristics.cpp
+++ b/src/hotspot/share/gc/shenandoah/heuristics/shenandoahHeuristics.cpp
@@ -77,9 +77,8 @@ ShenandoahHeuristics::~ShenandoahHeuristics() {
   FREE_C_HEAP_ARRAY(RegionGarbage, _region_data);
 }
 
-// Returns true iff the chosen collection set includes old-gen regions
-bool ShenandoahHeuristics::choose_collection_set(ShenandoahCollectionSet* collection_set, ShenandoahOldHeuristics* old_heuristics) {
-  bool result = false;
+void ShenandoahHeuristics::choose_collection_set(ShenandoahCollectionSet* collection_set, ShenandoahOldHeuristics* old_heuristics) {
+
   ShenandoahHeap* heap = ShenandoahHeap::heap();
 
   assert(collection_set->count() == 0, "Must be empty");
@@ -184,9 +183,7 @@ bool ShenandoahHeuristics::choose_collection_set(ShenandoahCollectionSet* collec
   if (immediate_percent <= ShenandoahImmediateThreshold) {
 
     if (old_heuristics != NULL) {
-      if (old_heuristics->prime_collection_set(collection_set)) {
-        result = true;
-      }
+      old_heuristics->prime_collection_set(collection_set);
 
       size_t bytes_reserved_for_old_evacuation = collection_set->get_old_bytes_reserved_for_evacuation();
       if (bytes_reserved_for_old_evacuation * ShenandoahEvacWaste < heap->get_old_evac_reserve()) {
@@ -206,7 +203,7 @@ bool ShenandoahHeuristics::choose_collection_set(ShenandoahCollectionSet* collec
     // we'll need to borrow from old-gen in order to evacuate.  If there's nothing to borrow, we're going to
     // degenerate to full GC.
 
-    // TODO: younng_available can include available (between top() and end()) within each young region that is not
+    // TODO: young_available can include available (between top() and end()) within each young region that is not
     // part of the collection set.  Making this memory available to the young_evacuation_reserve allows a larger
     // young collection set to be chosen when available memory is under extreme pressure.  Implementing this "improvement"
     // is tricky, because the incremental construction of the collection set actually changes the amount of memory
@@ -356,7 +353,6 @@ bool ShenandoahHeuristics::choose_collection_set(ShenandoahCollectionSet* collec
                      byte_size_in_proper_unit(collection_set->garbage()),
                      proper_unit_for_byte_size(collection_set->garbage()),
                      cset_percent);
-  return result;
 }
 
 void ShenandoahHeuristics::record_cycle_start() {

--- a/src/hotspot/share/gc/shenandoah/heuristics/shenandoahHeuristics.hpp
+++ b/src/hotspot/share/gc/shenandoah/heuristics/shenandoahHeuristics.hpp
@@ -153,8 +153,7 @@ public:
 
   virtual void record_requested_gc();
 
-  // Return true iff the chosen collection set includes at least one old-gen region.
-  virtual bool choose_collection_set(ShenandoahCollectionSet* collection_set, ShenandoahOldHeuristics* old_heuristics);
+  virtual void choose_collection_set(ShenandoahCollectionSet* collection_set, ShenandoahOldHeuristics* old_heuristics);
 
   virtual bool can_unload_classes();
   virtual bool can_unload_classes_normal();

--- a/src/hotspot/share/gc/shenandoah/heuristics/shenandoahOldHeuristics.cpp
+++ b/src/hotspot/share/gc/shenandoah/heuristics/shenandoahOldHeuristics.cpp
@@ -153,14 +153,13 @@ bool ShenandoahOldHeuristics::prime_collection_set(ShenandoahCollectionSet* coll
 }
 
 // Both arguments are don't cares for old-gen collections
-bool ShenandoahOldHeuristics::choose_collection_set(ShenandoahCollectionSet* collection_set,
+void ShenandoahOldHeuristics::choose_collection_set(ShenandoahCollectionSet* collection_set,
                                                     ShenandoahOldHeuristics* old_heuristics) {
   assert((collection_set == nullptr) && (old_heuristics == nullptr),
          "Expect null arguments in ShenandoahOldHeuristics::choose_collection_set()");
   // Old-gen doesn't actually choose a collection set to be evacuated by its own gang of worker tasks.
   // Instead, it computes the set of regions to be evacuated by subsequent young-gen evacuation passes.
   prepare_for_old_collections();
-  return false;
 }
 
 void ShenandoahOldHeuristics::prepare_for_old_collections() {

--- a/src/hotspot/share/gc/shenandoah/heuristics/shenandoahOldHeuristics.hpp
+++ b/src/hotspot/share/gc/shenandoah/heuristics/shenandoahOldHeuristics.hpp
@@ -79,8 +79,7 @@ private:
 public:
   ShenandoahOldHeuristics(ShenandoahGeneration* generation, ShenandoahHeuristics* trigger_heuristic);
 
-  // Return true iff chosen collection set includes at least one old-gen HeapRegion.
-  virtual bool choose_collection_set(ShenandoahCollectionSet* collection_set, ShenandoahOldHeuristics* old_heuristics) override;
+  virtual void choose_collection_set(ShenandoahCollectionSet* collection_set, ShenandoahOldHeuristics* old_heuristics) override;
 
   // Return true iff the collection set is primed with at least one old-gen region.
   bool prime_collection_set(ShenandoahCollectionSet* set);

--- a/src/hotspot/share/gc/shenandoah/shenandoahConcurrentGC.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahConcurrentGC.cpp
@@ -694,7 +694,7 @@ void ShenandoahConcurrentGC::op_final_mark() {
     // are negligible negative impacts from delaying completion of old-gen evacuation) and when young-gen collections
     // are "under duress" (as signalled by very low availability of memory within young-gen, indicating that/ young-gen
     // collections are not triggering frequently enough).
-    bool mixed_evac = _generation->prepare_regions_and_collection_set(true /*concurrent*/);
+    _generation->prepare_regions_and_collection_set(true /*concurrent*/);
 
     // Upon return from prepare_regions_and_collection_set(), certain parameters have been established to govern the
     // evacuation efforts that are about to begin.  In particular:
@@ -715,8 +715,6 @@ void ShenandoahConcurrentGC::op_final_mark() {
     //
     // heap->get_alloc_supplement_reserve() represents the amount of old-gen memory that can be allocated during evacuation
     // and update-refs phases of gc.  The young evacuation reserve has already been removed from this quantity.
-
-    heap->set_mixed_evac(mixed_evac);
 
     // Has to be done after cset selection
     heap->prepare_concurrent_roots();

--- a/src/hotspot/share/gc/shenandoah/shenandoahGeneration.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahGeneration.cpp
@@ -221,9 +221,8 @@ void ShenandoahGeneration::prepare_gc(bool do_old_gc_bootstrap) {
   }
 }
 
-// Returns true iff the chosen collection set includes a mix of young-gen and old-gen regions.
-bool ShenandoahGeneration::prepare_regions_and_collection_set(bool concurrent) {
-  bool result;
+void  ShenandoahGeneration::prepare_regions_and_collection_set(bool concurrent) {
+
   ShenandoahHeap* heap = ShenandoahHeap::heap();
   assert(!heap->is_full_gc_in_progress(), "Only for concurrent and degenerated GC");
   assert(generation_mode() != OLD, "Only YOUNG and GLOBAL GC perform evacuations");
@@ -333,7 +332,7 @@ bool ShenandoahGeneration::prepare_regions_and_collection_set(bool concurrent) {
 
     // The heuristics may consult and/or change the values of PromotionReserved, OldEvacuationReserved, and
     // YoungEvacuationReserved, all of which are represented in the shared ShenandoahHeap data structure.
-    result = _heuristics->choose_collection_set(heap->collection_set(), heap->old_heuristics());
+    _heuristics->choose_collection_set(heap->collection_set(), heap->old_heuristics());
 
     //  EvacuationAllocationSupplement: This represents memory that can be allocated in excess of young_gen->available()
     //     during evacuation and update-refs.  This memory can be temporarily borrowed from old-gen allotment, then
@@ -359,7 +358,6 @@ bool ShenandoahGeneration::prepare_regions_and_collection_set(bool concurrent) {
     ShenandoahHeapLocker locker(heap->lock());
     heap->free_set()->rebuild();
   }
-  return result;
 }
 
 bool ShenandoahGeneration::is_bitmap_clear() {

--- a/src/hotspot/share/gc/shenandoah/shenandoahGeneration.hpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahGeneration.hpp
@@ -112,7 +112,7 @@ protected:
   void prepare_gc(bool do_old_gc_bootstrap);
 
   // Return true iff prepared collection set includes at least one old-gen HeapRegion.
-  virtual bool prepare_regions_and_collection_set(bool concurrent);
+  virtual void prepare_regions_and_collection_set(bool concurrent);
 
   // Cancel marking (used by Full collect and when cancelling cycle).
   virtual void cancel_marking();

--- a/src/hotspot/share/gc/shenandoah/shenandoahHeap.hpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahHeap.hpp
@@ -151,10 +151,7 @@ private:
   ShenandoahHeapLock _lock;
   ShenandoahGeneration* _gc_generation;
 
-  bool _mixed_evac;                      // true iff most recent evac included at least one old-gen HeapRegion
   bool _prep_for_mixed_evac_in_progress; // true iff we are concurrently coalescing and filling old-gen HeapRegions
-
-  size_t _evacuation_allowance;          // amount by which young-gen usage may temporarily exceed young-gen capacity
 
 public:
   ShenandoahHeapLock* lock() {
@@ -168,10 +165,6 @@ public:
 
   void set_gc_generation(ShenandoahGeneration* generation) {
     _gc_generation = generation;
-  }
-
-  void set_mixed_evac(bool mixed_evac) {
-    _mixed_evac = mixed_evac;
   }
 
   ShenandoahOldHeuristics* old_heuristics();

--- a/src/hotspot/share/gc/shenandoah/shenandoahOldGeneration.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahOldGeneration.cpp
@@ -181,7 +181,7 @@ bool ShenandoahOldGeneration::contains(oop obj) const {
   return ShenandoahHeap::heap()->is_in_old(obj);
 }
 
-bool ShenandoahOldGeneration::prepare_regions_and_collection_set(bool concurrent) {
+void ShenandoahOldGeneration::prepare_regions_and_collection_set(bool concurrent) {
   ShenandoahHeap* heap = ShenandoahHeap::heap();
   assert(!heap->is_full_gc_in_progress(), "Only for concurrent and degenerated GC");
 
@@ -204,7 +204,6 @@ bool ShenandoahOldGeneration::prepare_regions_and_collection_set(bool concurrent
     ShenandoahHeapLocker locker(heap->lock());
     heap->free_set()->rebuild();
   }
-  return false;
 }
 
 ShenandoahHeuristics* ShenandoahOldGeneration::initialize_heuristics(ShenandoahMode* gc_mode) {

--- a/src/hotspot/share/gc/shenandoah/shenandoahOldGeneration.hpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahOldGeneration.hpp
@@ -48,7 +48,7 @@ class ShenandoahOldGeneration : public ShenandoahGeneration {
 
   virtual void cancel_marking() override;
 
-  bool prepare_regions_and_collection_set(bool concurrent) override;
+  void prepare_regions_and_collection_set(bool concurrent) override;
 
   virtual ShenandoahHeuristics* initialize_heuristics(ShenandoahMode* gc_mode) override;
 


### PR DESCRIPTION
The state that indicated when a mixed collection was in progress was represented in two places: a property of the collection set and a member variable on the heap set after the collection set was chosen. In some cases, a degenerated cycle could cause the heap's member variable to become stale (indicating a mixed evac was in progress when it was not). In this case, update references could fail to update references in old regions with an incomplete mark bitmap. With this change, update references uses the property of the collection set to know if a mixed evacuation is in progress.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

### Reviewers
 * [Kelvin Nilsen](https://openjdk.java.net/census#kdnilsen) (@kdnilsen - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/shenandoah pull/134/head:pull/134` \
`$ git checkout pull/134`

Update a local copy of the PR: \
`$ git checkout pull/134` \
`$ git pull https://git.openjdk.java.net/shenandoah pull/134/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 134`

View PR using the GUI difftool: \
`$ git pr show -t 134`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/shenandoah/pull/134.diff">https://git.openjdk.java.net/shenandoah/pull/134.diff</a>

</details>
