### PR TITLE
Start young collect instead of old if mixed evacuations are pending

### DIFF
--- a/src/hotspot/share/gc/shenandoah/shenandoahOldGC.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahOldGC.cpp
@@ -132,6 +132,7 @@ void ShenandoahOldGC::op_final_mark() {
 
 bool ShenandoahOldGC::collect(GCCause::Cause cause) {
   ShenandoahHeap* heap = ShenandoahHeap::heap();
+  assert(!heap->doing_mixed_evacuations(), "Should not start an old gc with pending mixed evacuations");
 
   if (!heap->is_concurrent_prep_for_mixed_evacuation_in_progress()) {
     // Skip over the initial phases of old collect if we're resuming mixed evacuation preparation.


### PR DESCRIPTION
This change addresses a race condition in which the heuristic could start an old gc while there are pending mixed evacuations. This condition could lead to a crash because the nascent old gen collect will clear the mark bitmap, but the remembered set scan of the bootstrap collection will use the mark bitmap to find objects if it believes mixed evacuations are in progress.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed (1 review required, with at least 1 committer)

### Reviewers
 * [Kelvin Nilsen](https://openjdk.java.net/census#kdnilsen) (@kdnilsen - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/shenandoah pull/141/head:pull/141` \
`$ git checkout pull/141`

Update a local copy of the PR: \
`$ git checkout pull/141` \
`$ git pull https://git.openjdk.java.net/shenandoah pull/141/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 141`

View PR using the GUI difftool: \
`$ git pr show -t 141`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/shenandoah/pull/141.diff">https://git.openjdk.java.net/shenandoah/pull/141.diff</a>

</details>
