### PR TITLE
Have adaptive heuristic include only full cycles in average cycle time

### DIFF
--- a/src/hotspot/share/gc/shenandoah/heuristics/shenandoahAdaptiveHeuristics.cpp
+++ b/src/hotspot/share/gc/shenandoah/heuristics/shenandoahAdaptiveHeuristics.cpp
@@ -150,8 +150,8 @@ void ShenandoahAdaptiveHeuristics::record_cycle_start() {
   _allocation_rate.allocation_counter_reset();
 }
 
-void ShenandoahAdaptiveHeuristics::record_success_concurrent() {
-  ShenandoahHeuristics::record_success_concurrent();
+void ShenandoahAdaptiveHeuristics::record_success_concurrent(bool abbreviated) {
+  ShenandoahHeuristics::record_success_concurrent(abbreviated);
 
   size_t available = ShenandoahHeap::heap()->free_set()->available();
 

--- a/src/hotspot/share/gc/shenandoah/heuristics/shenandoahAdaptiveHeuristics.hpp
+++ b/src/hotspot/share/gc/shenandoah/heuristics/shenandoahAdaptiveHeuristics.hpp
@@ -62,7 +62,7 @@ public:
                                                      size_t actual_free);
 
   void record_cycle_start();
-  void record_success_concurrent();
+  void record_success_concurrent(bool abbreviated);
   void record_success_degenerated();
   void record_success_full();
 

--- a/src/hotspot/share/gc/shenandoah/heuristics/shenandoahHeuristics.cpp
+++ b/src/hotspot/share/gc/shenandoah/heuristics/shenandoahHeuristics.cpp
@@ -414,7 +414,7 @@ void ShenandoahHeuristics::record_success_concurrent(bool abbreviated) {
   _degenerated_cycles_in_a_row = 0;
   _successful_cycles_in_a_row++;
 
-  if (!abbreviated) {
+  if (!(abbreviated && ShenandoahAdaptiveIgnoreShortCycles)) {
     _gc_time_history->add(time_since_last_gc());
     _gc_times_learned++;
   }

--- a/src/hotspot/share/gc/shenandoah/heuristics/shenandoahHeuristics.cpp
+++ b/src/hotspot/share/gc/shenandoah/heuristics/shenandoahHeuristics.cpp
@@ -410,12 +410,14 @@ void ShenandoahHeuristics::adjust_penalty(intx step) {
          "In range after adjustment: " INTX_FORMAT, _gc_time_penalties);
 }
 
-void ShenandoahHeuristics::record_success_concurrent() {
+void ShenandoahHeuristics::record_success_concurrent(bool abbreviated) {
   _degenerated_cycles_in_a_row = 0;
   _successful_cycles_in_a_row++;
 
-  _gc_time_history->add(time_since_last_gc());
-  _gc_times_learned++;
+  if (!abbreviated) {
+    _gc_time_history->add(time_since_last_gc());
+    _gc_times_learned++;
+  }
 
   adjust_penalty(Concurrent_Adjust);
 }

--- a/src/hotspot/share/gc/shenandoah/heuristics/shenandoahHeuristics.hpp
+++ b/src/hotspot/share/gc/shenandoah/heuristics/shenandoahHeuristics.hpp
@@ -143,7 +143,7 @@ public:
 
   virtual bool should_degenerate_cycle();
 
-  virtual void record_success_concurrent();
+  virtual void record_success_concurrent(bool abbreviated);
 
   virtual void record_success_degenerated();
 

--- a/src/hotspot/share/gc/shenandoah/heuristics/shenandoahOldHeuristics.cpp
+++ b/src/hotspot/share/gc/shenandoah/heuristics/shenandoahOldHeuristics.cpp
@@ -348,8 +348,8 @@ bool ShenandoahOldHeuristics::should_degenerate_cycle() {
   return _trigger_heuristic->should_degenerate_cycle();
 }
 
-void ShenandoahOldHeuristics::record_success_concurrent() {
-  _trigger_heuristic->record_success_concurrent();
+void ShenandoahOldHeuristics::record_success_concurrent(bool abbreviated) {
+  _trigger_heuristic->record_success_concurrent(abbreviated);
 }
 
 void ShenandoahOldHeuristics::record_success_degenerated() {

--- a/src/hotspot/share/gc/shenandoah/heuristics/shenandoahOldHeuristics.hpp
+++ b/src/hotspot/share/gc/shenandoah/heuristics/shenandoahOldHeuristics.hpp
@@ -129,7 +129,7 @@ public:
 
   virtual bool should_degenerate_cycle() override;
 
-  virtual void record_success_concurrent() override;
+  virtual void record_success_concurrent(bool abbreviated) override;
 
   virtual void record_success_degenerated() override;
 

--- a/src/hotspot/share/gc/shenandoah/shenandoahConcurrentGC.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahConcurrentGC.cpp
@@ -90,7 +90,7 @@ public:
 ShenandoahConcurrentGC::ShenandoahConcurrentGC(ShenandoahGeneration* generation, bool do_old_gc_bootstrap) :
   _mark(generation),
   _degen_point(ShenandoahDegenPoint::_degenerated_unset),
-  _mixed_evac (false),
+  _abbreviated(false),
   _do_old_gc_bootstrap(do_old_gc_bootstrap),
   _generation(generation) {
 }
@@ -214,7 +214,9 @@ bool ShenandoahConcurrentGC::collect(GCCause::Cause cause) {
   } else {
     // We chose not to evacuate because we found sufficient immediate garbage.
     vmop_entry_final_roots(heap->is_aging_cycle());
+    _abbreviated = true;
   }
+
   size_t old_available, young_available;
   {
     ShenandoahYoungGeneration* young_gen = heap->young_generation();

--- a/src/hotspot/share/gc/shenandoah/shenandoahConcurrentGC.hpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahConcurrentGC.hpp
@@ -49,7 +49,7 @@ protected:
 
 private:
   ShenandoahDegenPoint        _degen_point;
-  bool                        _mixed_evac; // true iff most recent evacuation includes old-gen HeapRegions
+  bool                        _abbreviated;
   const bool                  _do_old_gc_bootstrap;
 
 protected:
@@ -59,6 +59,7 @@ public:
   ShenandoahConcurrentGC(ShenandoahGeneration* generation, bool do_old_gc_bootstrap);
   bool collect(GCCause::Cause cause);
   ShenandoahDegenPoint degen_point() const;
+  bool abbreviated() const { return _abbreviated; }
 
 private:
   // Entry points to STW GC operations, these cause a related safepoint, that then

--- a/src/hotspot/share/gc/shenandoah/shenandoahControlThread.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahControlThread.cpp
@@ -537,7 +537,7 @@ void ShenandoahControlThread::resume_concurrent_old_cycle(ShenandoahGeneration* 
   // is allowed to cancel a GC.
   ShenandoahOldGC gc(generation, _allow_old_preemption);
   if (gc.collect(cause)) {
-    generation->heuristics()->record_success_concurrent();
+    generation->heuristics()->record_success_concurrent(false);
     heap->shenandoah_policy()->record_success_old();
   }
 
@@ -605,7 +605,7 @@ void ShenandoahControlThread::service_concurrent_cycle(ShenandoahGeneration* gen
   ShenandoahConcurrentGC gc(generation, do_old_gc_bootstrap);
   if (gc.collect(cause)) {
     // Cycle is complete
-    generation->heuristics()->record_success_concurrent();
+    generation->heuristics()->record_success_concurrent(gc.abbreviated());
     heap->shenandoah_policy()->record_success_concurrent();
   } else {
     assert(heap->cancelled_gc(), "Must have been cancelled");

--- a/src/hotspot/share/gc/shenandoah/shenandoah_globals.hpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoah_globals.hpp
@@ -170,6 +170,16 @@
           "Larger values give more weight to recent values.")               \
           range(0,1.0)                                                      \
                                                                             \
+  product(bool, ShenandoahAdaptiveIgnoreShortCycles, true, EXPERIMENTAL,    \
+          "The adaptive heuristic tracks a moving average of cycle "        \
+          "times in order to start a gc before memory is exhausted. "       \
+          "In some cases, Shenandoah may skip the evacuation and update "   \
+          "reference phases, resulting in a shorter cycle. These may skew " \
+          "the average cycle time downward and may cause the heuristic "    \
+          "to wait too long to start a cycle. Disabling this will have "    \
+          "the gc run less often, which will reduce CPU utilization, but"   \
+          "increase the risk of degenerated cycles.")                       \
+                                                                            \
   product(uintx, ShenandoahGuaranteedGCInterval, 5*60*1000, EXPERIMENTAL,   \
           "Many heuristics would guarantee a concurrent GC cycle at "       \
           "least with this interval. This is useful when large idle "       \


### PR DESCRIPTION
We have observed cases when a high percentage of short cut cycles (i.e., when evacuation and update reference phases are skipped) may cause the heuristic to believe it can complete _any_ cycle in the time it takes to complete an abbreviated cycle. Triggering the cycle too late may lead to a degenerated cycle. Abbreviated "learning cycles" are similarly ignored. 

A command line option has been added to disable this change in behavior and restore the previous behavior of including every cycle's time in the average time.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed (1 reviews required, with at least 1 committer)

### Reviewers
 * [Zhengyu Gu](https://openjdk.java.net/census#zgu) (@zhengyu123 - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/shenandoah pull/139/head:pull/139` \
`$ git checkout pull/139`

Update a local copy of the PR: \
`$ git checkout pull/139` \
`$ git pull https://git.openjdk.java.net/shenandoah pull/139/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 139`

View PR using the GUI difftool: \
`$ git pr show -t 139`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/shenandoah/pull/139.diff">https://git.openjdk.java.net/shenandoah/pull/139.diff</a>

</details>
