### PR TITLE
Only clear requested gc cause when it is handled

### DIFF
--- a/src/hotspot/share/gc/shenandoah/mode/shenandoahGenerationalMode.cpp
+++ b/src/hotspot/share/gc/shenandoah/mode/shenandoahGenerationalMode.cpp
@@ -85,3 +85,17 @@ const char* affiliation_name(ShenandoahRegionAffiliation type) {
       return nullptr;
   }
 }
+
+const char* generation_name(GenerationMode mode) {
+  switch (mode) {
+    case GenerationMode::GLOBAL:
+      return "Global";
+    case GenerationMode::OLD:
+      return "Old";
+    case GenerationMode::YOUNG:
+      return "Young";
+    default:
+      ShouldNotReachHere();
+      return nullptr;
+  }
+}

--- a/src/hotspot/share/gc/shenandoah/mode/shenandoahGenerationalMode.hpp
+++ b/src/hotspot/share/gc/shenandoah/mode/shenandoahGenerationalMode.hpp
@@ -43,6 +43,7 @@ enum ShenandoahRegionAffiliation {
 const char* affiliation_name(oop ptr);
 const char* affiliation_name(ShenandoahRegionAffiliation type);
 const char affiliation_code(ShenandoahRegionAffiliation type);
+const char* generation_name(GenerationMode mode);
 
 class ShenandoahGenerationalMode : public ShenandoahMode {
 public:


### PR DESCRIPTION
Do not unconditionally clear `_requested_gc_cause` on every idle iteration of the control loop as this may erroneously over-write a request to perform a GC cycle. With this change, `_requested_gc_cause` is only cleared when a gc request is handled.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

### Reviewers
 * [Kelvin Nilsen](https://openjdk.java.net/census#kdnilsen) (@kdnilsen - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/shenandoah pull/135/head:pull/135` \
`$ git checkout pull/135`

Update a local copy of the PR: \
`$ git checkout pull/135` \
`$ git pull https://git.openjdk.java.net/shenandoah pull/135/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 135`

View PR using the GUI difftool: \
`$ git pr show -t 135`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/shenandoah/pull/135.diff">https://git.openjdk.java.net/shenandoah/pull/135.diff</a>

</details>
