### PR TITLE
Filter out invalid pointers picked up by old gen SATB

### DIFF
--- a/src/hotspot/share/gc/shenandoah/shenandoahConcurrentGC.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahConcurrentGC.cpp
@@ -1140,6 +1140,24 @@ void ShenandoahConcurrentGC::op_final_updaterefs() {
     heap->verifier()->verify_roots_in_to_space();
   }
 
+  if (heap->mode()->is_generational() && heap->is_concurrent_old_mark_in_progress()) {
+    // When the SATB barrier is left on to support concurrent old gen mark, it may pick up writes to
+    // objects in the collection set. After those objects are evacuated, the pointers in the
+    // SATB are no longer safe. Once we have finished update references, we are guaranteed that
+    // no more writes to the collection set are possible.
+    //
+    // This will transfer any old pointers in _active_ regions from the SATB to the old gen
+    // mark queues. All other pointers will be discarded. This would also discard any pointers
+    // in old regions that were included in a mixed evacuation. We aren't using the SATB filter
+    // methods here because we cannot control when they execute. If the SATB filter runs _after_
+    // a region has been recycled, we will not be able to detect the bad pointer.
+    //
+    // We are not concerned about skipping this step in abbreviated cycles because regions
+    // with no live objects cannot have been written to and so cannot have entries in the SATB
+    // buffers.
+    heap->transfer_old_pointers_from_satb();
+  }
+
   heap->update_heap_region_states(true /*concurrent*/);
 
   heap->set_update_refs_in_progress(false);

--- a/src/hotspot/share/gc/shenandoah/shenandoahSATBMarkQueueSet.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahSATBMarkQueueSet.cpp
@@ -45,22 +45,7 @@ public:
   // Return true if entry should be filtered out (removed), false if
   // it should be retained.
   bool operator()(const void* entry) const {
-    if (!_heap->requires_marking(entry)) {
-      // The object is already marked, don't need to mark it again
-      return true;
-    }
-
-    if (_heap->mode()->is_generational() && _heap->is_concurrent_old_mark_in_progress()) {
-      // The SATB barrier is left on during concurrent marking of the old generation.
-      // It is possible for the barrier to record an address of a reachable object
-      // which exists in the collection set of a young generation collection. Once the
-      // object is evacuated, the address left in the SATB buffer is no longer valid (or safe).
-      ShenandoahHeapRegion* region = _heap->heap_region_containing(entry);
-      return !region->is_active() || region->is_cset();
-    }
-
-    // Keep this object in the SATB buffer.
-    return false;
+    return !_heap->requires_marking(entry);
   }
 };
 

--- a/src/hotspot/share/gc/shenandoah/shenandoahSATBMarkQueueSet.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahSATBMarkQueueSet.cpp
@@ -45,7 +45,22 @@ public:
   // Return true if entry should be filtered out (removed), false if
   // it should be retained.
   bool operator()(const void* entry) const {
-    return !_heap->requires_marking(entry);
+    if (!_heap->requires_marking(entry)) {
+      // The object is already marked, don't need to mark it again
+      return true;
+    }
+
+    if (_heap->mode()->is_generational() && _heap->is_concurrent_old_mark_in_progress()) {
+      // The SATB barrier is left on during concurrent marking of the old generation.
+      // It is possible for the barrier to record an address of a reachable object
+      // which exists in the collection set of a young generation collection. Once the
+      // object is evacuated, the address left in the SATB buffer is no longer valid (or safe).
+      ShenandoahHeapRegion* region = _heap->heap_region_containing(entry);
+      return !region->is_active() || region->is_cset();
+    }
+
+    // Keep this object in the SATB buffer.
+    return false;
   }
 };
 


### PR DESCRIPTION
In some cases, the SATB barrier used to support old generation marking may capture a reference to an object that is later evacuated. Old gen marking will crash when it tries to mark through the reference.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed (1 review required, with at least 1 committer)

### Reviewers
 * [Kelvin Nilsen](https://openjdk.java.net/census#kdnilsen) (@kdnilsen - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/shenandoah pull/140/head:pull/140` \
`$ git checkout pull/140`

Update a local copy of the PR: \
`$ git checkout pull/140` \
`$ git pull https://git.openjdk.java.net/shenandoah pull/140/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 140`

View PR using the GUI difftool: \
`$ git pr show -t 140`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/shenandoah/pull/140.diff">https://git.openjdk.java.net/shenandoah/pull/140.diff</a>

</details>
