### PR TITLE
Balance without cancel

### DIFF
--- a/src/hotspot/share/gc/shenandoah/heuristics/shenandoahHeuristics.cpp
+++ b/src/hotspot/share/gc/shenandoah/heuristics/shenandoahHeuristics.cpp
@@ -219,6 +219,9 @@ void ShenandoahHeuristics::choose_collection_set(ShenandoahCollectionSet* collec
                      byte_size_in_proper_unit(collection_set->garbage()),
                      proper_unit_for_byte_size(collection_set->garbage()),
                      cset_percent);
+
+  size_t bytes_evacuated = collection_set->get_bytes_reserved_for_evacuation();
+  log_info(gc, ergo)("Total Evacuation: " SIZE_FORMAT "%s", bytes_evacuated, proper_unit_for_byte_size(bytes_evacuated));
 }
 
 void ShenandoahHeuristics::record_cycle_start() {

--- a/src/hotspot/share/gc/shenandoah/heuristics/shenandoahHeuristics.cpp
+++ b/src/hotspot/share/gc/shenandoah/heuristics/shenandoahHeuristics.cpp
@@ -167,7 +167,6 @@ void ShenandoahHeuristics::choose_collection_set(ShenandoahCollectionSet* collec
       live_memory += region->get_live_data_bytes();
     }
   }
-
   save_last_live_memory(live_memory);
 
   // Step 2. Look back at garbage statistics, and decide if we want to collect anything,
@@ -179,12 +178,14 @@ void ShenandoahHeuristics::choose_collection_set(ShenandoahCollectionSet* collec
           byte_size_in_proper_unit(total_garbage),     proper_unit_for_byte_size(total_garbage));
 
   size_t immediate_percent = (total_garbage == 0) ? 0 : (immediate_garbage * 100 / total_garbage);
+  collection_set->set_immediate_trash(immediate_garbage);
 
   if (immediate_percent <= ShenandoahImmediateThreshold) {
 
     if (old_heuristics != NULL) {
       old_heuristics->prime_collection_set(collection_set);
 
+      // We can shrink old_evac_reserve() if the chosen collection set is smaller than maximum allowed.
       size_t bytes_reserved_for_old_evacuation = collection_set->get_old_bytes_reserved_for_evacuation();
       if (bytes_reserved_for_old_evacuation * ShenandoahEvacWaste < heap->get_old_evac_reserve()) {
         size_t old_evac_reserve = (size_t) (bytes_reserved_for_old_evacuation * ShenandoahEvacWaste);
@@ -193,144 +194,9 @@ void ShenandoahHeuristics::choose_collection_set(ShenandoahCollectionSet* collec
     }
     // else, this is global collection and doesn't need to prime_collection_set
 
-    ShenandoahYoungGeneration* young_generation = heap->young_generation();
-    size_t young_evacuation_reserve = (young_generation->soft_max_capacity() * ShenandoahEvacReserve) / 100;
-
-    // At this point, young_generation->available() does not know about recently discovered immediate garbage.
-    // What memory it does think to be available is not entirely trustworthy because any available memory associated
-    // with a region that is placed into the collection set becomes unavailable when the region is chosen
-    // for the collection set.  We'll compute an approximation of young available.  If young_available is zero,
-    // we'll need to borrow from old-gen in order to evacuate.  If there's nothing to borrow, we're going to
-    // degenerate to full GC.
-
-    // TODO: young_available can include available (between top() and end()) within each young region that is not
-    // part of the collection set.  Making this memory available to the young_evacuation_reserve allows a larger
-    // young collection set to be chosen when available memory is under extreme pressure.  Implementing this "improvement"
-    // is tricky, because the incremental construction of the collection set actually changes the amount of memory
-    // available to hold evacuated young-gen objects.  As currently implemented, the memory that is available within
-    // non-empty regions that are not selected as part of the collection set can be allocated by the mutator while
-    // GC is evacuating and updating references.
-
-    size_t region_size_bytes = ShenandoahHeapRegion::region_size_bytes();
-    size_t free_affiliated_regions = immediate_regions + free_regions;
-    size_t young_available = (free_affiliated_regions + young_generation->free_unaffiliated_regions()) * region_size_bytes;
-
-    size_t regions_available_to_loan = 0;
-
-    if (heap->mode()->is_generational()) {
-      //  Now that we've primed the collection set, we can figure out how much memory to reserve for evacuation
-      //  of young-gen objects.
-      //
-      //  YoungEvacuationReserve for young generation: how much memory are we reserving to hold the results
-      //     of evacuating young collection set regions?  This is typically smaller than the total amount
-      //     of available memory, and is also smaller than the total amount of marked live memory within
-      //     young-gen.  This value is the minimum of:
-      //       1. young_gen->available() + (old_gen->available - (OldEvacuationReserve + PromotionReserve))
-      //       2. young_gen->capacity() * ShenandoahEvacReserve
-      //
-      //     Note that any region added to the collection set will be completely evacuated and its memory will
-      //     be completely recycled at the end of GC.  The recycled memory will be at least as great as the
-      //     memory borrowed from old-gen.  Enforce that the amount borrowed from old-gen for YoungEvacuationReserve
-      //     is an integral number of entire heap regions.
-      //
-      young_evacuation_reserve -= heap->get_old_evac_reserve();
-
-      // Though we cannot know the evacuation_supplement until after we have computed the collection set, we do
-      // know that every young-gen region added to the collection set will have a net positive impact on available
-      // memory within young-gen, since each contributes a positive amount of garbage to available.  Thus, even
-      // without knowing the exact composition of the collection set, we can allow young_evacuation_reserve to
-      // exceed young_available if there are empty regions available within old-gen to hold the results of evacuation.
-
-      ShenandoahGeneration* old_generation = heap->old_generation();
-
-      // Not all of what is currently available within young-gen can be reserved to hold the results of young-gen
-      // evacuation.  This is because memory available within any heap region that is placed into the collection set
-      // is not available to be allocated during evacuation.  To be safe, we assure that all memory required for evacuation
-      // is available within "virgin" heap regions.
-
-      const size_t available_young_regions = free_regions + immediate_regions + young_generation->free_unaffiliated_regions();
-      const size_t available_old_regions = old_generation->free_unaffiliated_regions();
-      size_t already_reserved_old_bytes = heap->get_old_evac_reserve() + heap->get_promotion_reserve();
-      size_t regions_reserved_for_evac_and_promotion = (already_reserved_old_bytes + region_size_bytes - 1) / region_size_bytes;
-      regions_available_to_loan = available_old_regions - regions_reserved_for_evac_and_promotion;
-
-      if (available_young_regions * region_size_bytes < young_evacuation_reserve) {
-        // Try to borrow old-gen regions in order to avoid shrinking young_evacuation_reserve
-        size_t loan_request = young_evacuation_reserve - available_young_regions * region_size_bytes;
-        size_t loaned_region_request = (loan_request + region_size_bytes - 1) / region_size_bytes;
-        if (loaned_region_request > regions_available_to_loan) {
-          // Scale back young_evacuation_reserve to consume all available young and old regions.  After the
-          // collection set is chosen, we may get some of this memory back for pacing allocations during evacuation
-          // and update refs.
-          loaned_region_request = regions_available_to_loan;
-          young_evacuation_reserve = (available_young_regions + loaned_region_request) * region_size_bytes;
-        } else {
-          // No need to scale back young_evacuation_reserve.
-        }
-      } else {
-        // No need scale back young_evacuation_reserve and no need to borrow from old-gen.  We may even have some
-        // available_young_regions to support allocation pacing.
-      }
-
-    } else if (young_evacuation_reserve > young_available) {
-      // In non-generational mode, there's no old-gen memory to borrow from
-      young_evacuation_reserve = young_available;
-    }
-
-    heap->set_young_evac_reserve(young_evacuation_reserve);
-
     // Add young-gen regions into the collection set.  This is a virtual call, implemented differently by each
     // of the heuristics subclasses.
     choose_collection_set_from_regiondata(collection_set, candidates, cand_idx, immediate_garbage + free);
-
-    // Now compute the evacuation supplement, which is extra memory borrowed from old-gen that can be allocated
-    // by mutators while GC is working on evacuation and update-refs.
-
-    // During evacuation and update refs, we will be able to allocate any memory that is currently available
-    // plus any memory that can be borrowed on the collateral of the current collection set, reserving a certain
-    // percentage of the anticipated replenishment from collection set memory to be allocated during the subsequent
-    // concurrent marking effort.  This is how much I can repay.
-    size_t potential_supplement_regions = collection_set->get_young_region_count();
-
-    // Though I can repay potential_supplement_regions, I can't borrow them unless they are available in old-gen.
-    if (potential_supplement_regions > regions_available_to_loan) {
-      potential_supplement_regions = regions_available_to_loan;
-    }
-
-    size_t potential_evac_supplement;
-
-    // How much of the potential_supplement_regions will be consumed by young_evacuation_reserve: borrowed_evac_regions.
-    const size_t available_unaffiliated_young_regions = young_generation->free_unaffiliated_regions();
-    const size_t available_affiliated_regions = free_regions + immediate_regions;
-    const size_t available_young_regions = available_unaffiliated_young_regions + available_affiliated_regions;
-    size_t young_evac_regions = (young_evacuation_reserve + region_size_bytes - 1) / region_size_bytes;
-    size_t borrowed_evac_regions = (young_evac_regions > available_young_regions)? young_evac_regions - available_young_regions: 0;
-
-    potential_supplement_regions -= borrowed_evac_regions;
-    potential_evac_supplement = potential_supplement_regions * region_size_bytes;
-
-    // Leave some allocation runway for subsequent concurrent mark phase.
-    potential_evac_supplement = (potential_evac_supplement * ShenandoahBorrowPercent) / 100;
-
-    heap->set_alloc_supplement_reserve(potential_evac_supplement);
-
-    size_t promotion_budget = heap->get_promotion_reserve();
-    size_t old_evac_budget = heap->get_old_evac_reserve();
-    size_t alloc_budget_evac_and_update = potential_evac_supplement + young_available;
-
-    // TODO: young_available, which feeds into alloc_budget_evac_and_update is lacking memory available within
-    // existing young-gen regions that were not selected for the collection set.  Add this in and adjust the
-    // log message (where it says "empty-region allocation budget").
-
-    log_info(gc, ergo)("Memory reserved for evacuation and update-refs includes promotion budget: " SIZE_FORMAT
-                       "%s, young evacuation budget: " SIZE_FORMAT "%s, old evacuation budget: " SIZE_FORMAT
-                       "%s, empty-region allocation budget: " SIZE_FORMAT "%s, including supplement: " SIZE_FORMAT "%s",
-                       byte_size_in_proper_unit(promotion_budget), proper_unit_for_byte_size(promotion_budget),
-                       byte_size_in_proper_unit(young_evacuation_reserve), proper_unit_for_byte_size(young_evacuation_reserve),
-                       byte_size_in_proper_unit(old_evac_budget), proper_unit_for_byte_size(old_evac_budget),
-                       byte_size_in_proper_unit(alloc_budget_evac_and_update),
-                       proper_unit_for_byte_size(alloc_budget_evac_and_update),
-                       byte_size_in_proper_unit(potential_evac_supplement), proper_unit_for_byte_size(potential_evac_supplement));
   }
   // else, we're going to skip evacuation and update refs because we reclaimed sufficient amounts of immediate garbage.
 

--- a/src/hotspot/share/gc/shenandoah/heuristics/shenandoahOldHeuristics.cpp
+++ b/src/hotspot/share/gc/shenandoah/heuristics/shenandoahOldHeuristics.cpp
@@ -43,6 +43,13 @@ ShenandoahOldHeuristics::ShenandoahOldHeuristics(ShenandoahGeneration* generatio
 {
 }
 
+// A bound on memory available for old-gen evacuation has been computed and is fed into the function by
+// way of heap->get_evacuation_reserve().  When priming the old-gen collection set, we limit ourselves to
+// evacuating no more than heap->get_old_evac_reserve() / ShenandoahEvacWaste bytes.
+//
+// If prime_collection_set() does not consume all of this available memory, it will reduce the old_evac_reserve
+// and increase the promoted_reserve(), making sure to not promote into the memory 
+
 bool ShenandoahOldHeuristics::prime_collection_set(ShenandoahCollectionSet* collection_set) {
   if (unprocessed_old_collection_candidates() == 0) {
     return false;
@@ -60,82 +67,34 @@ bool ShenandoahOldHeuristics::prime_collection_set(ShenandoahCollectionSet* coll
 
   // max_old_evacuation_bytes represents a bound on how much evacuation effort is dedicated
   // to old-gen regions.
-  size_t max_old_evacuation_bytes = (heap->old_generation()->soft_max_capacity() * ShenandoahOldEvacReserve) / 100;
-  const size_t young_evacuation_bytes = (heap->young_generation()->soft_max_capacity() * ShenandoahEvacReserve) / 100;
-  const size_t ratio_bound_on_old_evac_bytes = (young_evacuation_bytes * ShenandoahOldEvacRatioPercent) / 100;
-  if (max_old_evacuation_bytes > ratio_bound_on_old_evac_bytes) {
-    max_old_evacuation_bytes = ratio_bound_on_old_evac_bytes;
-  }
 
-  // Usually, old-evacuation is limited by the CPU bounds on effort.  However, it can also be bounded by available
-  // memory within old-gen to hold the results of evacuation.  When we are bound by memory availability, we need
-  // to account below for the loss of available memory from within each region that is added to the old-gen collection
-  // set.
-  size_t old_available = heap->old_generation()->available();
-  size_t excess_old_capacity_for_evacuation;
-  if (max_old_evacuation_bytes > old_available) {
-    max_old_evacuation_bytes = old_available;
-    excess_old_capacity_for_evacuation = 0;
-  } else {
-    excess_old_capacity_for_evacuation = old_available - max_old_evacuation_bytes;
-  }
-
-  // promotion_budget_bytes represents an "arbitrary" bound on how many bytes can be consumed by young-gen
-  // objects promoted into old-gen memory.  We need to avoid a scenario under which promotion of objects
-  // depletes old-gen available memory to the point that there is insufficient memory to hold old-gen objects
-  // that need to be evacuated from within the old-gen collection set.
-  //
-  // Key idea: if there is not sufficient memory within old-gen to hold an object that wants to be promoted, defer
-  // promotion until a subsequent evacuation pass.  Enforcement is provided at the time PLABs and shared allocations
-  // in old-gen memory are requested.
-
-  const size_t promotion_budget_bytes = heap->get_promotion_reserve();
-
-  // old_evacuation_budget is an upper bound on the amount of live memory that can be evacuated.
-  //
   // If a region is put into the collection set, then this region's free (not yet used) bytes are no longer
   // "available" to hold the results of other evacuations.  This may cause a decrease in the remaining amount
   // of memory that can still be evacuated.  We address this by reducing the evacuation budget by the amount
   // of live memory in that region and by the amount of unallocated memory in that region if the evacuation
-  // budget is constrained by availability of free memory.  See remaining_old_evacuation_budget below.
+  // budget is constrained by availability of free memory.
 
-  size_t old_evacuation_budget = (size_t) (max_old_evacuation_bytes / ShenandoahEvacWaste);
-
-  log_info(gc)("Choose old regions for mixed collection: old evacuation budget: " SIZE_FORMAT "%s",
-                byte_size_in_proper_unit(old_evacuation_budget), proper_unit_for_byte_size(old_evacuation_budget));
-
+  size_t old_evacuation_budget = (size_t) (heap->get_old_evac_reserve() / ShenandoahEvacWaste);
   size_t remaining_old_evacuation_budget = old_evacuation_budget;
   size_t lost_evacuation_capacity = 0;
+  log_info(gc)("Choose old regions for mixed collection: old evacuation budget: " SIZE_FORMAT "%s, candidates: %u",
+               byte_size_in_proper_unit(old_evacuation_budget), proper_unit_for_byte_size(old_evacuation_budget),
+               unprocessed_old_collection_candidates());
 
-  // The number of old-gen regions that were selected as candidates for collection at the end of the most recent
-  // old-gen concurrent marking phase and have not yet been collected is represented by
-  // unprocessed_old_collection_candidates()
+  // The number of old-gen regions that were selected as candidates for collection at the end of the most recent old-gen
+  // concurrent marking phase and have not yet been collected is represented by unprocessed_old_collection_candidates()
   while (unprocessed_old_collection_candidates() > 0) {
     // Old collection candidates are sorted in order of decreasing garbage contained therein.
     ShenandoahHeapRegion* r = next_old_collection_candidate();
 
-
     // If we choose region r to be collected, then we need to decrease the capacity to hold other evacuations by
     // the size of r's free memory.
-    if ((r->get_live_data_bytes() <= remaining_old_evacuation_budget) &&
-        ((lost_evacuation_capacity + r->free() <= excess_old_capacity_for_evacuation)
-         || (r->get_live_data_bytes() + r->free() <= remaining_old_evacuation_budget))) {
-
+    if (r->get_live_data_bytes() <= remaining_old_evacuation_budget) {
       // Decrement remaining evacuation budget by bytes that will be copied.  If the cumulative loss of free memory from
       // regions that are to be collected exceeds excess_old_capacity_for_evacuation,  decrease
       // remaining_old_evacuation_budget by this loss as well.
       lost_evacuation_capacity += r->free();
       remaining_old_evacuation_budget -= r->get_live_data_bytes();
-      if (lost_evacuation_capacity > excess_old_capacity_for_evacuation) {
-        // This is slightly conservative because we really only need to remove from the remaining evacuation budget
-        // the amount by which lost_evacution_capacity exceeds excess_old_capacity_for_evacuation, but this is relatively
-        // rare event and current thought is to be a bit conservative rather than mess up the math on code that is so
-        // difficult to test and maintain...
-
-        // Once we have crossed the threshold of lost_evacuation_capacity exceeding excess_old_capacity_for_evacuation,
-        // every subsequent iteration of this loop will further decrease remaining_old_evacuation_budget.
-        remaining_old_evacuation_budget -= r->free();
-      }
       collection_set->add_region(r);
       included_old_regions++;
       evacuated_old_bytes += r->get_live_data_bytes();

--- a/src/hotspot/share/gc/shenandoah/heuristics/shenandoahOldHeuristics.cpp
+++ b/src/hotspot/share/gc/shenandoah/heuristics/shenandoahOldHeuristics.cpp
@@ -48,7 +48,7 @@ ShenandoahOldHeuristics::ShenandoahOldHeuristics(ShenandoahGeneration* generatio
 // evacuating no more than heap->get_old_evac_reserve() / ShenandoahEvacWaste bytes.
 //
 // If prime_collection_set() does not consume all of this available memory, it will reduce the old_evac_reserve
-// and increase the promoted_reserve(), making sure to not promote into the memory 
+// and increase the promoted_reserve(), making sure to not promote into the memory
 
 bool ShenandoahOldHeuristics::prime_collection_set(ShenandoahCollectionSet* collection_set) {
   if (unprocessed_old_collection_candidates() == 0) {

--- a/src/hotspot/share/gc/shenandoah/heuristics/shenandoahOldHeuristics.cpp
+++ b/src/hotspot/share/gc/shenandoah/heuristics/shenandoahOldHeuristics.cpp
@@ -58,6 +58,7 @@ bool ShenandoahOldHeuristics::prime_collection_set(ShenandoahCollectionSet* coll
   ShenandoahHeap* heap = ShenandoahHeap::heap();
   uint included_old_regions = 0;
   size_t evacuated_old_bytes = 0;
+  size_t collected_old_bytes = 0;
 
   // TODO:
   // The max_old_evacuation_bytes and promotion_budget_bytes constants represent a first
@@ -98,6 +99,7 @@ bool ShenandoahOldHeuristics::prime_collection_set(ShenandoahCollectionSet* coll
       collection_set->add_region(r);
       included_old_regions++;
       evacuated_old_bytes += r->get_live_data_bytes();
+      collected_old_bytes += r->garbage();
       consume_old_collection_candidate();
     } else {
       break;
@@ -105,8 +107,10 @@ bool ShenandoahOldHeuristics::prime_collection_set(ShenandoahCollectionSet* coll
   }
 
   if (included_old_regions > 0) {
-    log_info(gc)("Old-gen piggyback evac (" UINT32_FORMAT " regions, " SIZE_FORMAT " %s)",
-                 included_old_regions, byte_size_in_proper_unit(evacuated_old_bytes), proper_unit_for_byte_size(evacuated_old_bytes));
+    log_info(gc)("Old-gen piggyback evac (" UINT32_FORMAT " regions, evacuating: "
+                 SIZE_FORMAT "%s, reclaiming: " SIZE_FORMAT "%s)", included_old_regions,
+                 byte_size_in_proper_unit(evacuated_old_bytes), proper_unit_for_byte_size(evacuated_old_bytes),
+                 byte_size_in_proper_unit(collected_old_bytes), proper_unit_for_byte_size(collected_old_bytes));
   }
   return (included_old_regions > 0);
 }

--- a/src/hotspot/share/gc/shenandoah/shenandoahBarrierSet.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahBarrierSet.cpp
@@ -127,7 +127,7 @@ void ShenandoahBarrierSet::on_thread_detach(Thread *thread) {
     // This is safe iff it is assured that each PLAB is a whole-number multiple of card-mark memory size and each
     // PLAB is aligned with the start of each card's memory range.
     if (plab != NULL) {
-      _heap->retire_plab(plab);
+      _heap->retire_plab(plab, thread);
     }
 
     // SATB protocol requires to keep alive reacheable oops from roots at the beginning of GC

--- a/src/hotspot/share/gc/shenandoah/shenandoahCardTable.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahCardTable.cpp
@@ -29,6 +29,7 @@
 
 void ShenandoahCardTable::initialize() {
   CardTable::initialize();
+
   _write_byte_map = _byte_map;
   _write_byte_map_base = _byte_map_base;
   const size_t rs_align = _page_size == (size_t) os::vm_page_size() ? 0 :

--- a/src/hotspot/share/gc/shenandoah/shenandoahCollectionSet.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahCollectionSet.cpp
@@ -44,6 +44,7 @@ ShenandoahCollectionSet::ShenandoahCollectionSet(ShenandoahHeap* heap, ReservedS
   _garbage(0),
   _used(0),
   _region_count(0),
+  _old_garbage(0),
   _current_index(0) {
 
   // The collection set map is reserved to cover the entire heap *and* zero addresses.
@@ -94,6 +95,7 @@ void ShenandoahCollectionSet::add_region(ShenandoahHeapRegion* r) {
   } else if (r->affiliation() == OLD_GENERATION) {
     _old_region_count++;
     _old_bytes_to_evacuate += r->get_live_data_bytes();
+    _old_garbage += r->garbage();
   }
 
   _region_count++;
@@ -115,6 +117,7 @@ void ShenandoahCollectionSet::clear() {
 #endif
 
   _garbage = 0;
+  _old_garbage = 0;
   _used = 0;
 
   _region_count = 0;

--- a/src/hotspot/share/gc/shenandoah/shenandoahCollectionSet.hpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahCollectionSet.hpp
@@ -57,6 +57,8 @@ private:
   size_t                _young_region_count;
   size_t                _old_region_count;
 
+  size_t                _old_garbage;        // How many bytes of old garbage are present in a mixed collection set?
+
   shenandoah_padding(0);
   volatile size_t       _current_index;
   shenandoah_padding(1);
@@ -105,6 +107,8 @@ public:
   inline size_t get_old_region_count();
 
   inline size_t get_young_region_count();
+
+  inline size_t get_old_garbage();
 
   bool has_old_regions() const { return _has_old_regions; }
   size_t used()          const { return _used; }

--- a/src/hotspot/share/gc/shenandoah/shenandoahCollectionSet.inline.hpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahCollectionSet.inline.hpp
@@ -81,4 +81,8 @@ size_t ShenandoahCollectionSet::get_young_region_count() {
   return _young_region_count;
 }
 
+size_t ShenandoahCollectionSet::get_old_garbage() {
+  return _old_garbage;
+}
+
 #endif // SHARE_GC_SHENANDOAH_SHENANDOAHCOLLECTIONSET_INLINE_HPP

--- a/src/hotspot/share/gc/shenandoah/shenandoahConcurrentGC.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahConcurrentGC.cpp
@@ -122,7 +122,7 @@ bool ShenandoahConcurrentGC::collect(GCCause::Cause cause) {
     // Concurrent remembered set scanning
     if (_generation->generation_mode() == YOUNG) {
       ShenandoahConcurrentPhase gc_phase("Concurrent remembered set scanning", ShenandoahPhaseTimings::init_scan_rset);
-      _generation->scan_remembered_set();
+      _generation->scan_remembered_set(true /* is_concurrent */);
     }
 
     // Concurrent mark roots
@@ -222,6 +222,7 @@ bool ShenandoahConcurrentGC::collect(GCCause::Cause cause) {
     ShenandoahHeapLocker locker(heap->lock());
 
     size_t old_usage_before_evac = heap->capture_old_usage(0);
+
     size_t old_usage_now = old_gen->used();
     size_t promoted_bytes = old_usage_now - old_usage_before_evac;
     heap->set_previous_promotion(promoted_bytes);
@@ -237,7 +238,8 @@ bool ShenandoahConcurrentGC::collect(GCCause::Cause cause) {
     heap->set_young_evac_reserve(0);
     heap->set_old_evac_reserve(0);
     heap->reset_old_evac_expended();
-    heap->set_promotion_reserve(0);
+    heap->set_promoted_reserve(0);
+    heap->reset_promoted_expended();
   }
   log_info(gc, ergo)("At end of concurrent GC, old_available: " SIZE_FORMAT "%s, young_available: " SIZE_FORMAT "%s",
                      byte_size_in_proper_unit(old_available), proper_unit_for_byte_size(old_available),
@@ -699,7 +701,7 @@ void ShenandoahConcurrentGC::op_final_mark() {
     // Upon return from prepare_regions_and_collection_set(), certain parameters have been established to govern the
     // evacuation efforts that are about to begin.  In particular:
     //
-    // heap->get_promotion_reserve() represents the amount of memory within old-gen's available memory that has
+    // heap->get_promoted_reserve() represents the amount of memory within old-gen's available memory that has
     //   been set aside to hold objects promoted from young-gen memory.  This represents an estimated percentage
     //   of the live young-gen memory within the collection set.  If there is more data ready to be promoted than
     //   can fit within this reserve, the promotion of some objects will be deferred until a subsequent evacuation
@@ -749,7 +751,7 @@ void ShenandoahConcurrentGC::op_final_mark() {
         // loaned for young-gen allocations or evacuations.
         size_t old_available = heap->old_generation()->adjust_available(-heap->get_alloc_supplement_reserve());
 
-        log_info(gc, ergo)("After generational memory budget adjustments, old avaiable: " SIZE_FORMAT
+        log_info(gc, ergo)("After generational memory budget adjustments, old available: " SIZE_FORMAT
                            "%s, young_available: " SIZE_FORMAT "%s",
                            byte_size_in_proper_unit(old_available), proper_unit_for_byte_size(old_available),
                            byte_size_in_proper_unit(young_available), proper_unit_for_byte_size(young_available));

--- a/src/hotspot/share/gc/shenandoah/shenandoahDegeneratedGC.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahDegeneratedGC.cpp
@@ -72,6 +72,7 @@ void ShenandoahDegenGC::entry_degenerated() {
 
   // In case degenerated GC preempted evacuation or update-refs, clear the aging cycle now.  No harm in clearing it
   // redundantly if it is already clear.  We don't age during degenerated cycles.
+  // TODO: Why not age during degenerated cycles?  Investigate and fix, or explain why not.
   heap->set_aging_cycle(false);
 
   ShenandoahWorkerScope scope(heap->workers(),
@@ -286,7 +287,7 @@ void ShenandoahDegenGC::op_degenerated() {
     heap->set_young_evac_reserve(0);
     heap->set_old_evac_reserve(0);
     heap->reset_old_evac_expended();
-    heap->set_promotion_reserve(0);
+    heap->set_promoted_reserve(0);
 
   }
 

--- a/src/hotspot/share/gc/shenandoah/shenandoahFullGC.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahFullGC.cpp
@@ -191,7 +191,7 @@ void ShenandoahFullGC::do_it(GCCause::Cause gc_cause) {
   heap->set_young_evac_reserve(0);
   heap->set_old_evac_reserve(0);
   heap->reset_old_evac_expended();
-  heap->set_promotion_reserve(0);
+  heap->set_promoted_reserve(0);
 
   if (heap->mode()->is_generational()) {
     // Full GC supersedes any marking or coalescing in old generation.

--- a/src/hotspot/share/gc/shenandoah/shenandoahGeneration.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahGeneration.cpp
@@ -288,11 +288,11 @@ void ShenandoahGeneration::prepare_regions_and_collection_set(bool concurrent) {
         }
         if (((((young_generation->soft_max_capacity() * ShenandoahEvacReserve) / 100) * ShenandoahOldEvacRatioPercent) / 100) <
             old_evacuation_reserve) {
-          old_evacuation_reserve = 
+          old_evacuation_reserve =
             (((young_generation->soft_max_capacity() * ShenandoahEvacReserve) / 100) * ShenandoahOldEvacRatioPercent) / 100;
         }
       }
-      
+
       if (old_evacuation_reserve < minimum_evacuation_reserve) {
         // Even if there's nothing to be evacuated on this cycle, we still need to reserve this memory for future
         // evacuations.  It is ok to loan this memory to young-gen if we don't need it for evacuation on this pass.
@@ -312,7 +312,7 @@ void ShenandoahGeneration::prepare_regions_and_collection_set(bool concurrent) {
       //  young_evacuation_reserve for young generation: how much memory are we reserving to hold the results
       //  of evacuating young collection set regions?  This is typically smaller than the total amount
       //  of available memory, and is also smaller than the total amount of marked live memory within
-      //  young-gen.  This value is the smaller of 
+      //  young-gen.  This value is the smaller of
       //
       //    1. (young_gen->capacity() * ShenandoahEvacReserve) / 100
       //    2. (young_gen->available() + (old_gen->free_region_memory - old_evacuation_reserve);
@@ -343,7 +343,7 @@ void ShenandoahGeneration::prepare_regions_and_collection_set(bool concurrent) {
         regions_available_to_loan = net_available_old_regions;
       }
       // Otherwise, the reason regions_available_to_loan is less than net_available_old_regions is because the
-      // available memory is scattered between many partially used regions.  
+      // available memory is scattered between many partially used regions.
 
       if (young_evacuation_reserve > young_generation->available()) {
         size_t short_fall = young_evacuation_reserve - young_generation->available();
@@ -413,7 +413,7 @@ void ShenandoahGeneration::prepare_regions_and_collection_set(bool concurrent) {
         regions_available_to_loan += old_regions_loaned_for_young_evac;
         old_regions_loaned_for_young_evac = 0;
       }
-      
+
       // Limit promotion_reserve so that we can set aside memory to be loaned from old-gen to young-gen.  This
       // value is not "critical".  If we underestimate, certain promotions will simply be deferred.  If we put
       // "all the rest" of old-gen memory into the promotion reserve, we'll have nothing left to loan to young-gen
@@ -493,7 +493,7 @@ void ShenandoahGeneration::prepare_regions_and_collection_set(bool concurrent) {
 
       assert(old_regions_loaned_for_young_evac <= collection_set->get_young_region_count(),
              "Cannot loan more regions than will be reclaimed");
-      
+
       if (regions_available_to_loan > (collection_set->get_young_region_count() - old_regions_loaned_for_young_evac)) {
         regions_available_to_loan = collection_set->get_young_region_count() - old_regions_loaned_for_young_evac;
       }
@@ -508,7 +508,7 @@ void ShenandoahGeneration::prepare_regions_and_collection_set(bool concurrent) {
       // TODO: young_available, which feeds into alloc_budget_evac_and_update is lacking memory available within
       // existing young-gen regions that were not selected for the collection set.  Add this in and adjust the
       // log message (where it says "empty-region allocation budget").
-      
+
       log_info(gc, ergo)("Memory reserved for evacuation and update-refs includes promotion budget: " SIZE_FORMAT
                          "%s, young evacuation budget: " SIZE_FORMAT "%s, old evacuation budget: " SIZE_FORMAT
                          "%s, empty-region allocation budget: " SIZE_FORMAT "%s, including supplement: " SIZE_FORMAT "%s",
@@ -521,7 +521,7 @@ void ShenandoahGeneration::prepare_regions_and_collection_set(bool concurrent) {
                          byte_size_in_proper_unit(allocation_supplement), proper_unit_for_byte_size(allocation_supplement));
     }
   }
-  
+
   {
     ShenandoahGCPhase phase(concurrent ? ShenandoahPhaseTimings::final_rebuild_freeset :
                             ShenandoahPhaseTimings::degen_gc_final_rebuild_freeset);

--- a/src/hotspot/share/gc/shenandoah/shenandoahGeneration.hpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahGeneration.hpp
@@ -148,7 +148,7 @@ protected:
   virtual ShenandoahObjToScanQueueSet* old_gen_task_queues() const;
 
   // Scan remembered set at start of concurrent young-gen marking. */
-  void scan_remembered_set();
+  void scan_remembered_set(bool is_concurrent);
 
   void increment_affiliated_region_count();
   void decrement_affiliated_region_count();

--- a/src/hotspot/share/gc/shenandoah/shenandoahHeap.inline.hpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahHeap.inline.hpp
@@ -402,7 +402,7 @@ inline oop ShenandoahHeap::try_evacuate_object(oop p, Thread* thread, Shenandoah
 
                // In this situation, PLAB memory is precious.  We'll try to preserve our existing PLAB by forcing
                // this particular allocation to be shared.
-               
+
                PLAB* plab = ShenandoahThreadLocalData::plab(thread);
                if (plab->words_remaining() < PLAB::min_size()) {
                  ShenandoahThreadLocalData::set_plab_size(thread, PLAB::min_size());

--- a/src/hotspot/share/gc/shenandoah/shenandoahHeap.inline.hpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahHeap.inline.hpp
@@ -301,17 +301,23 @@ inline HeapWord* ShenandoahHeap::allocate_from_plab(Thread* thread, size_t size,
   assert(UseTLAB, "TLABs should be enabled");
 
   PLAB* plab = ShenandoahThreadLocalData::plab(thread);
-  if (is_promotion && !ShenandoahThreadLocalData::allow_plab_promotions(thread)) {
-    return NULL;
-  } else if (plab == NULL) {
-    assert(!thread->is_Java_thread() && !thread->is_Worker_thread(),
-           "Performance: thread should have PLAB: %s", thread->name());
+  HeapWord* obj;
+  if (plab == NULL) {
+    assert(!thread->is_Java_thread() && !thread->is_Worker_thread(), "Performance: thread should have PLAB: %s", thread->name());
     // No PLABs in this thread, fallback to shared allocation
-    return NULL;
+    return nullptr;
+  } else if (is_promotion && (plab->words_remaining() > 0) && !ShenandoahThreadLocalData::allow_plab_promotions(thread)) {
+    return nullptr;
   }
-  HeapWord* obj = plab->allocate(size);
-  if (obj == NULL) {
+  // if plab->word_size() <= 0, thread's plab not yet initialized for this pass, so allow_plab_promotions() is not trustworthy
+  obj = plab->allocate(size);
+  if ((obj == nullptr) && (plab->words_remaining() < PLAB::min_size())) {
+    // allocate_from_plab_slow will establish allow_plab_promotions(thread) for future invocations
     obj = allocate_from_plab_slow(thread, size, is_promotion);
+  }
+  // if plab->words_remaining() >= PLAB::min_size(), just return nullptr so we can use a shared allocation
+  if (obj == nullptr) {
+    return nullptr;
   }
   if (is_promotion) {
     ShenandoahThreadLocalData::add_to_plab_promoted(thread, size * HeapWordSize);
@@ -387,12 +393,29 @@ inline oop ShenandoahHeap::try_evacuate_object(oop p, Thread* thread, Shenandoah
         case OLD_GENERATION: {
            if (ShenandoahUsePLAB) {
              copy = allocate_from_plab(thread, size, is_promotion);
-             if ((copy == nullptr) && (size < ShenandoahThreadLocalData::plab_size(thread))) {
-               // PLAB allocation failed because we are bumping up against the limit on old evacuation reserve.  Try resetting
-               // the desired PLAB size and retry PLAB allocation to avoid cascading of shared memory allocations.
-               ShenandoahThreadLocalData::set_plab_size(thread, PLAB::min_size());
-               copy = allocate_from_plab(thread, size, is_promotion);
-               // If we still get nullptr, we'll try a shared allocation below.
+             if ((copy == nullptr) && (size < ShenandoahThreadLocalData::plab_size(thread)) &&
+                 ShenandoahThreadLocalData::plab_retries_enabled(thread)) {
+               // PLAB allocation failed because we are bumping up against the limit on old evacuation reserve or because
+               // the requested object does not fit within the current plab but the plab still has an "abundance" of memory,
+               // where abundance is defined as >= PLAB::min_size().  In the former case, we try resetting the desired
+               // PLAB size and retry PLAB allocation to avoid cascading of shared memory allocations.
+
+               // In this situation, PLAB memory is precious.  We'll try to preserve our existing PLAB by forcing
+               // this particular allocation to be shared.
+               
+               PLAB* plab = ShenandoahThreadLocalData::plab(thread);
+               if (plab->words_remaining() < PLAB::min_size()) {
+                 ShenandoahThreadLocalData::set_plab_size(thread, PLAB::min_size());
+                 copy = allocate_from_plab(thread, size, is_promotion);
+                 // If we still get nullptr, we'll try a shared allocation below.
+                 if (copy == nullptr) {
+                   // If retry fails, don't continue to retry until we have success (probably in next GC pass)
+                   ShenandoahThreadLocalData::disable_plab_retries(thread);
+                 }
+               }
+               // else, copy still equals nullptr.  this causes shared allocation below, preserving this plab for future needs.
+             } else if (copy != nullptr) {
+               ShenandoahThreadLocalData::enable_plab_retries(thread);
              }
            }
            break;
@@ -588,14 +611,14 @@ inline bool ShenandoahHeap::is_aging_cycle() const {
   return _is_aging_cycle.is_set();
 }
 
-inline size_t ShenandoahHeap::set_promotion_reserve(size_t new_val) {
-  size_t orig = _promotion_reserve;
-  _promotion_reserve = new_val;
+inline size_t ShenandoahHeap::set_promoted_reserve(size_t new_val) {
+  size_t orig = _promoted_reserve;
+  _promoted_reserve = new_val;
   return orig;
 }
 
-inline size_t ShenandoahHeap::get_promotion_reserve() const {
-  return _promotion_reserve;
+inline size_t ShenandoahHeap::get_promoted_reserve() const {
+  return _promoted_reserve;
 }
 
 // returns previous value
@@ -606,6 +629,7 @@ size_t ShenandoahHeap::capture_old_usage(size_t old_usage) {
 }
 
 void ShenandoahHeap::set_previous_promotion(size_t promoted_bytes) {
+  shenandoah_assert_heaplocked();
   _previous_promotion = promoted_bytes;
 }
 
@@ -620,20 +644,36 @@ inline size_t ShenandoahHeap::set_old_evac_reserve(size_t new_val) {
 }
 
 inline size_t ShenandoahHeap::get_old_evac_reserve() const {
-  return _old_evac_reserve;
+  size_t result = _old_evac_reserve;
+  return result;
 }
 
 inline void ShenandoahHeap::reset_old_evac_expended() {
-  _old_evac_expended = 0;
+  Atomic::store(&_old_evac_expended, (size_t) 0);
 }
 
 inline size_t ShenandoahHeap::expend_old_evac(size_t increment) {
-  _old_evac_expended += increment;
-  return _old_evac_expended;
+  return Atomic::add(&_old_evac_expended, increment);
 }
 
-inline size_t ShenandoahHeap::get_old_evac_expended() const {
-  return _old_evac_expended;
+inline size_t ShenandoahHeap::get_old_evac_expended() {
+  return Atomic::load(&_old_evac_expended);
+}
+
+inline void ShenandoahHeap::reset_promoted_expended() {
+  Atomic::store(&_promoted_expended, (size_t) 0);
+}
+
+inline size_t ShenandoahHeap::expend_promoted(size_t increment) {
+  return Atomic::add(&_promoted_expended, increment);
+}
+
+inline size_t ShenandoahHeap::unexpend_promoted(size_t decrement) {
+  return Atomic::sub(&_promoted_expended, decrement);
+}
+
+inline size_t ShenandoahHeap::get_promoted_expended() {
+  return Atomic::load(&_promoted_expended);
 }
 
 inline size_t ShenandoahHeap::set_young_evac_reserve(size_t new_val) {

--- a/src/hotspot/share/gc/shenandoah/shenandoahHeapRegion.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahHeapRegion.cpp
@@ -566,6 +566,57 @@ void ShenandoahHeapRegion::global_oop_iterate_objects_and_fill_dead(OopIterateCl
   }
 }
 
+// DO NOT CANCEL.  If this worker thread has accepted responsibility for scanning a particular range of addresses, it
+// must finish the work before it can be cancelled.
+void ShenandoahHeapRegion::oop_iterate_humongous_slice(OopIterateClosure* blk, bool dirty_only,
+                                                       HeapWord* start, size_t words, bool write_table, bool is_concurrent) {
+  assert(words % CardTable::card_size_in_words() == 0, "Humongous iteration must span whole number of cards");
+  assert(is_humongous(), "only humongous region here");
+  ShenandoahHeap* heap = ShenandoahHeap::heap();
+
+  // Find head.
+  ShenandoahHeapRegion* r = humongous_start_region();
+  assert(r->is_humongous_start(), "need humongous head here");
+
+  oop obj = cast_to_oop(r->bottom());
+  RememberedScanner* scanner = ShenandoahHeap::heap()->card_scan();
+  size_t card_index = scanner->card_index_for_addr(start);
+  size_t num_cards = words / CardTable::card_size_in_words();
+
+  if (dirty_only) {
+    if (write_table) {
+      while (num_cards-- > 0) {
+        if (scanner->is_write_card_dirty(card_index++)) {
+          obj->oop_iterate(blk, MemRegion(start, start + CardTable::card_size_in_words()));
+        }
+        start += CardTable::card_size_in_words();
+      }
+    } else {
+      while (num_cards-- > 0) {
+        if (scanner->is_card_dirty(card_index++)) {
+          obj->oop_iterate(blk, MemRegion(start, start + CardTable::card_size_in_words()));
+        }
+        start += CardTable::card_size_in_words();
+      }
+    }
+  } else {
+    // Scan all data, regardless of whether cards are dirty
+    while (num_cards-- > 0) {
+      obj->oop_iterate(blk, MemRegion(start, start + CardTable::card_size_in_words()));
+      start += CardTable::card_size_in_words();
+    }
+  }
+}
+
+void ShenandoahHeapRegion::oop_iterate_humongous(OopIterateClosure* blk, HeapWord* start, size_t words) {
+  assert(is_humongous(), "only humongous region here");
+  // Find head.
+  ShenandoahHeapRegion* r = humongous_start_region();
+  assert(r->is_humongous_start(), "need humongous head here");
+  oop obj = cast_to_oop(r->bottom());
+  obj->oop_iterate(blk, MemRegion(start, start + words));
+}
+
 void ShenandoahHeapRegion::oop_iterate_humongous(OopIterateClosure* blk) {
   assert(is_humongous(), "only humongous region here");
   // Find head.
@@ -592,7 +643,6 @@ ShenandoahHeapRegion* ShenandoahHeapRegion::humongous_start_region() const {
 
 void ShenandoahHeapRegion::recycle() {
   ShenandoahHeap* heap = ShenandoahHeap::heap();
-
   if (affiliation() == YOUNG_GENERATION) {
     heap->young_generation()->decrease_used(used());
   } else if (affiliation() == OLD_GENERATION) {

--- a/src/hotspot/share/gc/shenandoah/shenandoahHeapRegion.hpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahHeapRegion.hpp
@@ -401,6 +401,13 @@ public:
   // that are subsumed into coalesced ranges of dead memory need to be "unregistered".
   void global_oop_iterate_and_fill_dead(OopIterateClosure* cl);
   void oop_iterate_humongous(OopIterateClosure* cl);
+  void oop_iterate_humongous(OopIterateClosure* cl, HeapWord* start, size_t words);
+
+  // Invoke closure on every reference contained within the humongous object that spans this humongous
+  // region if the reference is contained within a DIRTY card and the reference is no more than words following
+  // start within the humongous object.
+  void oop_iterate_humongous_slice(OopIterateClosure* cl, bool dirty_only, HeapWord* start, size_t words,
+                                         bool write_table, bool is_concurrent);
 
   HeapWord* block_start(const void* p) const;
   size_t block_size(const HeapWord* p) const;

--- a/src/hotspot/share/gc/shenandoah/shenandoahSTWMark.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahSTWMark.cpp
@@ -116,7 +116,7 @@ void ShenandoahSTWMark::mark() {
     // Mark
     if (_generation->generation_mode() == YOUNG) {
       // But only scan the remembered set for young generation.
-      _generation->scan_remembered_set();
+      _generation->scan_remembered_set(false /* is_concurrent */);
     }
 
     StrongRootsScope scope(nworkers);

--- a/src/hotspot/share/gc/shenandoah/shenandoahScanRemembered.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahScanRemembered.cpp
@@ -87,29 +87,214 @@ void ShenandoahDirectCardMarkRememberedSet::merge_overreach(size_t first_cluster
 ShenandoahScanRememberedTask::ShenandoahScanRememberedTask(ShenandoahObjToScanQueueSet* queue_set,
                                                            ShenandoahObjToScanQueueSet* old_queue_set,
                                                            ShenandoahReferenceProcessor* rp,
-                                                           ShenandoahRegionIterator* regions) :
+                                                           ShenandoahRegionChunkIterator* work_list, bool is_concurrent) :
   WorkerTask("Scan Remembered Set"),
-  _queue_set(queue_set), _old_queue_set(old_queue_set), _rp(rp), _regions(regions) {}
+  _queue_set(queue_set), _old_queue_set(old_queue_set), _rp(rp), _work_list(work_list), _is_concurrent(is_concurrent) {}
 
 void ShenandoahScanRememberedTask::work(uint worker_id) {
-  // This sets up a thread local reference to the worker_id which is necessary
-  // the weak reference processor.
-  ShenandoahParallelWorkerSession worker_session(worker_id);
+  if (_is_concurrent) {
+    // This sets up a thread local reference to the worker_id which is needed by the weak reference processor.
+    ShenandoahConcurrentWorkerSession worker_session(worker_id);
+    ShenandoahSuspendibleThreadSetJoiner stsj(ShenandoahSuspendibleWorkers);
+    do_work(worker_id);
+  } else {
+    // This sets up a thread local reference to the worker_id which is needed by the weak reference processor.
+    ShenandoahParallelWorkerSession worker_session(worker_id);
+    do_work(worker_id);
+  }
+}
+
+void ShenandoahScanRememberedTask::do_work(uint worker_id) {
   ShenandoahWorkerTimingsTracker x(ShenandoahPhaseTimings::init_scan_rset, ShenandoahPhaseTimings::ScanClusters, worker_id);
 
   ShenandoahObjToScanQueue* q = _queue_set->queue(worker_id);
   ShenandoahObjToScanQueue* old = _old_queue_set == NULL ? NULL : _old_queue_set->queue(worker_id);
   ShenandoahMarkRefsClosure<YOUNG> cl(q, _rp, old);
-  RememberedScanner* scanner = ShenandoahHeap::heap()->card_scan();
+  ShenandoahHeap* heap = ShenandoahHeap::heap();
+  RememberedScanner* scanner = heap->card_scan();
 
   // set up thread local closure for shen ref processor
   _rp->set_mark_closure(worker_id, &cl);
-  ShenandoahHeapRegion* region = _regions->next();
-  while (region != NULL) {
-    log_debug(gc)("ShenandoahScanRememberedTask::work(%u), looking at region " SIZE_FORMAT, worker_id, region->index());
-    if (region->affiliation() == OLD_GENERATION) {
-      scanner->process_region(region, &cl);
+  work_chunk assignment;
+  bool has_work = _work_list->next(&assignment);
+  while (has_work) {
+#ifdef ENABLE_REMEMBERED_SET_CANCELLATION
+    // This check is currently disabled to avoid crashes that occur
+    // when we try to cancel remembered set scanning
+    if (heap->check_cancelled_gc_and_yield(_is_concurrent)) {
+      return;
     }
-    region = _regions->next();
+#endif
+    ShenandoahHeapRegion* region = assignment._r;
+    log_debug(gc)("ShenandoahScanRememberedTask::do_work(%u), processing slice of region "
+                  SIZE_FORMAT " at offset " SIZE_FORMAT ", size: " SIZE_FORMAT,
+                  worker_id, region->index(), assignment._chunk_offset, assignment._chunk_size);
+    if (region->affiliation() == OLD_GENERATION) {
+      size_t cluster_size =
+        CardTable::card_size_in_words() * ShenandoahCardCluster<ShenandoahDirectCardMarkRememberedSet>::CardsPerCluster;
+      size_t clusters = assignment._chunk_size / cluster_size;
+      assert(clusters * cluster_size == assignment._chunk_size, "Chunk assignments must align on cluster boundaries");
+      HeapWord* end_of_range = region->bottom() + assignment._chunk_offset + assignment._chunk_size;
+
+      // During concurrent mark, region->top() equals TAMS with respect to the current young-gen pass.  */
+      if (end_of_range > region->top()) {
+        end_of_range = region->top();
+      }
+      scanner->process_region_slice(region, assignment._chunk_offset, clusters, end_of_range, &cl, false, _is_concurrent);
+    }
+    has_work = _work_list->next(&assignment);
   }
+}
+
+size_t ShenandoahRegionChunkIterator::calc_group_size() {
+  // First group does roughly half of heap, one region at a time.  
+  // Second group does roughly one quarter of heap, half of a region at a time, and so on.
+  // Last group does the remnant of heap, one _smallest_chunk_size at a time.  
+  // Round down.
+  return _heap->num_regions() / 2;
+}
+
+size_t ShenandoahRegionChunkIterator::calc_first_group_chunk_size() {
+  size_t words_in_region = ShenandoahHeapRegion::region_size_words();
+  return words_in_region;
+}
+
+size_t ShenandoahRegionChunkIterator::calc_num_groups() {
+  size_t total_heap_size = _heap->num_regions() * ShenandoahHeapRegion::region_size_words();
+  size_t num_groups = 0;
+  size_t cumulative_group_span = 0;
+  size_t current_group_span = _first_group_chunk_size * _group_size;
+  size_t smallest_group_span = _smallest_chunk_size * _group_size;
+  while ((num_groups < _maximum_groups) && (cumulative_group_span + current_group_span <= total_heap_size)) {
+    num_groups++;
+    cumulative_group_span += current_group_span;
+    if (current_group_span <= smallest_group_span) {
+      break;
+    } else {
+      current_group_span /= 2;    // Each group spans half of what the preceding group spanned.
+    }
+  }
+  // Loop post condition:
+  //   num_groups <= _maximum_groups
+  //   cumulative_group_span is the memory spanned by num_groups
+  //   current_group_span is the span of the last fully populated group (assuming loop iterates at least once)
+  //   each of num_groups is fully populated with _group_size chunks in each
+  // Non post conditions:
+  //   cumulative_group_span may be less than total_heap size for one or more of the folowing reasons
+  //   a) The number of regions remaining to be spanned is smaller than a complete group, or
+  //   b) We have filled up all groups through _maximum_groups and still have not spanned all regions
+
+  if (cumulative_group_span < total_heap_size) {
+    // We've got more regions to span
+    if ((num_groups < _maximum_groups) && (current_group_span > smallest_group_span)) {
+      num_groups++;             // Place all remaining regions into a new not-full group (chunk_size half that of previous group)
+    }
+    // Else we are unable to create a new group because we've exceed the number of allowed groups or have reached the
+    // minimum chunk size.
+
+    // Any remaining regions will be treated as if they are part of the most recently created group.  This group will
+    // have more than _group_size chunks within it.
+  }
+  return num_groups;
+}
+
+size_t ShenandoahRegionChunkIterator::calc_total_chunks() {
+  size_t region_size_words = ShenandoahHeapRegion::region_size_words();
+  size_t unspanned_heap_size = _heap->num_regions() * region_size_words;
+  size_t num_chunks = 0;
+  size_t num_groups = 0;
+  size_t cumulative_group_span = 0;
+  size_t current_group_span = _first_group_chunk_size * _group_size;
+  size_t smallest_group_span = _smallest_chunk_size * _group_size;
+  while (unspanned_heap_size > 0) {
+    if (current_group_span <= unspanned_heap_size) {
+      unspanned_heap_size -= current_group_span;
+      num_chunks += _group_size;
+      num_groups++;
+
+      if (num_groups >= _num_groups) {
+        // The last group has more than _group_size entries.
+        size_t chunk_span = current_group_span / _group_size;
+        size_t extra_chunks = unspanned_heap_size / chunk_span;
+        assert (extra_chunks * chunk_span == unspanned_heap_size, "Chunks must precisely span regions");
+        num_chunks += extra_chunks;
+        return num_chunks;
+      } else if (current_group_span <= smallest_group_span) {
+        // We cannot introduce new groups because we've reached the lower bound on group size
+        size_t chunk_span = _smallest_chunk_size;
+        size_t extra_chunks = unspanned_heap_size / chunk_span;
+        assert (extra_chunks * chunk_span == unspanned_heap_size, "Chunks must precisely span regions");
+        num_chunks += extra_chunks;
+        return num_chunks;
+      } else {
+        current_group_span /= 2;
+      }
+    } else {
+      // The last group has fewer than _group_size entries.
+      size_t chunk_span = current_group_span / _group_size;
+      size_t last_group_size = unspanned_heap_size / chunk_span;
+      assert (last_group_size * chunk_span == unspanned_heap_size, "Chunks must precisely span regions");
+      num_chunks += last_group_size;
+      return num_chunks;
+    }      
+  }
+  return num_chunks;
+}
+
+ShenandoahRegionChunkIterator::ShenandoahRegionChunkIterator(size_t worker_count) :
+    _heap(ShenandoahHeap::heap()),
+    _group_size(calc_group_size()),
+    _first_group_chunk_size(calc_first_group_chunk_size()),
+    _num_groups(calc_num_groups()),
+    _total_chunks(calc_total_chunks()),
+    _index(0)
+{
+  assert(_smallest_chunk_size ==
+         CardTable::card_size_in_words() * ShenandoahCardCluster<ShenandoahDirectCardMarkRememberedSet>::CardsPerCluster,
+         "_smallest_chunk_size is not valid");
+
+  size_t words_in_region = ShenandoahHeapRegion::region_size_words();
+  size_t group_span = _first_group_chunk_size * _group_size;
+
+  _region_index[0] = 0;
+  _group_offset[0] = 0;
+  for (size_t i = 1; i < _num_groups; i++) {
+    _region_index[i] = _region_index[i-1] + (_group_offset[i-1] + group_span) / words_in_region;
+    _group_offset[i] = (_group_offset[i-1] + group_span) % words_in_region;
+    group_span /= 2;
+  }
+  // Not necessary, but keeps things tidy
+  for (size_t i = _num_groups; i < _maximum_groups; i++) {
+    _region_index[i] = 0;
+    _group_offset[i] = 0;
+  }
+}
+
+ShenandoahRegionChunkIterator::ShenandoahRegionChunkIterator(ShenandoahHeap* heap, size_t worker_count) :
+    _heap(heap),
+    _group_size(calc_group_size()),
+    _first_group_chunk_size(calc_first_group_chunk_size()),
+    _num_groups(calc_num_groups()),
+    _total_chunks(calc_total_chunks()),
+    _index(0)
+{
+  size_t words_in_region = ShenandoahHeapRegion::region_size_words();
+  size_t group_span = _first_group_chunk_size * _group_size;
+  
+  _region_index[0] = 0;
+  _group_offset[0] = 0;
+  for (size_t i = 1; i < _num_groups; i++) {
+    _region_index[i] = _region_index[i-1] + (_group_offset[i-1] + group_span) / words_in_region;
+    _group_offset[i] = (_group_offset[i-1] + group_span) % words_in_region;
+    group_span /= 2;
+  }
+  // Not necessary, but keeps things tidy
+  for (size_t i = _num_groups; i < _maximum_groups; i++) {
+    _region_index[i] = 0;
+    _group_offset[i] = 0;
+  }
+}
+
+void ShenandoahRegionChunkIterator::reset() {
+  _index = 0;
 }

--- a/src/hotspot/share/gc/shenandoah/shenandoahScanRemembered.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahScanRemembered.cpp
@@ -147,9 +147,9 @@ void ShenandoahScanRememberedTask::do_work(uint worker_id) {
 }
 
 size_t ShenandoahRegionChunkIterator::calc_group_size() {
-  // First group does roughly half of heap, one region at a time.  
+  // First group does roughly half of heap, one region at a time.
   // Second group does roughly one quarter of heap, half of a region at a time, and so on.
-  // Last group does the remnant of heap, one _smallest_chunk_size at a time.  
+  // Last group does the remnant of heap, one _smallest_chunk_size at a time.
   // Round down.
   return _heap->num_regions() / 2;
 }
@@ -236,7 +236,7 @@ size_t ShenandoahRegionChunkIterator::calc_total_chunks() {
       assert (last_group_size * chunk_span == unspanned_heap_size, "Chunks must precisely span regions");
       num_chunks += last_group_size;
       return num_chunks;
-    }      
+    }
   }
   return num_chunks;
 }
@@ -280,7 +280,7 @@ ShenandoahRegionChunkIterator::ShenandoahRegionChunkIterator(ShenandoahHeap* hea
 {
   size_t words_in_region = ShenandoahHeapRegion::region_size_words();
   size_t group_span = _first_group_chunk_size * _group_size;
-  
+
   _region_index[0] = 0;
   _group_offset[0] = 0;
   for (size_t i = 1; i < _num_groups; i++) {

--- a/src/hotspot/share/gc/shenandoah/shenandoahScanRemembered.hpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahScanRemembered.hpp
@@ -209,6 +209,7 @@
 #include "memory/iterator.hpp"
 #include "gc/shared/workerThread.hpp"
 #include "gc/shenandoah/shenandoahCardTable.hpp"
+#include "gc/shenandoah/shenandoahHeap.hpp"
 #include "gc/shenandoah/shenandoahHeapRegion.hpp"
 #include "gc/shenandoah/shenandoahTaskqueue.hpp"
 
@@ -923,11 +924,20 @@ public:
   void clear_old_remset() { _rs->clear_old_remset(); }
 
   size_t cluster_for_addr(HeapWord *addr);
+  HeapWord* addr_for_cluster(size_t cluster_no);
 
   void reset_object_range(HeapWord *from, HeapWord *to);
   void register_object(HeapWord *addr);
   void register_object_wo_lock(HeapWord *addr);
   void coalesce_objects(HeapWord *addr, size_t length_in_words);
+
+  HeapWord* first_object_in_card(size_t card_index) {
+    if (_scc->has_object(card_index)) {
+      return addr_for_card_index(card_index) + _scc->get_first_start(card_index);
+    } else {
+      return nullptr;
+    }
+  }
 
   // Return true iff this object is "properly" registered.
   bool verify_registration(HeapWord* address, ShenandoahMarkingContext* ctx);
@@ -967,16 +977,25 @@ public:
   // the template expansions were making it difficult for the link/loader to resolve references to the template-
   // parameterized implementations of this service.
   template <typename ClosureType>
-  inline void process_clusters(size_t first_cluster, size_t count, HeapWord *end_of_range, ClosureType *oops);
+  inline void process_clusters(size_t first_cluster, size_t count, HeapWord *end_of_range, ClosureType *oops, bool is_concurrent);
 
   template <typename ClosureType>
-  inline void process_clusters(size_t first_cluster, size_t count, HeapWord *end_of_range, ClosureType *oops, bool use_write_table);
+  inline void process_clusters(size_t first_cluster, size_t count, HeapWord *end_of_range, ClosureType *oops,
+                               bool use_write_table, bool is_concurrent);
 
   template <typename ClosureType>
-  inline void process_region(ShenandoahHeapRegion* region, ClosureType *cl);
+  inline void process_humongous_clusters(ShenandoahHeapRegion* r, size_t first_cluster, size_t count,
+                                         HeapWord *end_of_range, ClosureType *oops, bool use_write_table, bool is_concurrent);
 
   template <typename ClosureType>
-  inline void process_region(ShenandoahHeapRegion* region, ClosureType *cl, bool use_write_table);
+  inline void process_region(ShenandoahHeapRegion* region, ClosureType *cl, bool is_concurrent);
+
+  template <typename ClosureType>
+  inline void process_region(ShenandoahHeapRegion* region, ClosureType *cl, bool use_write_table, bool is_concurrent);
+
+  template <typename ClosureType>
+  inline void process_region_slice(ShenandoahHeapRegion* region, size_t offset, size_t clusters, HeapWord* end_of_range,
+                                   ClosureType *cl, bool use_write_table, bool is_concurrent);
 
   // To Do:
   //  Create subclasses of ShenandoahInitMarkRootsClosure and
@@ -1002,6 +1021,81 @@ public:
   void roots_do(OopIterateClosure* cl);
 };
 
+typedef struct ChunkOfRegion {
+  ShenandoahHeapRegion *_r;
+  size_t _chunk_offset;          // HeapWordSize offset
+  size_t _chunk_size;            // HeapWordSize qty
+} work_chunk;
+
+class ShenandoahRegionChunkIterator : public StackObj {
+private:
+  // smallest_chunk_size is 64 words per card *
+  // ShenandoahCardCluster<ShenandoahDirectCardMarkRememberedSet>::CardsPerCluster.
+  // This is computed from CardTable::card_size_in_words() *
+  //      ShenandoahCardCluster<ShenandoahDirectCardMarkRememberedSet>::CardsPerCluster;
+  // We can't perform this computation here, because of encapsulation and initialization constraints.  We paste
+  // the magic number here, and assert that this number matches the intended computation in constructor.
+  static const size_t _smallest_chunk_size = 64 * ShenandoahCardCluster<ShenandoahDirectCardMarkRememberedSet>::CardsPerCluster;
+
+  // The total remembered set scanning effort is divided into chunks of work that are assigned to individual worker tasks.
+  // The chunks of assigned work are divided into groups, where the size of each group (_group_size) is 4 * the number of
+  // worker tasks.  All of the assignments within a group represent the same amount of memory to be scanned.  Each of the
+  // assignments within the first group are of size _first_group_chunk_size (typically the ShenandoahHeapRegion size, but
+  // possibly smaller.  Each of the assignments within each subsequent group are half the size of the assignments in the
+  // preceding group.  The last group may be larger than the others.  Because no group is allowed to have smaller assignments
+  // than _smallest_chunk_size, which is 32 KB.
+
+  // Under normal circumstances, no configuration needs more than _maximum_groups (default value of 16).
+  // 
+
+  static const size_t _maximum_groups = 16;
+
+  const ShenandoahHeap* _heap;
+
+  const size_t _group_size;                        // Number of chunks in each group, equals worker_threads * 8
+  const size_t _first_group_chunk_size;
+  const size_t _num_groups;                        // Number of groups in this configuration
+  const size_t _total_chunks;
+
+  shenandoah_padding(0);
+  volatile size_t _index;
+  shenandoah_padding(1);
+
+  size_t _region_index[_maximum_groups];
+  size_t _group_offset[_maximum_groups];
+
+
+  // No implicit copying: iterators should be passed by reference to capture the state
+  NONCOPYABLE(ShenandoahRegionChunkIterator);
+
+  // Makes use of _heap.
+  size_t calc_group_size();
+
+  // Makes use of _group_size, which must be initialized before call.
+  size_t calc_first_group_chunk_size();
+
+  // Makes use of _group_size and _first_group_chunk_size, both of which must be initialized before call.
+  size_t calc_num_groups();
+
+  // Makes use of _group_size, _first_group_chunk_size, which must be initialized before call.
+  size_t calc_total_chunks();
+
+public:
+  ShenandoahRegionChunkIterator(size_t worker_count);
+  ShenandoahRegionChunkIterator(ShenandoahHeap* heap, size_t worker_count);
+
+  // Reset iterator to default state
+  void reset();
+
+  // Fills in assignment with next chunk of work and returns true iff there is more work.
+  // Otherwise, returns false.  This is multi-thread-safe.
+  inline bool next(work_chunk *assignment);
+
+  // This is *not* MT safe. However, in the absence of multithreaded access, it
+  // can be used to determine if there is more work to do.
+  inline bool has_next() const;
+};
+
 typedef ShenandoahScanRemembered<ShenandoahDirectCardMarkRememberedSet> RememberedScanner;
 
 class ShenandoahScanRememberedTask : public WorkerTask {
@@ -1009,13 +1103,15 @@ class ShenandoahScanRememberedTask : public WorkerTask {
   ShenandoahObjToScanQueueSet* _queue_set;
   ShenandoahObjToScanQueueSet* _old_queue_set;
   ShenandoahReferenceProcessor* _rp;
-  ShenandoahRegionIterator* _regions;
+  ShenandoahRegionChunkIterator* _work_list;
+  bool _is_concurrent;
  public:
   ShenandoahScanRememberedTask(ShenandoahObjToScanQueueSet* queue_set,
                                ShenandoahObjToScanQueueSet* old_queue_set,
                                ShenandoahReferenceProcessor* rp,
-                               ShenandoahRegionIterator* regions);
-
+                               ShenandoahRegionChunkIterator* work_list,
+                               bool is_concurrent);
   void work(uint worker_id);
+  void do_work(uint worker_id);
 };
 #endif // SHARE_GC_SHENANDOAH_SHENANDOAHSCANREMEMBERED_HPP

--- a/src/hotspot/share/gc/shenandoah/shenandoahScanRemembered.hpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahScanRemembered.hpp
@@ -1046,7 +1046,7 @@ private:
   // than _smallest_chunk_size, which is 32 KB.
 
   // Under normal circumstances, no configuration needs more than _maximum_groups (default value of 16).
-  // 
+  //
 
   static const size_t _maximum_groups = 16;
 

--- a/src/hotspot/share/gc/shenandoah/shenandoahScanRemembered.inline.hpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahScanRemembered.inline.hpp
@@ -449,9 +449,12 @@ ShenandoahScanRemembered<RememberedSet>::verify_registration(HeapWord* address, 
         last_obj = obj;
       } else {
         offset = ctx->get_next_marked_addr(base_addr + offset, tams) - base_addr;
-        // offset will be zero if no objects are marked in this card.
+        // If there are no marked objects remaining in this region, offset equals tams - base_addr.  If this offset is
+        // greater than max_offset, we will immediately exit this loop.  Otherwise, the next iteration of the loop will
+        // treat the object at offset as marked and live (because address >= tams) and we will continue iterating object
+        // by consulting the size() fields of each.
       }
-    } while (offset > 0 && offset < max_offset);
+    } while (offset < max_offset);
     if (last_obj != nullptr && prev_offset + last_obj->size() >= max_offset) {
       // last marked object extends beyond end of card
       if (_scc->get_last_start(index) != prev_offset) {
@@ -481,18 +484,21 @@ template<typename RememberedSet>
 template <typename ClosureType>
 inline void
 ShenandoahScanRemembered<RememberedSet>::process_clusters(size_t first_cluster, size_t count, HeapWord *end_of_range,
-                                                          ClosureType *cl) {
-  process_clusters(first_cluster, count, end_of_range, cl, false);
+                                                          ClosureType *cl, bool is_concurrent) {
+  process_clusters(first_cluster, count, end_of_range, cl, false, is_concurrent);
 }
 
 // Process all objects starting within count clusters beginning with first_cluster for which the start address is
-// less than end_of_range.  For any such object, process the complete object, even if its end reaches beyond
-// end_of_range.
+// less than end_of_range.  For any such object, process the complete object, even if its end reaches beyond end_of_range.
+
+// Do not CANCEL within process_clusters.  It is assumed that if a worker thread accepts responsbility for processing
+// a chunk of work, it will finish the work it starts.  Otherwise, the chunk of work will be lost in the transition to
+// degenerated execution.
 template<typename RememberedSet>
 template <typename ClosureType>
 inline void
 ShenandoahScanRemembered<RememberedSet>::process_clusters(size_t first_cluster, size_t count, HeapWord *end_of_range,
-                                                          ClosureType *cl, bool write_table) {
+                                                          ClosureType *cl, bool write_table, bool is_concurrent) {
 
   // Unlike traditional Shenandoah marking, the old-gen resident objects that are examined as part of the remembered set are not
   // themselves marked.  Each such object will be scanned only once.  Any young-gen objects referenced from the remembered set will
@@ -514,14 +520,24 @@ ShenandoahScanRemembered<RememberedSet>::process_clusters(size_t first_cluster, 
     ctx = nullptr;
   }
 
-  HeapWord* end_of_clusters = _rs->addr_for_card_index(first_cluster)
-    + count * ShenandoahCardCluster<RememberedSet>::CardsPerCluster * CardTable::card_size_in_words();
+  size_t card_index = first_cluster * ShenandoahCardCluster<RememberedSet>::CardsPerCluster;
+  HeapWord *start_of_range = _rs->addr_for_card_index(card_index);
+  ShenandoahHeapRegion* r = heap->heap_region_containing(start_of_range);
+  assert(end_of_range <= r->top(), "process_clusters() examines one region at a time");
+
   while (count-- > 0) {
-    size_t card_index = first_cluster * ShenandoahCardCluster<RememberedSet>::CardsPerCluster;
+    // TODO: do we want to check cancellation in inner loop, on every card processed?  That would be more responsive,
+    // but require more overhead for checking.
+    card_index = first_cluster * ShenandoahCardCluster<RememberedSet>::CardsPerCluster;
     size_t end_card_index = card_index + ShenandoahCardCluster<RememberedSet>::CardsPerCluster;
     first_cluster++;
     size_t next_card_index = 0;
     while (card_index < end_card_index) {
+      if (_rs->addr_for_card_index(card_index) > end_of_range) {
+        count = 0;
+        card_index = end_card_index;
+        break;
+      }
       bool is_dirty = (write_table)? is_write_card_dirty(card_index): is_card_dirty(card_index);
       bool has_object = _scc->has_object(card_index);
       if (is_dirty) {
@@ -532,6 +548,8 @@ ShenandoahScanRemembered<RememberedSet>::process_clusters(size_t first_cluster, 
           HeapWord *p = _rs->addr_for_card_index(card_index);
           HeapWord *card_start = p;
           HeapWord *endp = p + CardTable::card_size_in_words();
+          assert(!r->is_humongous(), "Process humongous regions elsewhere");
+
           if (endp > end_of_range) {
             endp = end_of_range;
             next_card_index = end_card_index;
@@ -569,8 +587,7 @@ ShenandoahScanRemembered<RememberedSet>::process_clusters(size_t first_cluster, 
               }
               p += obj->size();
             } else {
-              // This object is not marked so we don't scan it.
-              ShenandoahHeapRegion* r = heap->heap_region_containing(p);
+              // This object is not marked so we don't scan it.  Containing region r is initialized above.
               HeapWord* tams = ctx->top_at_mark_start(r);
               if (p >= tams) {
                 p += obj->size();
@@ -618,6 +635,11 @@ ShenandoahScanRemembered<RememberedSet>::process_clusters(size_t first_cluster, 
               }
           }
 
+          // TODO: only iterate over this object if it spans dirty within this cluster or within following clusters.
+          // Code as written is known not to examine a zombie object because either the object is marked, or we are
+          // not using the mark-context to differentiate objects, so the object is known to have been coalesced and
+          // filled if it is not "live".
+
           if (reaches_next_cluster || spans_dirty_within_this_cluster) {
             if (obj->is_objArray()) {
               objArrayOop array = objArrayOop(obj);
@@ -635,8 +657,7 @@ ShenandoahScanRemembered<RememberedSet>::process_clusters(size_t first_cluster, 
           }
         } else {
           // The object that spans end of this clean card is not marked, so no need to scan it or its
-          // unmarked neighbors.
-          ShenandoahHeapRegion* r = heap->heap_region_containing(p);
+          // unmarked neighbors.  Containing region r is initialized above.
           HeapWord* tams = ctx->top_at_mark_start(r);
           HeapWord* nextp;
           if (p >= tams) {
@@ -656,19 +677,59 @@ ShenandoahScanRemembered<RememberedSet>::process_clusters(size_t first_cluster, 
   }
 }
 
+
+// Given that this range of clusters is known to span a humongous object spanned by region r, scan the
+// portion of the humongous object that corresponds to the specified range.
 template<typename RememberedSet>
 template <typename ClosureType>
 inline void
-ShenandoahScanRemembered<RememberedSet>::process_region(ShenandoahHeapRegion *region, ClosureType *cl) {
-  process_region(region, cl, false);
+ShenandoahScanRemembered<RememberedSet>::process_humongous_clusters(ShenandoahHeapRegion* r, size_t first_cluster, size_t count,
+                                                                    HeapWord *end_of_range, ClosureType *cl, bool write_table,
+                                                                    bool is_concurrent) {
+  ShenandoahHeapRegion* start_region = r->humongous_start_region();
+  HeapWord* p = start_region->bottom();
+  oop obj = cast_to_oop(p);
+  assert(r->is_humongous(), "Only process humongous regions here");
+  assert(start_region->is_humongous_start(), "Should be start of humongous region");
+  assert(p + obj->size() >= end_of_range, "Humongous object ends before range ends");
+
+  size_t first_card_index = first_cluster * ShenandoahCardCluster<RememberedSet>::CardsPerCluster;
+  HeapWord* first_cluster_addr = _rs->addr_for_card_index(first_card_index);
+  size_t spanned_words = count * ShenandoahCardCluster<RememberedSet>::CardsPerCluster * CardTable::card_size_in_words();
+
+  start_region->oop_iterate_humongous_slice(cl, true, first_cluster_addr, spanned_words, write_table, is_concurrent);
 }
 
 template<typename RememberedSet>
 template <typename ClosureType>
 inline void
-ShenandoahScanRemembered<RememberedSet>::process_region(ShenandoahHeapRegion *region, ClosureType *cl, bool use_write_table) {
-  HeapWord *start_of_range = region->bottom();
+ShenandoahScanRemembered<RememberedSet>::process_region(ShenandoahHeapRegion *region, ClosureType *cl, bool is_concurrent) {
+  process_region(region, cl, false, is_concurrent);
+}
+
+template<typename RememberedSet>
+template <typename ClosureType>
+inline void
+ShenandoahScanRemembered<RememberedSet>::process_region(ShenandoahHeapRegion *region, ClosureType *cl,
+                                                        bool use_write_table, bool is_concurrent) {
+  size_t cluster_size =
+    CardTable::card_size_in_words() * ShenandoahCardCluster<ShenandoahDirectCardMarkRememberedSet>::CardsPerCluster;
+  size_t clusters = ShenandoahHeapRegion::region_size_words() / cluster_size;
+  process_region_slice(region, 0, clusters, region->end(), cl, use_write_table, is_concurrent);
+}
+
+template<typename RememberedSet>
+template <typename ClosureType>
+inline void
+ShenandoahScanRemembered<RememberedSet>::process_region_slice(ShenandoahHeapRegion *region, size_t start_offset, size_t clusters,
+                                                              HeapWord *end_of_range, ClosureType *cl, bool use_write_table,
+                                                              bool is_concurrent) {
+  HeapWord *start_of_range = region->bottom() + start_offset;
+  size_t cluster_size =
+    CardTable::card_size_in_words() * ShenandoahCardCluster<ShenandoahDirectCardMarkRememberedSet>::CardsPerCluster;
+  size_t words = clusters * cluster_size;
   size_t start_cluster_no = cluster_for_addr(start_of_range);
+  assert(addr_for_cluster(start_cluster_no) == start_of_range, "process_region_slice range must align on cluster boundary");
 
   // region->end() represents the end of memory spanned by this region, but not all of this
   //   memory is eligible to be scanned because some of this memory has not yet been allocated.
@@ -676,34 +737,43 @@ ShenandoahScanRemembered<RememberedSet>::process_region(ShenandoahHeapRegion *re
   // region->top() represents the end of allocated memory within this region.  Any addresses
   //   beyond region->top() should not be scanned as that memory does not hold valid objects.
 
-  HeapWord *end_of_range;
   if (use_write_table) {
     // This is update-refs servicing.
-    end_of_range = region->get_update_watermark();
+    if (end_of_range > region->get_update_watermark()) {
+      end_of_range = region->get_update_watermark();
+    }
   } else {
     // This is concurrent mark servicing.  Note that TAMS for this region is TAMS at start of old-gen
     // collection.  Here, we need to scan up to TAMS for most recently initiated young-gen collection.
     // Since all LABs are retired at init mark, and since replacement LABs are allocated lazily, and since no
     // promotions occur until evacuation phase, TAMS for most recent young-gen is same as top().
-    end_of_range = region->top();
+    if (end_of_range > region->top()) {
+      end_of_range = region->top();
+    }
   }
 
   log_debug(gc)("Remembered set scan processing Region " SIZE_FORMAT ", from " PTR_FORMAT " to " PTR_FORMAT ", using %s table",
-                region->index(), p2i(region->bottom()), p2i(end_of_range),
+                region->index(), p2i(start_of_range), p2i(end_of_range),
                 use_write_table? "read/write (updating)": "read (marking)");
-  // end_of_range may point to the middle of a cluster because region->top() may be different than region->end().
+
+  // Note that end_of_range may point to the middle of a cluster because region->top() or region->get_update_watermark() may
+  // be less than start_of_range + words.
+
   // We want to assure that our process_clusters() request spans all relevant clusters.  Note that each cluster
   // processed will avoid processing beyond end_of_range.
 
   // Note that any object that starts between start_of_range and end_of_range, including humongous objects, will
   // be fully processed by process_clusters, even though the object may reach beyond end_of_range.
-  size_t num_heapwords = end_of_range - start_of_range;
-  unsigned int cluster_size = CardTable::card_size_in_words() * ShenandoahCardCluster<ShenandoahDirectCardMarkRememberedSet>::CardsPerCluster;
-  size_t num_clusters = (size_t) ((num_heapwords - 1 + cluster_size) / cluster_size);
 
-  if (!region->is_humongous_continuation()) {
-    // Remembered set scanner
-    process_clusters(start_cluster_no, num_clusters, end_of_range, cl, use_write_table);
+  // If I am assigned to process a range that starts beyond end_of_range (top or update-watermark), we have no work to do.
+
+  if (start_of_range < end_of_range) {
+    if (region->is_humongous()) {
+      ShenandoahHeapRegion* start_region = region->humongous_start_region();
+      process_humongous_clusters(start_region, start_cluster_no, clusters, end_of_range, cl, use_write_table, is_concurrent);
+    } else {
+      process_clusters(start_cluster_no, clusters, end_of_range, cl, use_write_table, is_concurrent);
+    }
   }
 }
 
@@ -713,6 +783,13 @@ ShenandoahScanRemembered<RememberedSet>::cluster_for_addr(HeapWordImpl **addr) {
   size_t card_index = _rs->card_index_for_addr(addr);
   size_t result = card_index / ShenandoahCardCluster<RememberedSet>::CardsPerCluster;
   return result;
+}
+
+template<typename RememberedSet>
+inline HeapWord*
+ShenandoahScanRemembered<RememberedSet>::addr_for_cluster(size_t cluster_no) {
+  size_t card_index = cluster_no * ShenandoahCardCluster<RememberedSet>::CardsPerCluster;
+  return addr_for_card_index(card_index);
 }
 
 // This is used only for debug verification so don't worry about making the scan parallel.
@@ -731,9 +808,53 @@ inline void ShenandoahScanRemembered<RememberedSet>::roots_do(OopIterateClosure*
       size_t num_clusters = (size_t) ((num_heapwords - 1 + cluster_size) / cluster_size);
 
       // Remembered set scanner
-      process_clusters(start_cluster_no, num_clusters, end_of_range, cl);
+      if (region->is_humongous()) {
+        process_humongous_clusters(region->humongous_start_region(), start_cluster_no, num_clusters, end_of_range, cl,
+                                   false /* is_write_table */, false /* is_concurrent */);
+      } else {
+        process_clusters(start_cluster_no, num_clusters, end_of_range, cl, false /* is_concurrent */);
+      }
     }
   }
+}
+
+inline bool ShenandoahRegionChunkIterator::has_next() const {
+  return _index < _total_chunks;
+}
+
+inline bool ShenandoahRegionChunkIterator::next(work_chunk *assignment) {
+  if (_index > _total_chunks) {
+    return false;
+  }
+  size_t new_index = Atomic::add(&_index, (size_t) 1, memory_order_relaxed);
+  if (new_index > _total_chunks) {
+    return false;
+  }
+  // convert to zero-based indexing
+  new_index--;
+
+  size_t group_no = new_index / _group_size;
+  if (group_no + 1 > _num_groups) {
+    group_no = _num_groups - 1;
+  }
+
+  // All size computations measured in HeapWord
+  size_t region_size_words = ShenandoahHeapRegion::region_size_words();
+  size_t group_region_index = _region_index[group_no];
+  size_t group_region_offset = _group_offset[group_no];
+
+  size_t index_within_group = new_index - (group_no * _group_size);
+  size_t group_chunk_size = _first_group_chunk_size >> group_no;
+  size_t offset_of_this_chunk = group_region_offset + index_within_group * group_chunk_size;
+  size_t regions_spanned_by_chunk_offset = offset_of_this_chunk / region_size_words;
+  size_t region_index = group_region_index + regions_spanned_by_chunk_offset;
+  size_t offset_within_region = offset_of_this_chunk % region_size_words;
+  
+  assignment->_r = _heap->get_region(region_index);
+  assignment->_chunk_offset = offset_within_region;
+  assignment->_chunk_size = group_chunk_size;
+
+  return true;
 }
 
 #endif   // SHARE_GC_SHENANDOAH_SHENANDOAHSCANREMEMBEREDINLINE_HPP

--- a/src/hotspot/share/gc/shenandoah/shenandoahScanRemembered.inline.hpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahScanRemembered.inline.hpp
@@ -849,7 +849,7 @@ inline bool ShenandoahRegionChunkIterator::next(work_chunk *assignment) {
   size_t regions_spanned_by_chunk_offset = offset_of_this_chunk / region_size_words;
   size_t region_index = group_region_index + regions_spanned_by_chunk_offset;
   size_t offset_within_region = offset_of_this_chunk % region_size_words;
-  
+
   assignment->_r = _heap->get_region(region_index);
   assignment->_chunk_offset = offset_within_region;
   assignment->_chunk_size = group_chunk_size;

--- a/src/hotspot/share/gc/shenandoah/shenandoahThreadLocalData.hpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahThreadLocalData.hpp
@@ -56,12 +56,15 @@ private:
   PLAB* _plab;
   size_t _plab_size;
 
-  size_t _plab_evacuated;
-  size_t _plab_promoted;
-
   uint  _worker_id;
   int  _disarmed_value;
   double _paced_time;
+
+  size_t _plab_evacuated;
+  size_t _plab_promoted;
+  size_t _plab_preallocated_promoted;
+  bool   _plab_retries_enabled;
+
 
   ShenandoahThreadLocalData() :
     _gc_state(0),
@@ -72,10 +75,12 @@ private:
     _gclab_size(0),
     _plab(NULL),
     _plab_size(0),
+    _disarmed_value(0),
+    _paced_time(0),
     _plab_evacuated(0),
     _plab_promoted(0),
-    _disarmed_value(0),
-    _paced_time(0) {
+    _plab_preallocated_promoted(0),
+    _plab_retries_enabled(true) {
 
     // At least on x86_64, nmethod entry barrier encodes _disarmed_value offset
     // in instruction as disp8 immed
@@ -155,6 +160,18 @@ public:
     data(thread)->_plab_size = v;
   }
 
+  static void enable_plab_retries(Thread* thread) {
+    data(thread)->_plab_retries_enabled = true;
+  }
+
+  static void disable_plab_retries(Thread* thread) {
+    data(thread)->_plab_retries_enabled = false;
+  }
+
+  static bool plab_retries_enabled(Thread* thread) {
+    return data(thread)->_plab_retries_enabled;
+  }
+
   static void enable_plab_promotions(Thread* thread) {
     data(thread)->_plab_allows_promotion = true;
   }
@@ -197,6 +214,14 @@ public:
 
   static size_t get_plab_promoted(Thread* thread) {
     return data(thread)->_plab_promoted;
+  }
+
+  static void set_plab_preallocated_promoted(Thread* thread, size_t value) {
+    data(thread)->_plab_preallocated_promoted = value;
+  }
+
+  static size_t get_plab_preallocated_promoted(Thread* thread) {
+    return data(thread)->_plab_preallocated_promoted;
   }
 
   static void add_paced_time(Thread* thread, double v) {

--- a/src/hotspot/share/gc/shenandoah/shenandoah_globals.hpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoah_globals.hpp
@@ -267,8 +267,9 @@
           "evacuate more live objects on every cycle, while leaving "       \
           "less headroom for application to allocate while GC is "          \
           "evacuating and updating references. This parameter is "          \
-          "consulted at the of marking, before selecting the collection "   \
-          "set.  If available memory at this time is smaller than the "     \
+          "consulted at the end of marking, before selecting the "          \
+          "collection set.  "                                               \
+          "If available memory at this time is smaller than the "           \
           "indicated reserve, the bound on collection set size is "         \
           "adjusted downward.  The size of a generational mixed "           \
           "evacuation collection set (comprised of both young and old "     \
@@ -323,14 +324,14 @@
           "reserve/waste is incorrect, at the risk that application "       \
           "runs out of memory too early.")                                  \
                                                                             \
-  product(uintx, ShenandoahOldEvacReserve, 2, EXPERIMENTAL,                 \
+  product(uintx, ShenandoahOldEvacReserve, 5, EXPERIMENTAL,                 \
           "How much of old-generation heap to reserve for old-generation "  \
           "evacuations.  Larger values allow GC to evacuate more live "     \
           "old-generation objects on every cycle, while potentially "       \
           "creating greater impact on the cadence at which the young- "     \
           "generation allocation pool is replenished.  During mixed "       \
           "evacuations, the bound on amount of old-generation heap "        \
-          "regions included in the collecdtion set is the smaller "         \
+          "regions included in the collection set is the smaller "          \
           "of the quantities specified by this parameter and the "          \
           "size of ShenandoahEvacReserve as adjusted by the value of "      \
           "ShenandoahOldEvacRatioPercent.  In percents of total "           \
@@ -340,7 +341,8 @@
   product(uintx, ShenandoahOldEvacRatioPercent, 12, EXPERIMENTAL,           \
           "The maximum proportion of evacuation from old-gen memory, as "   \
           "a percent ratio.  The default value 12 denotes that no more "    \
-          "than one eighth (12%) of the collection set evacuation "         \
+          "than one eighth (~12%) of the potential collection set "         \
+          "evacuation "                                                     \
           "workload may be comprised of old-gen heap regions.  A larger "   \
           "value allows a smaller number of mixed evacuations to process "  \
           "the entire list of old-gen collection candidates at the cost "   \
@@ -510,6 +512,13 @@
           "young collection set memory to be allocated during the "         \
           "subsequent concurrent mark phase of GC.")                        \
           range(0, 100)                                                     \
+                                                                            \
+  product(uintx, ShenandoahOldCompactionReserve, 8, EXPERIMENTAL,           \
+          "During generational GC, prevent promotions from filling "        \
+          "this number of heap regions.  These regions are reserved "       \
+          "for the purpose of supporting compaction of old-gen "            \
+          "memory.  Otherwise, old-gen memory cannot be compacted.")        \
+          range(0, 128)                                                     \
                                                                             \
   product(bool, ShenandoahPromoteTenuredObjects, true, DIAGNOSTIC,          \
           "Turn on/off evacuating individual tenured young objects "        \


### PR DESCRIPTION
This commit does load balancing on remembered set scanning that happens during concurrent marking and during concurrent updating of references.  Experiments show that the concurrency of remembered set marking is now much closer to the number of concurrent GC threads (generally within 5%) whereas before this commit, the level of concurrency was often less than 1/4 of the number of concurrent GC threads.

An additional fix integrated in this commit is to not scan the entirety of humongous object arrays.  We only scan the portions of these arrays that overlay with dirty cards in the remembered set.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [ ] Change must be properly reviewed (1 review required, with at least 1 committer)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/shenandoah pull/136/head:pull/136` \
`$ git checkout pull/136`

Update a local copy of the PR: \
`$ git checkout pull/136` \
`$ git pull https://git.openjdk.java.net/shenandoah pull/136/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 136`

View PR using the GUI difftool: \
`$ git pr show -t 136`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/shenandoah/pull/136.diff">https://git.openjdk.java.net/shenandoah/pull/136.diff</a>

</details>
