### PR TITLE
Allow regulator to schedule global cycles for the purpose of class unloading

### DIFF
--- a/src/hotspot/share/gc/shenandoah/mode/shenandoahGenerationalMode.cpp
+++ b/src/hotspot/share/gc/shenandoah/mode/shenandoahGenerationalMode.cpp
@@ -36,7 +36,7 @@ void ShenandoahGenerationalMode::initialize_flags() const {
     FLAG_SET_DEFAULT(VerifyBeforeExit, false);
   }
 
-  SHENANDOAH_ERGO_OVERRIDE_DEFAULT(ShenandoahUnloadClassesFrequency, 50);
+  SHENANDOAH_ERGO_OVERRIDE_DEFAULT(ShenandoahUnloadClassesFrequency, 0);
   SHENANDOAH_ERGO_ENABLE_FLAG(ExplicitGCInvokesConcurrent);
   SHENANDOAH_ERGO_ENABLE_FLAG(ShenandoahImplicitGCInvokesConcurrent);
 

--- a/src/hotspot/share/gc/shenandoah/mode/shenandoahGenerationalMode.cpp
+++ b/src/hotspot/share/gc/shenandoah/mode/shenandoahGenerationalMode.cpp
@@ -32,11 +32,11 @@
 
 void ShenandoahGenerationalMode::initialize_flags() const {
   if (ClassUnloading) {
-    // Leaving this here for the day we re-enable class unloading
     FLAG_SET_DEFAULT(ShenandoahSuspendibleWorkers, true);
     FLAG_SET_DEFAULT(VerifyBeforeExit, false);
   }
 
+  SHENANDOAH_ERGO_OVERRIDE_DEFAULT(ShenandoahUnloadClassesFrequency, 25);
   SHENANDOAH_ERGO_ENABLE_FLAG(ExplicitGCInvokesConcurrent);
   SHENANDOAH_ERGO_ENABLE_FLAG(ShenandoahImplicitGCInvokesConcurrent);
 

--- a/src/hotspot/share/gc/shenandoah/mode/shenandoahGenerationalMode.cpp
+++ b/src/hotspot/share/gc/shenandoah/mode/shenandoahGenerationalMode.cpp
@@ -36,7 +36,7 @@ void ShenandoahGenerationalMode::initialize_flags() const {
     FLAG_SET_DEFAULT(VerifyBeforeExit, false);
   }
 
-  SHENANDOAH_ERGO_OVERRIDE_DEFAULT(ShenandoahUnloadClassesFrequency, 25);
+  SHENANDOAH_ERGO_OVERRIDE_DEFAULT(ShenandoahUnloadClassesFrequency, 50);
   SHENANDOAH_ERGO_ENABLE_FLAG(ExplicitGCInvokesConcurrent);
   SHENANDOAH_ERGO_ENABLE_FLAG(ShenandoahImplicitGCInvokesConcurrent);
 

--- a/src/hotspot/share/gc/shenandoah/shenandoahRegulatorThread.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahRegulatorThread.cpp
@@ -71,14 +71,24 @@ void ShenandoahRegulatorThread::regulate_concurrent_cycles() {
   while (!should_terminate()) {
     ShenandoahControlThread::GCMode mode = _control_thread->gc_mode();
     if (mode == ShenandoahControlThread::none) {
-      if (start_old_cycle()) {
-        log_info(gc)("Heuristics request for old collection accepted");
-      } else if (start_young_cycle()) {
-        log_info(gc)("Heuristics request for young collection accepted");
+      if (should_unload_classes()) {
+        if (start_global_cycle()) {
+          log_info(gc)("Heuristics request for global (unload classes) accepted.");
+        }
+      } else {
+        if (start_old_cycle()) {
+          log_info(gc)("Heuristics request for old collection accepted");
+        } else if (start_young_cycle()) {
+          log_info(gc)("Heuristics request for young collection accepted");
+        }
       }
     } else if (mode == ShenandoahControlThread::marking_old) {
-      if (start_young_cycle()) {
-        log_info(gc)("Heuristics request for young collection accepted");
+      if (should_unload_classes()) {
+        if (start_global_cycle()) {
+          log_info(gc)("Heuristics request to interrupt old for global (unload classes) accepted.");
+        }
+      } else if (start_young_cycle()) {
+        log_info(gc)("Heuristics request to interrupt old for young collection accepted");
       }
     }
 
@@ -147,5 +157,11 @@ bool ShenandoahRegulatorThread::start_global_cycle() {
 
 void ShenandoahRegulatorThread::stop_service() {
   log_info(gc)("%s: Stop requested.", name());
+}
+
+bool ShenandoahRegulatorThread::should_unload_classes() {
+  // The heuristics delegate this decision to the collector policy, which is based on the number
+  // of cycles started.
+  return _global_heuristics->should_unload_classes();
 }
 

--- a/src/hotspot/share/gc/shenandoah/shenandoahRegulatorThread.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahRegulatorThread.cpp
@@ -72,7 +72,7 @@ void ShenandoahRegulatorThread::regulate_concurrent_cycles() {
     ShenandoahControlThread::GCMode mode = _control_thread->gc_mode();
     if (mode == ShenandoahControlThread::none) {
       if (should_unload_classes()) {
-        if (start_global_cycle()) {
+        if (_control_thread->request_concurrent_gc(GLOBAL)) {
           log_info(gc)("Heuristics request for global (unload classes) accepted.");
         }
       } else {
@@ -83,11 +83,7 @@ void ShenandoahRegulatorThread::regulate_concurrent_cycles() {
         }
       }
     } else if (mode == ShenandoahControlThread::marking_old) {
-      if (should_unload_classes()) {
-        if (start_global_cycle()) {
-          log_info(gc)("Heuristics request to interrupt old for global (unload classes) accepted.");
-        }
-      } else if (start_young_cycle()) {
+      if (start_young_cycle()) {
         log_info(gc)("Heuristics request to interrupt old for young collection accepted");
       }
     }

--- a/src/hotspot/share/gc/shenandoah/shenandoahRegulatorThread.hpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahRegulatorThread.hpp
@@ -73,6 +73,8 @@ class ShenandoahRegulatorThread: public ConcurrentGCThread {
   bool start_young_cycle();
   bool start_global_cycle();
 
+  bool should_unload_classes();
+
   ShenandoahSharedFlag _heap_changed;
   ShenandoahControlThread* _control_thread;
   ShenandoahHeuristics* _young_heuristics;


### PR DESCRIPTION
Generational mode only supports class unloading during _global_ cycles. Global cycles can only be triggered in generational mode by an explicit `System.gc` call. With this change, the regulator is able to trigger periodic global cycles based on the value of `ShenandoahUnloadClassesFrequency`. This is currently disabled by default for the generational mode because we've not found a workload that shows a clear benefit, however, we expect it will be needed for longer running workloads and we want the ability to turn this on when necessary.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

### Reviewers
 * [Kelvin Nilsen](https://openjdk.java.net/census#kdnilsen) (@kdnilsen - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/shenandoah pull/138/head:pull/138` \
`$ git checkout pull/138`

Update a local copy of the PR: \
`$ git checkout pull/138` \
`$ git pull https://git.openjdk.java.net/shenandoah pull/138/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 138`

View PR using the GUI difftool: \
`$ git pr show -t 138`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/shenandoah/pull/138.diff">https://git.openjdk.java.net/shenandoah/pull/138.diff</a>

</details>
