### PR TITLE
Improve humongous remset scan

### DIFF
--- a/src/hotspot/share/gc/shenandoah/shenandoahHeap.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahHeap.cpp
@@ -2462,15 +2462,7 @@ private:
               // old-gen heap regions.
               if (r->is_humongous()) {
                 // Need to examine both dirty and clean cards during mixed evac.
-                ShenandoahHeapRegion* start_region = r->humongous_start_region();
-                oop obj = cast_to_oop(start_region->bottom());
-                size_t obj_size = obj->size();
-                HeapWord* end_of_object = start_region->bottom() + obj_size;
-                HeapWord* start_of_scan = r->bottom();
-                size_t card_size_in_words = CardTable::card_size_in_words();
-                size_t words_to_scan = end_of_object - start_of_scan;
-                size_t size_up = (words_to_scan - 1 + card_size_in_words) & ~(card_size_in_words - 1);
-                r->oop_iterate_humongous_slice(&cl, false, start_of_scan, size_up, true, CONCURRENT);
+                r->oop_iterate_humongous(&cl);
               } else {
                 // This is a mixed evacuation.  Old regions that are candidates for collection have not been coalesced
                 // and filled.  Use mark bits to find objects that need to be updated.

--- a/src/hotspot/share/gc/shenandoah/shenandoahHeap.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahHeap.cpp
@@ -2461,7 +2461,16 @@ private:
               // old-gen region in the most recent collection set, or if this card holds pointers to other non-specific
               // old-gen heap regions.
               if (r->is_humongous()) {
-                r->oop_iterate_humongous(&cl);
+                // Need to examine both dirty and clean cards during mixed evac.
+                ShenandoahHeapRegion* start_region = r->humongous_start_region();
+                oop obj = cast_to_oop(start_region->bottom());
+                size_t obj_size = obj->size();
+                HeapWord* end_of_object = start_region->bottom() + obj_size;
+                HeapWord* start_of_scan = r->bottom();
+                size_t card_size_in_words = CardTable::card_size_in_words();
+                size_t words_to_scan = end_of_object - start_of_scan;
+                size_t size_up = (words_to_scan - 1 + card_size_in_words) & ~(card_size_in_words - 1);
+                r->oop_iterate_humongous_slice(&cl, false, start_of_scan, size_up, true, CONCURRENT);
               } else {
                 // This is a mixed evacuation.  Old regions that are candidates for collection have not been coalesced
                 // and filled.  Use mark bits to find objects that need to be updated.

--- a/src/hotspot/share/gc/shenandoah/shenandoahHeapRegion.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahHeapRegion.cpp
@@ -580,6 +580,59 @@ void ShenandoahHeapRegion::global_oop_iterate_objects_and_fill_dead(OopIterateCl
   }
 }
 
+// DO NOT CANCEL.  If this worker thread has accepted responsibility for scanning a particular range of addresses, it
+// must finish the work before it can be cancelled.
+void ShenandoahHeapRegion::oop_iterate_humongous_slice(OopIterateClosure* blk, bool dirty_only,
+                                                       HeapWord* start, size_t words, bool write_table, bool is_concurrent) {
+  assert(words % CardTable::card_size_in_words() == 0, "Humongous iteration must span whole number of cards");
+  assert(is_humongous(), "only humongous region here");
+  ShenandoahHeap* heap = ShenandoahHeap::heap();
+
+  // Find head.
+  ShenandoahHeapRegion* r = humongous_start_region();
+  assert(r->is_humongous_start(), "need humongous head here");
+  assert(CardTable::card_size_in_words() * (words / CardTable::card_size_in_words()) == words,
+         "slice must be integral number of cards");
+
+  oop obj = cast_to_oop(r->bottom());
+  RememberedScanner* scanner = ShenandoahHeap::heap()->card_scan();
+  size_t card_index = scanner->card_index_for_addr(start);
+  size_t num_cards = words / CardTable::card_size_in_words();
+
+  if (dirty_only) {
+    if (write_table) {
+      while (num_cards-- > 0) {
+        if (scanner->is_write_card_dirty(card_index++)) {
+          obj->oop_iterate(blk, MemRegion(start, start + CardTable::card_size_in_words()));
+        }
+        start += CardTable::card_size_in_words();
+      }
+    } else {
+      while (num_cards-- > 0) {
+        if (scanner->is_card_dirty(card_index++)) {
+          obj->oop_iterate(blk, MemRegion(start, start + CardTable::card_size_in_words()));
+        }
+        start += CardTable::card_size_in_words();
+      }
+    }
+  } else {
+    // Scan all data, regardless of whether cards are dirty
+    while (num_cards-- > 0) {
+      obj->oop_iterate(blk, MemRegion(start, start + CardTable::card_size_in_words()));
+      start += CardTable::card_size_in_words();
+    }
+  }
+}
+
+void ShenandoahHeapRegion::oop_iterate_humongous(OopIterateClosure* blk, HeapWord* start, size_t words) {
+  assert(is_humongous(), "only humongous region here");
+  // Find head.
+  ShenandoahHeapRegion* r = humongous_start_region();
+  assert(r->is_humongous_start(), "need humongous head here");
+  oop obj = cast_to_oop(r->bottom());
+  obj->oop_iterate(blk, MemRegion(start, start + words));
+}
+
 void ShenandoahHeapRegion::oop_iterate_humongous(OopIterateClosure* blk) {
   assert(is_humongous(), "only humongous region here");
   // Find head.

--- a/src/hotspot/share/gc/shenandoah/shenandoahHeapRegion.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahHeapRegion.cpp
@@ -617,10 +617,7 @@ void ShenandoahHeapRegion::oop_iterate_humongous_slice(OopIterateClosure* blk, b
     }
   } else {
     // Scan all data, regardless of whether cards are dirty
-    while (num_cards-- > 0) {
-      obj->oop_iterate(blk, MemRegion(start, start + CardTable::card_size_in_words()));
-      start += CardTable::card_size_in_words();
-    }
+    obj->oop_iterate(blk, MemRegion(start, start + num_cards * CardTable::card_size_in_words()));
   }
 }
 

--- a/src/hotspot/share/gc/shenandoah/shenandoahHeapRegion.hpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahHeapRegion.hpp
@@ -402,6 +402,13 @@ public:
   // that are subsumed into coalesced ranges of dead memory need to be "unregistered".
   void global_oop_iterate_and_fill_dead(OopIterateClosure* cl);
   void oop_iterate_humongous(OopIterateClosure* cl);
+  void oop_iterate_humongous(OopIterateClosure* cl, HeapWord* start, size_t words);
+
+  // Invoke closure on every reference contained within the humongous object that spans this humongous
+  // region if the reference is contained within a DIRTY card and the reference is no more than words following
+  // start within the humongous object.
+  void oop_iterate_humongous_slice(OopIterateClosure* cl, bool dirty_only, HeapWord* start, size_t words,
+                                   bool write_table, bool is_concurrent);
 
   HeapWord* block_start(const void* p) const;
   size_t block_size(const HeapWord* p) const;


### PR DESCRIPTION
These changes allow humongous objects residing within the remembered set to be scanned by muitiple concurrent GC worker threads, allowing more efficient parallelization of the remembered set scanning effort.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed (1 review required, with at least 1 [Committer](https://openjdk.org/bylaws#committer))

### Reviewers
 * [William Kemper](https://openjdk.org/census#wkemper) (@earthling-amzn - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/shenandoah pull/144/head:pull/144` \
`$ git checkout pull/144`

Update a local copy of the PR: \
`$ git checkout pull/144` \
`$ git pull https://git.openjdk.org/shenandoah pull/144/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 144`

View PR using the GUI difftool: \
`$ git pr show -t 144`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/shenandoah/pull/144.diff">https://git.openjdk.org/shenandoah/pull/144.diff</a>

</details>
