### PR TITLE
Reserve regions for the collector according to generational reserves

### DIFF
--- a/src/hotspot/share/gc/shenandoah/shenandoahFreeSet.hpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahFreeSet.hpp
@@ -105,6 +105,8 @@ public:
   double external_fragmentation();
 
   void print_on(outputStream* out) const;
+
+  void reserve_regions(size_t to_reserve);
 };
 
 #endif // SHARE_GC_SHENANDOAH_SHENANDOAHFREESET_HPP


### PR DESCRIPTION
When the freeset is rebuilt, it reserves a number of regions for evacuation proportional to the total size of the heap. With default settings, this will reserve more regions than intended for the generational mode and may lead to premature allocation failures for mutators.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed (1 review required, with at least 1 [Committer](https://openjdk.java.net/bylaws#committer))

### Reviewers
 * [Kelvin Nilsen](https://openjdk.java.net/census#kdnilsen) (@kdnilsen - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/shenandoah pull/143/head:pull/143` \
`$ git checkout pull/143`

Update a local copy of the PR: \
`$ git checkout pull/143` \
`$ git pull https://git.openjdk.org/shenandoah pull/143/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 143`

View PR using the GUI difftool: \
`$ git pr show -t 143`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/shenandoah/pull/143.diff">https://git.openjdk.org/shenandoah/pull/143.diff</a>

</details>
