### PR TITLE
Fix fullgc

### DIFF
--- a/src/hotspot/share/gc/shenandoah/shenandoahDegeneratedGC.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahDegeneratedGC.cpp
@@ -53,6 +53,14 @@ ShenandoahDegenGC::ShenandoahDegenGC(ShenandoahDegenPoint degen_point, Shenandoa
 
 bool ShenandoahDegenGC::collect(GCCause::Cause cause) {
   vmop_degenerated();
+  ShenandoahHeap* heap = ShenandoahHeap::heap();
+  if (heap->mode()->is_generational()) {
+    size_t old_available = heap->old_generation()->available();
+    size_t young_available = heap->young_generation()->available();
+    log_info(gc, ergo)("At end of Degenerated GC, old_available: " SIZE_FORMAT "%s, young_available: " SIZE_FORMAT "%s",
+                       byte_size_in_proper_unit(old_available), proper_unit_for_byte_size(old_available),
+                       byte_size_in_proper_unit(young_available), proper_unit_for_byte_size(young_available));
+  }
   return true;
 }
 

--- a/src/hotspot/share/gc/shenandoah/shenandoahFullGC.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahFullGC.cpp
@@ -834,8 +834,8 @@ public:
       r->recycle();
     }
     if (r->is_cset()) {
-      // If generational, leave affiliation alone.
-      r->make_regular_bypass(!is_generational);
+      // Leave afffiliatoin unchanged.
+      r->make_regular_bypass();
     }
     if (r->is_empty_uncommitted()) {
       r->make_committed_bypass();
@@ -1269,7 +1269,11 @@ public:
 
     // Make empty regions that have been allocated into regular
     if (r->is_empty() && live > 0) {
-      r->make_regular_bypass(!is_generational);
+      if (!is_generational) {
+        r->set_affiliation(YOUNG_GENERATION);
+      }
+      // else, generational mode compaction has already established affiliation.
+      r->make_regular_bypass();
     }
 
     // Reclaim regular regions that became empty
@@ -1343,8 +1347,8 @@ void ShenandoahFullGC::compact_humongous_objects() {
         ShenandoahRegionAffiliation original_affiliation = r->affiliation();
         for (size_t c = old_start; c <= old_end; c++) {
           ShenandoahHeapRegion* r = heap->get_region(c);
-          // Consider regions emptied by humongous evacuation to be young
-          r->make_regular_bypass(true);
+          // Leave humongous region affiliation unchanged.
+          r->make_regular_bypass();
           r->set_top(r->bottom());
         }
 

--- a/src/hotspot/share/gc/shenandoah/shenandoahFullGC.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahFullGC.cpp
@@ -167,7 +167,13 @@ void ShenandoahFullGC::op_full(GCCause::Cause cause) {
   do_it(cause);
 
   metrics.snap_after();
-
+  if (heap->mode()->is_generational()) {
+    size_t old_available = heap->old_generation()->available();
+    size_t young_available = heap->young_generation()->available();
+    log_info(gc, ergo)("At end of Full GC, old_available: " SIZE_FORMAT "%s, young_available: " SIZE_FORMAT "%s",
+                       byte_size_in_proper_unit(old_available), proper_unit_for_byte_size(old_available),
+                       byte_size_in_proper_unit(young_available), proper_unit_for_byte_size(young_available));
+  }
   if (metrics.is_good_progress()) {
     ShenandoahHeap::heap()->notify_gc_progress();
   } else {
@@ -182,18 +188,18 @@ void ShenandoahFullGC::do_it(GCCause::Cause gc_cause) {
   // Since we may arrive here from degenerated GC failure of either young or old, establish generation as GLOBAL.
   heap->set_gc_generation(heap->global_generation());
 
-  // There will be no concurrent allocations during full GC so reset these coordination variables.
-  heap->young_generation()->unadjust_available();
-  heap->old_generation()->unadjust_available();
-  // No need to old_gen->increase_used().  That was done when plabs were allocated, accounting for both old evacs and promotions.
-
-  heap->set_alloc_supplement_reserve(0);
-  heap->set_young_evac_reserve(0);
-  heap->set_old_evac_reserve(0);
-  heap->reset_old_evac_expended();
-  heap->set_promotion_reserve(0);
-
   if (heap->mode()->is_generational()) {
+    // There will be no concurrent allocations during full GC so reset these coordination variables.
+    heap->young_generation()->unadjust_available();
+    heap->old_generation()->unadjust_available();
+    // No need to old_gen->increase_used().  That was done when plabs were allocated, accounting for both old evacs and promotions.
+
+    heap->set_alloc_supplement_reserve(0);
+    heap->set_young_evac_reserve(0);
+    heap->set_old_evac_reserve(0);
+    heap->reset_old_evac_expended();
+    heap->set_promotion_reserve(0);
+
     // Full GC supersedes any marking or coalescing in old generation.
     heap->cancel_old_gc();
   }
@@ -514,7 +520,7 @@ public:
 
     bool promote_object = false;
     if ((_from_affiliation == ShenandoahRegionAffiliation::YOUNG_GENERATION) &&
-        (from_region_age + object_age > InitialTenuringThreshold)) {
+        (from_region_age + object_age >= InitialTenuringThreshold)) {
       if ((_old_to_region != nullptr) && (_old_compact_point + obj_size > _old_to_region->end())) {
         finish_old_region();
         _old_to_region = nullptr;
@@ -823,11 +829,13 @@ private:
 public:
   ShenandoahEnsureHeapActiveClosure() : _heap(ShenandoahHeap::heap()) {}
   void heap_region_do(ShenandoahHeapRegion* r) {
+    bool is_generational = _heap->mode()->is_generational();
     if (r->is_trash()) {
       r->recycle();
     }
     if (r->is_cset()) {
-      r->make_regular_bypass();
+      // If generational, leave affiliation alone.
+      r->make_regular_bypass(!is_generational);
     }
     if (r->is_empty_uncommitted()) {
       r->make_committed_bypass();
@@ -1246,6 +1254,7 @@ public:
 
   void heap_region_do(ShenandoahHeapRegion* r) {
     assert (!r->is_cset(), "cset regions should have been demoted already");
+    bool is_generational = _heap->mode()->is_generational();
 
     // Need to reset the complete-top-at-mark-start pointer here because
     // the complete marking bitmap is no longer valid. This ensures
@@ -1260,7 +1269,7 @@ public:
 
     // Make empty regions that have been allocated into regular
     if (r->is_empty() && live > 0) {
-      r->make_regular_bypass();
+      r->make_regular_bypass(!is_generational);
     }
 
     // Reclaim regular regions that became empty
@@ -1275,7 +1284,7 @@ public:
     }
 
     // Update final usage for generations
-    if (_heap->mode()->is_generational() && live != 0) {
+    if (is_generational && live != 0) {
       if (r->is_young()) {
         _heap->young_generation()->increase_used(live);
       } else if (r->is_old()) {
@@ -1334,7 +1343,8 @@ void ShenandoahFullGC::compact_humongous_objects() {
         ShenandoahRegionAffiliation original_affiliation = r->affiliation();
         for (size_t c = old_start; c <= old_end; c++) {
           ShenandoahHeapRegion* r = heap->get_region(c);
-          r->make_regular_bypass();
+          // Consider regions emptied by humongous evacuation to be young
+          r->make_regular_bypass(true);
           r->set_top(r->bottom());
         }
 

--- a/src/hotspot/share/gc/shenandoah/shenandoahFullGC.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahFullGC.cpp
@@ -834,7 +834,7 @@ public:
       r->recycle();
     }
     if (r->is_cset()) {
-      // Leave afffiliatoin unchanged.
+      // Leave afffiliation unchanged.
       r->make_regular_bypass();
     }
     if (r->is_empty_uncommitted()) {
@@ -1270,7 +1270,7 @@ public:
     // Make empty regions that have been allocated into regular
     if (r->is_empty() && live > 0) {
       if (!is_generational) {
-        r->set_affiliation(YOUNG_GENERATION);
+        r->make_young_maybe();
       }
       // else, generational mode compaction has already established affiliation.
       r->make_regular_bypass();

--- a/src/hotspot/share/gc/shenandoah/shenandoahHeapRegion.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahHeapRegion.cpp
@@ -110,7 +110,7 @@ void ShenandoahHeapRegion::make_regular_allocation(ShenandoahRegionAffiliation a
   }
 }
 
-void ShenandoahHeapRegion::make_regular_bypass(bool make_young_affiliation) {
+void ShenandoahHeapRegion::make_regular_bypass() {
   shenandoah_assert_heaplocked();
   assert (ShenandoahHeap::heap()->is_full_gc_in_progress() || ShenandoahHeap::heap()->is_degenerated_gc_in_progress(),
           "only for full or degen GC");
@@ -122,9 +122,6 @@ void ShenandoahHeapRegion::make_regular_bypass(bool make_young_affiliation) {
     case _cset:
     case _humongous_start:
     case _humongous_cont:
-      if (make_young_affiliation) {
-        set_affiliation(YOUNG_GENERATION);
-      }
       set_state(_regular);
       return;
     case _pinned_cset:

--- a/src/hotspot/share/gc/shenandoah/shenandoahHeapRegion.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahHeapRegion.cpp
@@ -110,7 +110,7 @@ void ShenandoahHeapRegion::make_regular_allocation(ShenandoahRegionAffiliation a
   }
 }
 
-void ShenandoahHeapRegion::make_regular_bypass() {
+void ShenandoahHeapRegion::make_regular_bypass(bool make_young_affiliation) {
   shenandoah_assert_heaplocked();
   assert (ShenandoahHeap::heap()->is_full_gc_in_progress() || ShenandoahHeap::heap()->is_degenerated_gc_in_progress(),
           "only for full or degen GC");
@@ -122,12 +122,9 @@ void ShenandoahHeapRegion::make_regular_bypass() {
     case _cset:
     case _humongous_start:
     case _humongous_cont:
-      // TODO: Changing this region to young during compaction may not be
-      // technically correct here because it completely disregards the ages
-      // and origins of the objects being moved. It is, however, certainly
-      // more correct than putting live objects into a region without a
-      // generational affiliation.
-      set_affiliation(YOUNG_GENERATION);
+      if (make_young_affiliation) {
+        set_affiliation(YOUNG_GENERATION);
+      }
       set_state(_regular);
       return;
     case _pinned_cset:

--- a/src/hotspot/share/gc/shenandoah/shenandoahHeapRegion.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahHeapRegion.cpp
@@ -110,6 +110,26 @@ void ShenandoahHeapRegion::make_regular_allocation(ShenandoahRegionAffiliation a
   }
 }
 
+// Change affiliation to YOUNG_GENERATION if _state is not _pinned_cset, _regular, or _pinned.  This implements
+// behavior previously performed as a side effect of make_regular_bypass().
+void ShenandoahHeapRegion::make_young_maybe() {
+ switch (_state) {
+   case _empty_uncommitted:
+   case _empty_committed:
+   case _cset:
+   case _humongous_start:
+   case _humongous_cont:
+     set_affiliation(YOUNG_GENERATION);
+     return;
+   case _pinned_cset:
+   case _regular:
+   case _pinned:
+     return;
+   default:
+     assert(false, "Unexpected _state in make_young_maybe");
+  }
+}
+
 void ShenandoahHeapRegion::make_regular_bypass() {
   shenandoah_assert_heaplocked();
   assert (ShenandoahHeap::heap()->is_full_gc_in_progress() || ShenandoahHeap::heap()->is_degenerated_gc_in_progress(),

--- a/src/hotspot/share/gc/shenandoah/shenandoahHeapRegion.hpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahHeapRegion.hpp
@@ -169,6 +169,7 @@ public:
 
   // Allowed transitions from the outside code:
   void make_regular_allocation(ShenandoahRegionAffiliation affiliation);
+  void make_young_maybe();
   void make_regular_bypass();
   void make_humongous_start();
   void make_humongous_cont();

--- a/src/hotspot/share/gc/shenandoah/shenandoahHeapRegion.hpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahHeapRegion.hpp
@@ -169,7 +169,7 @@ public:
 
   // Allowed transitions from the outside code:
   void make_regular_allocation(ShenandoahRegionAffiliation affiliation);
-  void make_regular_bypass();
+  void make_regular_bypass(bool make_young_affiliation);
   void make_humongous_start();
   void make_humongous_cont();
   void make_humongous_start_bypass(ShenandoahRegionAffiliation affiliation);

--- a/src/hotspot/share/gc/shenandoah/shenandoahHeapRegion.hpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahHeapRegion.hpp
@@ -169,7 +169,7 @@ public:
 
   // Allowed transitions from the outside code:
   void make_regular_allocation(ShenandoahRegionAffiliation affiliation);
-  void make_regular_bypass(bool make_young_affiliation);
+  void make_regular_bypass();
   void make_humongous_start();
   void make_humongous_cont();
   void make_humongous_start_bypass(ShenandoahRegionAffiliation affiliation);


### PR DESCRIPTION
Two errors were recently discovered in the generational-mode implementation of FullGC:

1. There was an off-by-one error which caused full-gc to promote one cycle later than intent.
2. During a post-compaction phase of full-gc, certain old-gen regions were relabeled as young-gen, sometimes resulting in young-gen having usage above its capacity.  When this occurs, further allocations are blocked because available within young-gen is zero (actually is negative).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed (1 review required, with at least 1 [Committer](https://openjdk.java.net/bylaws#committer))

### Reviewers
 * [William Kemper](https://openjdk.java.net/census#wkemper) (@earthling-amzn - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/shenandoah pull/142/head:pull/142` \
`$ git checkout pull/142`

Update a local copy of the PR: \
`$ git checkout pull/142` \
`$ git pull https://git.openjdk.org/shenandoah pull/142/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 142`

View PR using the GUI difftool: \
`$ git pr show -t 142`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/shenandoah/pull/142.diff">https://git.openjdk.org/shenandoah/pull/142.diff</a>

</details>
