### PR TITLE
Pack old evacuations tightly

### DIFF
--- a/src/hotspot/share/gc/shenandoah/heuristics/shenandoahHeuristics.cpp
+++ b/src/hotspot/share/gc/shenandoah/heuristics/shenandoahHeuristics.cpp
@@ -77,8 +77,25 @@ ShenandoahHeuristics::~ShenandoahHeuristics() {
   FREE_C_HEAP_ARRAY(RegionGarbage, _region_data);
 }
 
-void ShenandoahHeuristics::choose_collection_set(ShenandoahCollectionSet* collection_set, ShenandoahOldHeuristics* old_heuristics) {
+size_t ShenandoahHeuristics::prioritize_aged_regions(size_t old_available, size_t num_regions, bool preselected_regions[]) {
+  ShenandoahHeap* heap = ShenandoahHeap::heap();
+  size_t old_consumed = 0;
+  if (heap->mode()->is_generational()) {
+    for (size_t i = 0; i < num_regions; i++) {
+      ShenandoahHeapRegion* region = heap->get_region(i);
+      if (in_generation(region) && !region->is_empty() && region->is_regular() && (region->age() >= InitialTenuringThreshold)) {
+        size_t promotion_need = (size_t) (region->get_live_data_bytes() * ShenandoahEvacWaste);
+        if (old_consumed + promotion_need < old_available) {
+          old_consumed += promotion_need;
+          preselected_regions[i] = true;
+        }
+      }
+    }
+  }
+  return old_consumed;
+}
 
+void ShenandoahHeuristics::choose_collection_set(ShenandoahCollectionSet* collection_set, ShenandoahOldHeuristics* old_heuristics) {
   ShenandoahHeap* heap = ShenandoahHeap::heap();
 
   assert(collection_set->count() == 0, "Must be empty");
@@ -131,9 +148,16 @@ void ShenandoahHeuristics::choose_collection_set(ShenandoahCollectionSet* collec
         live_memory += region->get_live_data_bytes();
         // This is our candidate for later consideration.
         candidates[cand_idx]._region = region;
-        if (heap->mode()->is_generational() && (region->age() >= InitialTenuringThreshold)) {
-          // Bias selection of regions that have reached tenure age
-          for (uint j = region->age() - InitialTenuringThreshold; j > 0; j--) {
+        if (collection_set->is_preselected(i)) {
+          // If regions is presected, we know mode()->is_generational() and region->age() >= InitialTenuringThreshold)
+
+          // TODO: Deprecate and/or refine ShenandoahTenuredRegionUsageBias.  If we preselect the regions, we can just
+          // set garbage to "max" value, which is the region size rather than doing this extra work to bias selection.
+          // May also want to exercise more discretion in prioritize_aged_regions() if we decide there are good reasons
+          // to not promote all eligible aged regions on the current GC pass.
+
+          // If we're at tenure age, bias at least once.
+          for (uint j = region->age() + 1 - InitialTenuringThreshold; j > 0; j--) {
             garbage = (garbage + ShenandoahTenuredRegionUsageBias) * ShenandoahTenuredRegionUsageBias;
           }
         }
@@ -250,7 +274,7 @@ void ShenandoahHeuristics::choose_collection_set(ShenandoahCollectionSet* collec
 
       const size_t available_young_regions = free_regions + immediate_regions + young_generation->free_unaffiliated_regions();
       const size_t available_old_regions = old_generation->free_unaffiliated_regions();
-      size_t already_reserved_old_bytes = heap->get_old_evac_reserve() + heap->get_promotion_reserve();
+      size_t already_reserved_old_bytes = heap->get_old_evac_reserve() + heap->get_promoted_reserve();
       size_t regions_reserved_for_evac_and_promotion = (already_reserved_old_bytes + region_size_bytes - 1) / region_size_bytes;
       regions_available_to_loan = available_old_regions - regions_reserved_for_evac_and_promotion;
 
@@ -314,7 +338,7 @@ void ShenandoahHeuristics::choose_collection_set(ShenandoahCollectionSet* collec
 
     heap->set_alloc_supplement_reserve(potential_evac_supplement);
 
-    size_t promotion_budget = heap->get_promotion_reserve();
+    size_t promotion_budget = heap->get_promoted_reserve();
     size_t old_evac_budget = heap->get_old_evac_reserve();
     size_t alloc_budget_evac_and_update = potential_evac_supplement + young_available;
 
@@ -359,6 +383,10 @@ void ShenandoahHeuristics::choose_collection_set(ShenandoahCollectionSet* collec
                      byte_size_in_proper_unit(collection_set->garbage()),
                      proper_unit_for_byte_size(collection_set->garbage()),
                      cset_percent);
+
+  size_t bytes_evacuated = collection_set->get_bytes_reserved_for_evacuation();
+  log_info(gc, ergo)("Total Evacuation: " SIZE_FORMAT "%s",
+                     byte_size_in_proper_unit(bytes_evacuated), proper_unit_for_byte_size(bytes_evacuated));
 }
 
 void ShenandoahHeuristics::record_cycle_start() {

--- a/src/hotspot/share/gc/shenandoah/heuristics/shenandoahHeuristics.cpp
+++ b/src/hotspot/share/gc/shenandoah/heuristics/shenandoahHeuristics.cpp
@@ -77,7 +77,7 @@ ShenandoahHeuristics::~ShenandoahHeuristics() {
   FREE_C_HEAP_ARRAY(RegionGarbage, _region_data);
 }
 
-size_t ShenandoahHeuristics::prioritize_aged_regions(size_t old_available, size_t num_regions, bool preselected_regions[]) {
+size_t ShenandoahHeuristics::select_aged_regions(size_t old_available, size_t num_regions, bool preselected_regions[]) {
   ShenandoahHeap* heap = ShenandoahHeap::heap();
   size_t old_consumed = 0;
   if (heap->mode()->is_generational()) {
@@ -153,7 +153,7 @@ void ShenandoahHeuristics::choose_collection_set(ShenandoahCollectionSet* collec
 
           // TODO: Deprecate and/or refine ShenandoahTenuredRegionUsageBias.  If we preselect the regions, we can just
           // set garbage to "max" value, which is the region size rather than doing this extra work to bias selection.
-          // May also want to exercise more discretion in prioritize_aged_regions() if we decide there are good reasons
+          // May also want to exercise more discretion in select_aged_regions() if we decide there are good reasons
           // to not promote all eligible aged regions on the current GC pass.
 
           // If we're at tenure age, bias at least once.

--- a/src/hotspot/share/gc/shenandoah/heuristics/shenandoahHeuristics.hpp
+++ b/src/hotspot/share/gc/shenandoah/heuristics/shenandoahHeuristics.hpp
@@ -153,6 +153,8 @@ public:
 
   virtual void record_requested_gc();
 
+  virtual size_t prioritize_aged_regions(size_t old_available, size_t num_regions, bool preselected_regions[]);
+
   virtual void choose_collection_set(ShenandoahCollectionSet* collection_set, ShenandoahOldHeuristics* old_heuristics);
 
   virtual bool can_unload_classes();

--- a/src/hotspot/share/gc/shenandoah/heuristics/shenandoahHeuristics.hpp
+++ b/src/hotspot/share/gc/shenandoah/heuristics/shenandoahHeuristics.hpp
@@ -153,7 +153,7 @@ public:
 
   virtual void record_requested_gc();
 
-  virtual size_t prioritize_aged_regions(size_t old_available, size_t num_regions, bool preselected_regions[]);
+  virtual size_t select_aged_regions(size_t old_available, size_t num_regions, bool preselected_regions[]);
 
   virtual void choose_collection_set(ShenandoahCollectionSet* collection_set, ShenandoahOldHeuristics* old_heuristics);
 

--- a/src/hotspot/share/gc/shenandoah/heuristics/shenandoahOldHeuristics.cpp
+++ b/src/hotspot/share/gc/shenandoah/heuristics/shenandoahOldHeuristics.cpp
@@ -89,7 +89,7 @@ bool ShenandoahOldHeuristics::prime_collection_set(ShenandoahCollectionSet* coll
   // promotion until a subsequent evacuation pass.  Enforcement is provided at the time PLABs and shared allocations
   // in old-gen memory are requested.
 
-  const size_t promotion_budget_bytes = heap->get_promotion_reserve();
+  const size_t promotion_budget_bytes = heap->get_promoted_reserve();
 
   // old_evacuation_budget is an upper bound on the amount of live memory that can be evacuated.
   //

--- a/src/hotspot/share/gc/shenandoah/shenandoahCollectionSet.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahCollectionSet.cpp
@@ -44,6 +44,7 @@ ShenandoahCollectionSet::ShenandoahCollectionSet(ShenandoahHeap* heap, ReservedS
   _garbage(0),
   _used(0),
   _region_count(0),
+  _old_garbage(0),
   _current_index(0) {
 
   // The collection set map is reserved to cover the entire heap *and* zero addresses.
@@ -91,9 +92,13 @@ void ShenandoahCollectionSet::add_region(ShenandoahHeapRegion* r) {
   if (r->affiliation() == YOUNG_GENERATION) {
     _young_region_count++;
     _young_bytes_to_evacuate += r->get_live_data_bytes();
+    if (r->age() >= InitialTenuringThreshold) {
+      _young_bytes_to_promote += r->get_live_data_bytes();
+    }
   } else if (r->affiliation() == OLD_GENERATION) {
     _old_region_count++;
     _old_bytes_to_evacuate += r->get_live_data_bytes();
+    _old_garbage += r->garbage();
   }
 
   _region_count++;
@@ -115,6 +120,7 @@ void ShenandoahCollectionSet::clear() {
 #endif
 
   _garbage = 0;
+  _old_garbage = 0;
   _used = 0;
 
   _region_count = 0;
@@ -123,6 +129,7 @@ void ShenandoahCollectionSet::clear() {
   _young_region_count = 0;
   _old_region_count = 0;
   _young_bytes_to_evacuate = 0;
+  _young_bytes_to_promote = 0;
   _old_bytes_to_evacuate = 0;
 
   _has_old_regions = false;

--- a/src/hotspot/share/gc/shenandoah/shenandoahCollectionSet.hpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahCollectionSet.hpp
@@ -52,10 +52,17 @@ private:
                                              // not include bytes reserved for old-generation replicas.  The value is
                                              // conservative in that memory may be reserved for objects that will be promoted.
   size_t                _young_bytes_to_evacuate;
+  size_t                _young_bytes_to_promote;
   size_t                _old_bytes_to_evacuate;
 
   size_t                _young_region_count;
   size_t                _old_region_count;
+
+  size_t                _old_garbage;        // How many bytes of old garbage are present in a mixed collection set?
+
+  bool*                 _preselected_regions;   // Points to array identifying which tenure-age regions have been preselected
+                                                // for inclusion in collection set.  This field is only valid during brief
+                                                // spans of time while collection set is being constructed.
 
   shenandoah_padding(0);
   volatile size_t       _current_index;
@@ -102,9 +109,17 @@ public:
   inline size_t get_old_bytes_reserved_for_evacuation();
   inline void reserve_old_bytes_for_evacuation(size_t byte_count);
 
+  inline size_t get_young_bytes_to_be_promoted();
+
   inline size_t get_old_region_count();
 
   inline size_t get_young_region_count();
+
+  inline size_t get_old_garbage();
+
+  void establish_preselected(bool *preselected) { _preselected_regions = preselected; }
+  void abandon_preselected() { _preselected_regions = nullptr; }
+  bool is_preselected(int region_idx) { return (_preselected_regions != nullptr) && _preselected_regions[region_idx]; }
 
   bool has_old_regions() const { return _has_old_regions; }
   size_t used()          const { return _used; }

--- a/src/hotspot/share/gc/shenandoah/shenandoahCollectionSet.inline.hpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahCollectionSet.inline.hpp
@@ -69,6 +69,10 @@ size_t ShenandoahCollectionSet::get_young_bytes_reserved_for_evacuation() {
   return _young_bytes_to_evacuate;
 }
 
+size_t ShenandoahCollectionSet::get_young_bytes_to_be_promoted() {
+  return _young_bytes_to_promote;
+}
+
 size_t ShenandoahCollectionSet::get_bytes_reserved_for_evacuation() {
   return _young_bytes_to_evacuate + _old_bytes_to_evacuate;
 }
@@ -79,6 +83,10 @@ size_t ShenandoahCollectionSet::get_old_region_count() {
 
 size_t ShenandoahCollectionSet::get_young_region_count() {
   return _young_region_count;
+}
+
+size_t ShenandoahCollectionSet::get_old_garbage() {
+  return _old_garbage;
 }
 
 #endif // SHARE_GC_SHENANDOAH_SHENANDOAHCOLLECTIONSET_INLINE_HPP

--- a/src/hotspot/share/gc/shenandoah/shenandoahConcurrentGC.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahConcurrentGC.cpp
@@ -241,9 +241,9 @@ bool ShenandoahConcurrentGC::collect(GCCause::Cause cause) {
       heap->set_young_evac_reserve(0);
       heap->set_old_evac_reserve(0);
       heap->reset_old_evac_expended();
-      heap->set_promotion_reserve(0);
+      heap->set_promoted_reserve(0);
     }
-    log_info(gc, ergo)("At end of concurrent GC, old_available: " SIZE_FORMAT "%s, young_available: " SIZE_FORMAT "%s",
+    log_info(gc, ergo)("At end of Concurrent GC, old_available: " SIZE_FORMAT "%s, young_available: " SIZE_FORMAT "%s",
                        byte_size_in_proper_unit(old_available), proper_unit_for_byte_size(old_available),
                        byte_size_in_proper_unit(young_available), proper_unit_for_byte_size(young_available));
   }
@@ -704,7 +704,7 @@ void ShenandoahConcurrentGC::op_final_mark() {
     // Upon return from prepare_regions_and_collection_set(), certain parameters have been established to govern the
     // evacuation efforts that are about to begin.  In particular:
     //
-    // heap->get_promotion_reserve() represents the amount of memory within old-gen's available memory that has
+    // heap->get_promoted_reserve() represents the amount of memory within old-gen's available memory that has
     //   been set aside to hold objects promoted from young-gen memory.  This represents an estimated percentage
     //   of the live young-gen memory within the collection set.  If there is more data ready to be promoted than
     //   can fit within this reserve, the promotion of some objects will be deferred until a subsequent evacuation

--- a/src/hotspot/share/gc/shenandoah/shenandoahDegeneratedGC.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahDegeneratedGC.cpp
@@ -294,8 +294,7 @@ void ShenandoahDegenGC::op_degenerated() {
     heap->set_young_evac_reserve(0);
     heap->set_old_evac_reserve(0);
     heap->reset_old_evac_expended();
-    heap->set_promotion_reserve(0);
-
+    heap->set_promoted_reserve(0);
   }
 
   if (ShenandoahVerify) {

--- a/src/hotspot/share/gc/shenandoah/shenandoahFullGC.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahFullGC.cpp
@@ -198,7 +198,7 @@ void ShenandoahFullGC::do_it(GCCause::Cause gc_cause) {
     heap->set_young_evac_reserve(0);
     heap->set_old_evac_reserve(0);
     heap->reset_old_evac_expended();
-    heap->set_promotion_reserve(0);
+    heap->set_promoted_reserve(0);
 
     // Full GC supersedes any marking or coalescing in old generation.
     heap->cancel_old_gc();

--- a/src/hotspot/share/gc/shenandoah/shenandoahGeneration.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahGeneration.cpp
@@ -300,7 +300,7 @@ void  ShenandoahGeneration::prepare_regions_and_collection_set(bool concurrent) 
           old_evacuation_reserve = young_evac_reserve_max;
         }
       }
-      
+
       if (minimum_evacuation_reserve > old_generation->available()) {
         // Due to round-off errors during enforcement of minimum_evacuation_reserve during previous GC passes,
         // there can be slight discrepancies here.
@@ -326,7 +326,7 @@ void  ShenandoahGeneration::prepare_regions_and_collection_set(bool concurrent) 
       //  young_evacuation_reserve for young generation: how much memory are we reserving to hold the results
       //  of evacuating young collection set regions?  This is typically smaller than the total amount
       //  of available memory, and is also smaller than the total amount of marked live memory within
-      //  young-gen.  This value is the smaller of 
+      //  young-gen.  This value is the smaller of
       //
       //    1. (young_gen->capacity() * ShenandoahEvacReserve) / 100
       //    2. (young_gen->available() + old_gen_memory_available_to_be_loaned
@@ -406,7 +406,7 @@ void  ShenandoahGeneration::prepare_regions_and_collection_set(bool concurrent) 
         regions_available_to_loan = net_available_old_regions;
       }
       // Otherwise, regions_available_to_loan is less than net_available_old_regions because available memory is
-      // scattered between multiple partially used regions.  
+      // scattered between multiple partially used regions.
 
       if (young_evacuation_reserve > young_generation->available()) {
         size_t short_fall = young_evacuation_reserve - young_generation->available();
@@ -500,7 +500,7 @@ void  ShenandoahGeneration::prepare_regions_and_collection_set(bool concurrent) 
         // to old-gen before we start a subsequent evacuation.
         old_evacuation_committed = minimum_evacuation_reserve - old_bytes_loaned;
       }
-      
+
       // Limit promoted_reserve so that we can set aside memory to be loaned from old-gen to young-gen.  This
       // value is not "critical".  If we underestimate, certain promotions will simply be deferred.  If we put
       // "all the rest" of old-gen memory into the promotion reserve, we'll have nothing left to loan to young-gen
@@ -519,7 +519,7 @@ void  ShenandoahGeneration::prepare_regions_and_collection_set(bool concurrent) 
 
       // We experimented with constraining promoted_reserve to be no larger than 4 times the size of previously_promoted,
       // but this constraint was too limiting, resulting in failure of legitimate promotions.
-      
+
       // We had also experimented with constraining promoted_reserve to be no more than young_evacuation_committed
       // divided by promotion_divisor, where:
       //  size_t promotion_divisor = (0x02 << InitialTenuringThreshold) - 1;
@@ -583,7 +583,7 @@ void  ShenandoahGeneration::prepare_regions_and_collection_set(bool concurrent) 
       // TODO: young_available, which feeds into alloc_budget_evac_and_update is lacking memory available within
       // existing young-gen regions that were not selected for the collection set.  Add this in and adjust the
       // log message (where it says "empty-region allocation budget").
-      
+
       log_info(gc, ergo)("Memory reserved for evacuation and update-refs includes promotion budget: " SIZE_FORMAT
                          "%s, young evacuation budget: " SIZE_FORMAT "%s, old evacuation budget: " SIZE_FORMAT
                          "%s, empty-region allocation budget: " SIZE_FORMAT "%s, including supplement: " SIZE_FORMAT "%s",

--- a/src/hotspot/share/gc/shenandoah/shenandoahGeneration.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahGeneration.cpp
@@ -222,8 +222,10 @@ void ShenandoahGeneration::prepare_gc(bool do_old_gc_bootstrap) {
 }
 
 void  ShenandoahGeneration::prepare_regions_and_collection_set(bool concurrent) {
-
   ShenandoahHeap* heap = ShenandoahHeap::heap();
+  ShenandoahCollectionSet* collection_set = heap->collection_set();
+  size_t region_size_bytes = ShenandoahHeapRegion::region_size_bytes();
+
   assert(!heap->is_full_gc_in_progress(), "Only for concurrent and degenerated GC");
   assert(generation_mode() != OLD, "Only YOUNG and GLOBAL GC perform evacuations");
   {
@@ -247,109 +249,352 @@ void  ShenandoahGeneration::prepare_regions_and_collection_set(bool concurrent) 
     ShenandoahHeapLocker locker(heap->lock());
     heap->collection_set()->clear();
 
-
+    size_t minimum_evacuation_reserve = ShenandoahOldCompactionReserve * region_size_bytes;
+    size_t avail_evac_reserve_for_loan_to_young_gen = 0;
+    size_t old_regions_loaned_for_young_evac = 0;
+    size_t regions_available_to_loan = 0;
+    size_t old_evacuation_reserve = 0;
+    size_t num_regions = heap->num_regions();
+    size_t consumed_by_advance_promotion = 0;
+    bool preselected_regions[num_regions];
+    for (unsigned int i = 0; i < num_regions; i++) {
+      preselected_regions[i] = false;
+    }
     if (heap->mode()->is_generational()) {
+      ShenandoahGeneration* old_generation = heap->old_generation();
+      ShenandoahYoungGeneration* young_generation = heap->young_generation();
 
       // During initialization and phase changes, it is more likely that fewer objects die young and old-gen
-      // memory is not yet full (or is in the process of being replaced).  During these tiems especially, it
+      // memory is not yet full (or is in the process of being replaced).  During these times especially, it
       // is beneficial to loan memory from old-gen to young-gen during the evacuation and update-refs phases
       // of execution.
 
-      //  PromotionReserve for old generation: how much memory are we reserving to hold the results of
-      //     promoting young-gen objects that have reached tenure age?  This value is not "critical".  If we
-      //     underestimate, certain promotions will simply be deferred.  The basis of this estimate is
-      //     historical precedent.  Conservatively, budget this value to be twice the amount of memory
-      //     promoted in previous GC pass.  Whenever the amount promoted during previous GC is zero,
-      //     including initial passes before any objects have reached tenure age, use live memory within
-      //     young-gen memory divided by (ShenandoahTenureAge multiplied by InitialTenuringThreshold) as the
-      //     the very conservative value of this parameter.  Note that during initialization, there is
-      //     typically plentiful old-gen memory so it's ok to be conservative with the initial estimates
-      //     of this value.  But PromotionReserve can be no larger than available memory.  In summary, we
-      //     compute PromotionReserve as the smaller of:
-      //      1. old_gen->available
-      //      2. young_gen->capacity() * ShenandoahEvacReserve
-      //      3. (bytes promoted by previous promotion) * 2 if (bytes promoted by previous promotion) is not zero
-      //      4. if (bytes promoted by previous promotion) is zero, divide young_gen->used()
-      //         by (ShenandoahTenureAge * InitialTenuringThreshold)
-      //
-      //     We don't yet know how much live memory.  Inside choose_collection_set(), after it computes live memory,
-      //     the PromotionReserve may be further reduced.
-      //
-      //      5. live bytes in young-gen divided by (ShenandoahTenureAge * InitialTenuringThreshold
-      //         if the number of bytes promoted by previous promotion is zero
-      //
-      ShenandoahGeneration* old_generation = heap->old_generation();
-      ShenandoahYoungGeneration* young_generation = heap->young_generation();
-      size_t promotion_reserve = old_generation->available();
+      // Calculate EvacuationReserve before PromotionReserve.  Evacuation is more critical than promotion.
+      // If we cannot evacuate old-gen, we will not be able to reclaim old-gen memory.  Promotions are less
+      // critical.  If we cannot promote, there may be degradation of young-gen memory because old objects
+      // accumulate there until they can be promoted.  This increases the young-gen marking and evacuation work.
 
-      size_t max_young_evacuation = (young_generation->soft_max_capacity() * ShenandoahOldEvacReserve) / 100;
-      if (max_young_evacuation < promotion_reserve) {
-        promotion_reserve = max_young_evacuation;
-      }
+      // Do not fill up old-gen memory with promotions.  Reserve some amount of memory for compaction purposes.
+      ShenandoahOldHeuristics* old_heuristics = heap->old_heuristics();
+      if (old_heuristics->unprocessed_old_collection_candidates() > 0) {
 
-      size_t previously_promoted = heap->get_previous_promotion();
-      if (previously_promoted == 0) {
-        // Very conservatively, assume linear population decay (rather than more typical exponential) and assume all of
-        // used is live.
-        size_t proposed_reserve = young_generation->used() / (ShenandoahAgingCyclePeriod * InitialTenuringThreshold);
-        if (promotion_reserve > proposed_reserve) {
-          promotion_reserve = proposed_reserve;
+        // Compute old_evacuation_reserve: how much memory are we reserving to hold the results of
+        // evacuating old-gen heap regions?  In order to sustain a consistent pace of young-gen collections,
+        // the goal is to maintain a consistent value for this parameter (when the candidate set is not
+        // empty).  This value is the minimum of:
+        //   1. old_gen->available()
+        //   2. old-gen->capacity() * ShenandoahOldEvacReserve) / 100
+        //       (e.g. old evacuation should be no larger than 5% of old_gen capacity)
+        //   3. ((young_gen->capacity * ShenandoahEvacReserve / 100) * ShenandoahOldEvacRatioPercent) / 100
+        //       (e.g. old evacuation should be no larger than 12% of young-gen evacuation)
+
+        old_evacuation_reserve = old_generation->available();
+        assert(old_evacuation_reserve > minimum_evacuation_reserve, "Old-gen available has not been preserved!");
+        size_t old_evac_reserve_max = old_generation->soft_max_capacity() * ShenandoahOldEvacReserve / 100;
+        if (old_evac_reserve_max < old_evacuation_reserve) {
+          old_evacuation_reserve = old_evac_reserve_max;
         }
-      } else if (previously_promoted * 2 < promotion_reserve) {
-        promotion_reserve = previously_promoted * 2;
+        size_t young_evac_reserve_max =
+          (((young_generation->soft_max_capacity() * ShenandoahEvacReserve) / 100) * ShenandoahOldEvacRatioPercent) / 100;
+        if (young_evac_reserve_max < old_evacuation_reserve) {
+          old_evacuation_reserve = young_evac_reserve_max;
+        }
       }
-
-      heap->set_promotion_reserve(promotion_reserve);
-      heap->capture_old_usage(old_generation->used());
-
-      //  OldEvacuationReserve for old generation: how much memory are we reserving to hold the results of
-      //     evacuating old-gen heap regions?  In order to sustain a consistent pace of young-gen collections,
-      //     the goal is to maintain a consistent value for this parameter (when the candidate set is not
-      //     empty).  This value is the minimum of:
-      //       1. old_gen->available() - PromotionReserve
-      //       2. (young_gen->capacity() scaled by ShenandoahEvacReserve) scaled by ShenandoahOldEvacRatioPercent
-
-      // Don't reserve for old_evac any more than the memory that is available in old_gen.
-      size_t old_evacuation_reserve = old_generation->available() - promotion_reserve;
-
-      // Make sure old evacuation is no more than ShenandoahOldEvacRatioPercent of the total evacuation budget.
-      size_t max_total_evac = (young_generation->soft_max_capacity() * ShenandoahEvacReserve) / 100;
-      size_t max_old_evac_portion = (max_total_evac * ShenandoahOldEvacRatioPercent) / 100;
-
-      if (old_evacuation_reserve > max_old_evac_portion) {
-        old_evacuation_reserve = max_old_evac_portion;
+      
+      if (minimum_evacuation_reserve > old_generation->available()) {
+        // Due to round-off errors during enforcement of minimum_evacuation_reserve during previous GC passes,
+        // there can be slight discrepancies here.
+        minimum_evacuation_reserve = old_generation->available();
+      }
+      if (old_evacuation_reserve < minimum_evacuation_reserve) {
+        // Even if there's nothing to be evacuated on this cycle, we still need to reserve this memory for future
+        // evacuations.  It is ok to loan this memory to young-gen if we don't need it for evacuation on this pass.
+        avail_evac_reserve_for_loan_to_young_gen = minimum_evacuation_reserve - old_evacuation_reserve;
+        old_evacuation_reserve = minimum_evacuation_reserve;
       }
 
       heap->set_old_evac_reserve(old_evacuation_reserve);
       heap->reset_old_evac_expended();
 
-      // Compute YoungEvacuationReserve after we prime the collection set with old-gen candidates.  This depends
-      // on how much memory old-gen wants to evacuate.  This is done within _heuristics->choose_collection_set().
+      // Compute the young evauation reserve: This is how much memory is available for evacuating young-gen objects.
+      // We ignore the possible effect of promotions, which reduce demand for young-gen evacuation memory.
+      //
+      // TODO: We could give special treatment to the regions that have reached promotion age, because we know their
+      // live data is entirely eligible for promotion.  This knowledge can feed both into calculations of young-gen
+      // evacuation reserve and promotion reserve.
+      //
+      //  young_evacuation_reserve for young generation: how much memory are we reserving to hold the results
+      //  of evacuating young collection set regions?  This is typically smaller than the total amount
+      //  of available memory, and is also smaller than the total amount of marked live memory within
+      //  young-gen.  This value is the smaller of 
+      //
+      //    1. (young_gen->capacity() * ShenandoahEvacReserve) / 100
+      //    2. (young_gen->available() + old_gen_memory_available_to_be_loaned
+      //
+      //  ShenandoahEvacReserve represents the configured taget size of the evacuation region.  We can only honor
+      //  this target if there is memory available to hold the evacuations.  Memory is available if it is already
+      //  free within young gen, or if it can be borrowed from old gen.  Since we have not yet chosen the collection
+      //  sets, we do not yet know the exact accounting of how many regions will be freed by this collection pass.
+      //  What we do know is that there will be at least one evacuated young-gen region for each old-gen region that
+      //  is loaned to the evacuation effort (because regions to be collected consume more memory than the compacted
+      //  regions that will replace them).  In summary, if there are old-gen regions that are available to hold the
+      //  results of young-gen evacuations, it is safe to loan them for this purpose.  At this point, we have not yet
+      //  established a promoted_reserve.  We'll do that after we choose the collection set and analyze its impact
+      //  on available memory.
+      //
+      // We do not know the evacuation_supplement until after we have computed the collection set.  It is not always
+      // the case that young-regions inserted into the collection set will result in net decrease of in-use regions
+      // because ShenandoahEvacWaste times multiplied by memory within the region may be larger than the region size.
+      // The problem is especially relevant to regions that have been inserted into the collection set because they have
+      // reached tenure age.  These regions tend to have much higher utilization (e.g. 95%).  These regions also offer
+      // a unique opportunity because we know that every live object contained within the region is elgible to be
+      // promoted.  Thus, the following implementation treats these regions specially:
+      //
+      //  1. Before beginning collection set selection, we tally the total amount of live memory held within regions
+      //     that are known to have reached tenure age.  If this memory times ShenandoahEvacWaste is available within
+      //     old-gen memory, establish an advance promotion reserve to hold all or some percentage of these objects.
+      //     This advance promotion reserve is excluded from memory available for holding old-gen evacuations and cannot
+      //     be "loaned" to young gen.
+      //
+      //  2. Tenure-aged regions are included in the collection set iff their evacuation size * ShenandoahEvacWaste fits
+      //     within the advance promotion reserve.  It is counter productive to evacuate these regions if they cannot be
+      //     evacuated directly into old-gen memory.  So if there is not sufficient memory to hold copies of their
+      //     live data right now, we'll just let these regions remain in young for now, to be evacuated by a subsequent
+      //     evacuation pass.
+      //
+      //  3. Next, we calculate a young-gen evacuation budget, which is the smaller of the two quantities mentioned
+      //     above.  old_gen_memory_available_to_be_loaned is calculated as:
+      //       old_gen->available - (advance-promotion-reserve + old-gen_evacuation_reserve)
+      //
+      //  4. When choosing the collection set, special care is taken to assure that the amount of loaned memory required to
+      //     hold the results of evacuation is smaller than the total memory occupied by the regions added to the collection
+      //     set.  We need to take these precautions because we do not know how much memory will be reclaimed by evacuation
+      //     until after the collection set has been constructed.  The algorithm is as follows:
+      //
+      //     a. We feed into the algorithm (i) young available at the start of evacuation and (ii) the amount of memory
+      //        loaned from old-gen that is available to hold the results of evacuation.
+      //     b. As candidate regions are added into the young-gen collection set, we maintain accumulations of the amount
+      //        of memory spanned by the collection set regions and the amount of memory that must be reserved to hold
+      //        evacuation results (by multiplying live-data size by ShenandoahEvacWaste).  We process candidate regions
+      //        in order of decreasing amounts of garbage.  We skip over (and do not include into the collection set) any
+      //        regions that do not satisfy all of the following conditions:
+      //
+      //          i. The amount of live data within the region as scaled by ShenandoahEvacWaste must fit within the
+      //             relevant evacuation reserve (live data of old-gen regions must fit within the old-evac-reserve, live
+      //             data of young-gen tenure-aged regions must fit within the advance promotion reserve, live data within
+      //             other young-gen regions must fit within the youn-gen evacuation reserve).
+      //         ii. The accumulation of memory consumed by evacuation must not exceed the accumulation of memory reclaimed
+      //             through evacuation by more than young-gen available.
+      //        iii. Other conditions may be enforced as appropriate for specific heuristics.
+      //
+      //       Note that regions are considered for inclusion in the selection set in order of decreasing amounts of garbage.
+      //       It is possible that a region with a larger amount of garbage will be rejected because it also has a larger
+      //       amount of live data and some region that follows this region in candidate order is included in the collection
+      //       set (because it has less live data and thus can fit within the evacuation limits even though it has less
+      //       garbage).
 
-      // There's no need to pass this information to ShenandoahFreeSet::rebuild().  The GC allocator automatically borrows
-      // memory from mutator regions when necessary.
+      size_t young_evacuation_reserve = (young_generation->soft_max_capacity() * ShenandoahEvacReserve) / 100;
+      // old evacuation can pack into existing partially used regions.  young evacuation and loans for young allocations
+      // need to target regions that do not already hold any old-gen objects.  Round down.
+      regions_available_to_loan = old_generation->free_unaffiliated_regions();
+      consumed_by_advance_promotion = _heuristics->prioritize_aged_regions(old_generation->available() - old_evacuation_reserve,
+                                                                           num_regions, preselected_regions);
+      size_t net_available_old_regions =
+        (old_generation->available() - old_evacuation_reserve - consumed_by_advance_promotion) / region_size_bytes;
+
+      if (regions_available_to_loan > net_available_old_regions) {
+        regions_available_to_loan = net_available_old_regions;
+      }
+      // Otherwise, regions_available_to_loan is less than net_available_old_regions because available memory is
+      // scattered between multiple partially used regions.  
+
+      if (young_evacuation_reserve > young_generation->available()) {
+        size_t short_fall = young_evacuation_reserve - young_generation->available();
+        if (regions_available_to_loan * region_size_bytes >= short_fall) {
+          old_regions_loaned_for_young_evac = (short_fall + region_size_bytes - 1) / region_size_bytes;
+          regions_available_to_loan -= old_regions_loaned_for_young_evac;
+        } else {
+          old_regions_loaned_for_young_evac = regions_available_to_loan;
+          regions_available_to_loan = 0;
+          young_evacuation_reserve = young_generation->available() + old_regions_loaned_for_young_evac * region_size_bytes;
+        }
+      } else {
+        old_regions_loaned_for_young_evac = 0;
+      }
+      // In generational mode, we may end up choosing a young collection set that contains so many promotable objects
+      // that there is not sufficient space in old generation to hold the promoted objects.  That is ok because we have
+      // assured there is sufficient space in young generation to hold the rejected promotion candidates.  These rejected
+      // promotion candidates will presumably be promoted in a future evacuation cycle.
+      heap->set_young_evac_reserve(young_evacuation_reserve);
+    } else {
+      // Not generational mode: limit young evac reserve by young available; no need to establish old_evac_reserve.
+      ShenandoahYoungGeneration* young_generation = heap->young_generation();
+      size_t young_evac_reserve = (young_generation->soft_max_capacity() * ShenandoahEvacReserve) / 100;
+      if (young_evac_reserve > young_generation->available()) {
+        young_evac_reserve = young_generation->available();
+      }
+      heap->set_young_evac_reserve(young_evac_reserve);
     }
 
-    // The heuristics may consult and/or change the values of PromotionReserved, OldEvacuationReserved, and
-    // YoungEvacuationReserved, all of which are represented in the shared ShenandoahHeap data structure.
+    // TODO: young_available can include available (between top() and end()) within each young region that is not
+    // part of the collection set.  Making this memory available to the young_evacuation_reserve allows a larger
+    // young collection set to be chosen when available memory is under extreme pressure.  Implementing this "improvement"
+    // is tricky, because the incremental construction of the collection set actually changes the amount of memory
+    // available to hold evacuated young-gen objects.  As currently implemented, the memory that is available within
+    // non-empty regions that are not selected as part of the collection set can be allocated by the mutator while
+    // GC is evacuating and updating references.
+
+    collection_set->establish_preselected(preselected_regions);
     _heuristics->choose_collection_set(heap->collection_set(), heap->old_heuristics());
+    collection_set->abandon_preselected();
 
-    //  EvacuationAllocationSupplement: This represents memory that can be allocated in excess of young_gen->available()
-    //     during evacuation and update-refs.  This memory can be temporarily borrowed from old-gen allotment, then
-    //     repaid at the end of update-refs from the recycled collection set.  After we have computed the collection set
-    //     based on the parameters established above, we can make additional calculates based on our knowledge of the
-    //     collection set to determine how much allocation we can allow during the evacuation and update-refs phases
-    //     of execution.  With full awareness of collection set, we can shrink the values of PromotionReserve,
-    //     OldEvacuationReserve, and YoungEvacuationReserve.  Then, we can compute EvacuationAllocationReserve as the
-    //     minimum of:
-    //       1. old_gen->available - (PromotionReserve + OldEvacuationReserve)
-    //       2. The replenishment budget (number of regions in collection set - the number of regions already
-    //          under lien for the YoungEvacuationReserve)
-    //
+    // At this point, young_generation->available() knows about recently discovered immediate garbage.  We also
+    // know the composition of the chosen collection set.
 
-    // The possibly revised values are also consulted by the ShenandoahPacer when it establishes pacing parameters
-    // for evacuation and update-refs.
+    if (heap->mode()->is_generational()) {
+      ShenandoahGeneration* old_generation = heap->old_generation();
+      ShenandoahYoungGeneration* young_generation = heap->young_generation();
+      size_t old_evacuation_committed = (size_t) (ShenandoahEvacWaste *
+                                                  collection_set->get_old_bytes_reserved_for_evacuation());
+      size_t immediate_garbage_regions = collection_set->get_immediate_trash() / region_size_bytes;
 
+      if (old_evacuation_committed > old_evacuation_reserve) {
+        // This should only happen due to round-off errors when enforcing ShenandoahEvacWaste
+        assert(old_evacuation_committed < (33 * old_evacuation_reserve) / 32, "Round-off errors should be less than 3.125%%");
+        old_evacuation_committed = old_evacuation_reserve;
+      }
+
+      // Recompute old_regions_loaned_for_young_evac because young-gen collection set may not need all the memory
+      // originally reserved.
+
+      size_t young_evacuation_reserve_used =
+        collection_set->get_young_bytes_reserved_for_evacuation() - collection_set->get_young_bytes_to_be_promoted();
+      young_evacuation_reserve_used = (size_t) (ShenandoahEvacWaste * young_evacuation_reserve_used);
+      heap->set_young_evac_reserve(young_evacuation_reserve_used);
+
+      // Adjust old_regions_loaned_for_young_evac to feed into calculations of promoted_reserve
+      if (young_evacuation_reserve_used > young_generation->available()) {
+        size_t short_fall = young_evacuation_reserve_used - young_generation->available();
+
+        // region_size_bytes is a power of 2.  loan an integral number of regions.
+        size_t revised_loan_for_young_evacuation = (short_fall + region_size_bytes - 1) / region_size_bytes;
+
+        // Undo the previous loan
+        regions_available_to_loan += old_regions_loaned_for_young_evac;
+        old_regions_loaned_for_young_evac = revised_loan_for_young_evacuation;
+        // And make a new loan
+        assert(regions_available_to_loan > old_regions_loaned_for_young_evac, "Cannot loan regions that we do not have");
+        regions_available_to_loan -= old_regions_loaned_for_young_evac;
+      } else {
+        // Undo the prevous loan
+        regions_available_to_loan += old_regions_loaned_for_young_evac;
+        old_regions_loaned_for_young_evac = 0;
+      }
+
+      size_t old_bytes_loaned = old_regions_loaned_for_young_evac * region_size_bytes;
+      // Need to enforce that old_evacuation_committed + old_bytes_loaned >= minimum_evacuation_reserve
+      // in order to prevent promotion reserve from violating minimum evacuation reserve.
+      if (old_evacuation_committed + old_bytes_loaned < minimum_evacuation_reserve) {
+        // Pretend the old_evacuation_commitment is larger than what will be evacuated to assure that promotions
+        // do not fill the minimum_evacuation_reserve.  Note that regions loaned from old-gen will be returned
+        // to old-gen before we start a subsequent evacuation.
+        old_evacuation_committed = minimum_evacuation_reserve - old_bytes_loaned;
+      }
+      
+      // Limit promoted_reserve so that we can set aside memory to be loaned from old-gen to young-gen.  This
+      // value is not "critical".  If we underestimate, certain promotions will simply be deferred.  If we put
+      // "all the rest" of old-gen memory into the promotion reserve, we'll have nothing left to loan to young-gen
+      // during the evac and update phases of GC.  So we "limit" the sizes of the promotion budget to be the smaller of:
+      //
+      //  1. old_gen->available - (old_evacuation_committed + old_bytes_loaned + consumed_by_advance_promotion)
+      //  2. young bytes reserved for evacuation
+
+      assert(old_generation->available() > old_evacuation_committed, "Cannot evacuate more than available");
+      assert(old_generation->available() > old_evacuation_committed + old_bytes_loaned, "Cannot loan more than available");
+      assert(old_generation->available() > old_evacuation_committed + old_bytes_loaned + consumed_by_advance_promotion,
+             "Cannot promote more than available");
+
+      size_t old_avail = old_generation->available();
+      size_t promotion_reserve = old_avail - (old_evacuation_committed + consumed_by_advance_promotion + old_bytes_loaned);
+
+      // We experimented with constraining promoted_reserve to be no larger than 4 times the size of previously_promoted,
+      // but this constraint was too limiting, resulting in failure of legitimate promotions.
+      
+      // We had also experimented with constraining promoted_reserve to be no more than young_evacuation_committed
+      // divided by promotion_divisor, where:
+      //  size_t promotion_divisor = (0x02 << InitialTenuringThreshold) - 1;
+      // This also was found to be too limiting, resulting in failure of legitimate promotions.
+      //
+      // Both experiments were conducted in the presence of other bugs which could have been the root cause for
+      // the failures identified above as being "too limiting".  TODO: conduct new experiments with the more limiting
+      // values of young_evacuation_reserved_used.
+      young_evacuation_reserve_used -= consumed_by_advance_promotion;
+      if (young_evacuation_reserve_used < promotion_reserve) {
+        // Shrink promotion_reserve if its larger than the memory to be consumed by evacuating all young objects in
+        // collection set, including anticipated waste.  There's no benefit in using a larger promotion_reserve.
+        promotion_reserve = young_evacuation_reserve_used;
+      }
+
+      assert(old_avail >= promotion_reserve + old_evacuation_committed + old_bytes_loaned + consumed_by_advance_promotion,
+             "Budget exceeds available old-gen memory");
+      log_info(gc, ergo)("Old available: " SIZE_FORMAT ", Original promotion reserve: " SIZE_FORMAT ", Old evacuation reserve: "
+                         SIZE_FORMAT ", Advance promotion reserve supplement: " SIZE_FORMAT ", Old loaned to young: " SIZE_FORMAT,
+                         old_avail, promotion_reserve, old_evacuation_committed, consumed_by_advance_promotion,
+                         old_regions_loaned_for_young_evac * region_size_bytes);
+      promotion_reserve += consumed_by_advance_promotion;
+      heap->set_promoted_reserve(promotion_reserve);
+      heap->reset_promoted_expended();
+      if (collection_set->get_old_bytes_reserved_for_evacuation() == 0) {
+        // Setting old evacuation reserve to zero denotes that there is no old-gen evacuation in this pass.
+        heap->set_old_evac_reserve(0);
+      }
+
+      size_t old_gen_usage_base = old_generation->used() - collection_set->get_old_garbage();
+      heap->capture_old_usage(old_gen_usage_base);
+
+      // Compute the evacuation supplement, which is extra memory borrowed from old-gen that can be allocated
+      // by mutators while GC is working on evacuation and update-refs.  This memory can be temporarily borrowed
+      // from old-gen allotment, then repaid at the end of update-refs from the recycled collection set.  After
+      // we have computed the collection set based on the parameters established above, we can make additional
+      // loans based on our knowledge of the collection set to determine how much allocation we can allow
+      // during the evacuation and update-refs phases of execution.  The total available supplement is the smaller of:
+      //
+      //   1. old_gen->available() -
+      //        (promotion_reserve + old_evacuation_commitment + old_bytes_loaned)
+      //   2. The replenishment budget (number of regions in collection set - the number of regions already
+      //         under lien for the young_evacuation_reserve)
+      //
+
+      size_t young_regions_evacuated = collection_set->get_young_region_count();
+      size_t regions_for_runway = 0;
+      if (young_regions_evacuated > old_regions_loaned_for_young_evac) {
+        regions_for_runway = young_regions_evacuated - old_regions_loaned_for_young_evac;
+        old_regions_loaned_for_young_evac = young_regions_evacuated;
+        regions_available_to_loan -= regions_for_runway;
+      }
+
+      size_t allocation_supplement = regions_for_runway * region_size_bytes;
+      heap->set_alloc_supplement_reserve(allocation_supplement);
+
+      size_t promotion_budget = heap->get_promoted_reserve();
+      size_t old_evac_budget = heap->get_old_evac_reserve();
+      size_t alloc_budget_evac_and_update = allocation_supplement + young_generation->available();
+
+      // TODO: young_available, which feeds into alloc_budget_evac_and_update is lacking memory available within
+      // existing young-gen regions that were not selected for the collection set.  Add this in and adjust the
+      // log message (where it says "empty-region allocation budget").
+      
+      log_info(gc, ergo)("Memory reserved for evacuation and update-refs includes promotion budget: " SIZE_FORMAT
+                         "%s, young evacuation budget: " SIZE_FORMAT "%s, old evacuation budget: " SIZE_FORMAT
+                         "%s, empty-region allocation budget: " SIZE_FORMAT "%s, including supplement: " SIZE_FORMAT "%s",
+                         byte_size_in_proper_unit(promotion_budget), proper_unit_for_byte_size(promotion_budget),
+                         byte_size_in_proper_unit(young_evacuation_reserve_used),
+                         proper_unit_for_byte_size(young_evacuation_reserve_used),
+                         byte_size_in_proper_unit(old_evac_budget), proper_unit_for_byte_size(old_evac_budget),
+                         byte_size_in_proper_unit(alloc_budget_evac_and_update),
+                         proper_unit_for_byte_size(alloc_budget_evac_and_update),
+                         byte_size_in_proper_unit(allocation_supplement), proper_unit_for_byte_size(allocation_supplement));
+    }
   }
 
   {

--- a/src/hotspot/share/gc/shenandoah/shenandoahGeneration.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahGeneration.cpp
@@ -393,12 +393,12 @@ void  ShenandoahGeneration::prepare_regions_and_collection_set(bool concurrent) 
       //       set (because it has less live data and thus can fit within the evacuation limits even though it has less
       //       garbage).
 
-      size_t young_evacuation_reserve = (young_generation->soft_max_capacity() * ShenandoahEvacReserve) / 100;
+      size_t young_evacuation_reserve = (young_generation->max_capacity() * ShenandoahEvacReserve) / 100;
       // old evacuation can pack into existing partially used regions.  young evacuation and loans for young allocations
       // need to target regions that do not already hold any old-gen objects.  Round down.
       regions_available_to_loan = old_generation->free_unaffiliated_regions();
-      consumed_by_advance_promotion = _heuristics->prioritize_aged_regions(old_generation->available() - old_evacuation_reserve,
-                                                                           num_regions, preselected_regions);
+      consumed_by_advance_promotion = _heuristics->select_aged_regions(old_generation->available() - old_evacuation_reserve,
+                                                                       num_regions, preselected_regions);
       size_t net_available_old_regions =
         (old_generation->available() - old_evacuation_reserve - consumed_by_advance_promotion) / region_size_bytes;
 

--- a/src/hotspot/share/gc/shenandoah/shenandoahHeap.inline.hpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahHeap.inline.hpp
@@ -452,7 +452,7 @@ inline oop ShenandoahHeap::try_evacuate_object(oop p, Thread* thread, Shenandoah
         // Signal that promotion failed. Will evacuate this old object somewhere in young gen.
 
         // We squelch excessive reports to reduce noise in logs.  Squelch enforcement is not "perfect" because
-        // this same code can be in-lined in multiple contexts, and each context will have its own copy of the static 
+        // this same code can be in-lined in multiple contexts, and each context will have its own copy of the static
         // last_report_epoch and this_epoch_report_count variables.
         const uint MaxReportsPerEpoch = 4;
         static uint last_report_epoch = 0;

--- a/src/hotspot/share/gc/shenandoah/shenandoahHeap.inline.hpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahHeap.inline.hpp
@@ -301,18 +301,25 @@ inline HeapWord* ShenandoahHeap::allocate_from_plab(Thread* thread, size_t size,
   assert(UseTLAB, "TLABs should be enabled");
 
   PLAB* plab = ShenandoahThreadLocalData::plab(thread);
-  if (is_promotion && !ShenandoahThreadLocalData::allow_plab_promotions(thread)) {
-    return NULL;
-  } else if (plab == NULL) {
-    assert(!thread->is_Java_thread() && !thread->is_Worker_thread(),
-           "Performance: thread should have PLAB: %s", thread->name());
+  HeapWord* obj;
+  if (plab == NULL) {
+    assert(!thread->is_Java_thread() && !thread->is_Worker_thread(), "Performance: thread should have PLAB: %s", thread->name());
     // No PLABs in this thread, fallback to shared allocation
-    return NULL;
+    return nullptr;
+  } else if (is_promotion && (plab->words_remaining() > 0) && !ShenandoahThreadLocalData::allow_plab_promotions(thread)) {
+    return nullptr;
   }
-  HeapWord* obj = plab->allocate(size);
-  if (obj == NULL) {
+  // if plab->word_size() <= 0, thread's plab not yet initialized for this pass, so allow_plab_promotions() is not trustworthy
+  obj = plab->allocate(size);
+  if ((obj == nullptr) && (plab->words_remaining() < PLAB::min_size())) {
+    // allocate_from_plab_slow will establish allow_plab_promotions(thread) for future invocations
     obj = allocate_from_plab_slow(thread, size, is_promotion);
   }
+  // if plab->words_remaining() >= PLAB::min_size(), just return nullptr so we can use a shared allocation
+  if (obj == nullptr) {
+    return nullptr;
+  }
+
   if (is_promotion) {
     ShenandoahThreadLocalData::add_to_plab_promoted(thread, size * HeapWordSize);
   } else {
@@ -350,7 +357,7 @@ inline oop ShenandoahHeap::evacuate_object(oop p, Thread* thread) {
       if (result != NULL) {
         return result;
       }
-      // If we failed to promote this aged object, we'll fall through to code below and evacuat to young-gen.
+      // If we failed to promote this aged object, we'll fall through to code below and evacuate to young-gen.
     }
   }
   return try_evacuate_object(p, thread, r, target_gen);
@@ -361,6 +368,7 @@ inline oop ShenandoahHeap::evacuate_object(oop p, Thread* thread) {
 inline oop ShenandoahHeap::try_evacuate_object(oop p, Thread* thread, ShenandoahHeapRegion* from_region,
                                                ShenandoahRegionAffiliation target_gen) {
   bool alloc_from_lab = true;
+  bool has_plab = false;
   HeapWord* copy = NULL;
   size_t size = p->size();
   bool is_promotion = (target_gen == OLD_GENERATION) && from_region->is_young();
@@ -386,13 +394,30 @@ inline oop ShenandoahHeap::try_evacuate_object(oop p, Thread* thread, Shenandoah
         }
         case OLD_GENERATION: {
            if (ShenandoahUsePLAB) {
+             PLAB* plab = ShenandoahThreadLocalData::plab(thread);
+             if (plab != nullptr) {
+               has_plab = true;
+             }
              copy = allocate_from_plab(thread, size, is_promotion);
-             if ((copy == nullptr) && (size < ShenandoahThreadLocalData::plab_size(thread))) {
-               // PLAB allocation failed because we are bumping up against the limit on old evacuation reserve.  Try resetting
-               // the desired PLAB size and retry PLAB allocation to avoid cascading of shared memory allocations.
-               ShenandoahThreadLocalData::set_plab_size(thread, PLAB::min_size());
-               copy = allocate_from_plab(thread, size, is_promotion);
-               // If we still get nullptr, we'll try a shared allocation below.
+             if ((copy == nullptr) && (size < ShenandoahThreadLocalData::plab_size(thread)) &&
+                 ShenandoahThreadLocalData::plab_retries_enabled(thread)) {
+               // PLAB allocation failed because we are bumping up against the limit on old evacuation reserve or because
+               // the requested object does not fit within the current plab but the plab still has an "abundance" of memory,
+               // where abundance is defined as >= PLAB::min_size().  In the former case, we try resetting the desired
+               // PLAB size and retry PLAB allocation to avoid cascading of shared memory allocations.
+
+               // In this situation, PLAB memory is precious.  We'll try to preserve our existing PLAB by forcing
+               // this particular allocation to be shared.
+               if (plab->words_remaining() < PLAB::min_size()) {
+                 ShenandoahThreadLocalData::set_plab_size(thread, PLAB::min_size());
+                 copy = allocate_from_plab(thread, size, is_promotion);
+                 // If we still get nullptr, we'll try a shared allocation below.
+                 if (copy == nullptr) {
+                   // If retry fails, don't continue to retry until we have success (probably in next GC pass)
+                   ShenandoahThreadLocalData::disable_plab_retries(thread);
+                 }
+               }
+               // else, copy still equals nullptr.  this causes shared allocation below, preserving this plab for future needs.
              }
            }
            break;
@@ -405,10 +430,16 @@ inline oop ShenandoahHeap::try_evacuate_object(oop p, Thread* thread, Shenandoah
     }
 
     if (copy == NULL) {
-      // If we failed to allocated in LAB, we'll try a shared allocation.
-      ShenandoahAllocRequest req = ShenandoahAllocRequest::for_shared_gc(size, target_gen);
-      copy = allocate_memory(req, is_promotion);
-      alloc_from_lab = false;
+      // If we failed to allocate in LAB, we'll try a shared allocation.
+      if (!is_promotion || !has_plab || (size > PLAB::min_size())) {
+        ShenandoahAllocRequest req = ShenandoahAllocRequest::for_shared_gc(size, target_gen);
+        copy = allocate_memory(req, is_promotion);
+        alloc_from_lab = false;
+      }
+      // else, we leave copy equal to NULL, signaling a promotion failure below if appropriate.
+      // We choose not to promote objects smaller than PLAB::min_size() by way of shared allocations, as this is too
+      // costly.  Instead, we'll simply "evacuate" to young-gen memory (using a GCLAB) and will promote in a future
+      // evacuation pass.  This condition is denoted by: is_promotion && has_plab && (size <= PLAB::min_size())
     }
 #ifdef ASSERT
   }
@@ -419,6 +450,55 @@ inline oop ShenandoahHeap::try_evacuate_object(oop p, Thread* thread, Shenandoah
       assert(mode()->is_generational(), "Should only be here in generational mode.");
       if (from_region->is_young()) {
         // Signal that promotion failed. Will evacuate this old object somewhere in young gen.
+
+        // We squelch excessive reports to reduce noise in logs.  Squelch enforcement is not "perfect" because
+        // this same code can be in-lined in multiple contexts, and each context will have its own copy of the static 
+        // last_report_epoch and this_epoch_report_count variables.
+        const uint MaxReportsPerEpoch = 4;
+        static uint last_report_epoch = 0;
+        static uint epoch_report_count = 0;
+        PLAB* plab = ShenandoahThreadLocalData::plab(thread);
+        size_t words_remaining = (plab == nullptr)? 0: plab->words_remaining();
+        const char* promote_enabled = ShenandoahThreadLocalData::allow_plab_promotions(thread)? "enabled": "disabled";
+        size_t promotion_reserve;
+        size_t promotion_expended;
+        // We can only query GCId::current() if current thread is a named thread.  If current thread is not a
+        // named thread, then we don't even try to squelch the promotion failure report, we don't update the
+        // the last_report_epoch, and we don't increment the epoch_report_count
+        if (thread->is_Named_thread()) {
+          uint gc_id = GCId::current();
+          if ((gc_id != last_report_epoch) || (epoch_report_count++ < MaxReportsPerEpoch)) {
+            {
+              // Promotion failures should be very rare.  Invest in providing useful diagnostic info.
+              ShenandoahHeapLocker locker(lock());
+              promotion_reserve = get_promoted_reserve();
+              promotion_expended = get_promoted_expended();
+            }
+            log_info(gc, ergo)("Promotion failed, size " SIZE_FORMAT ", has plab? %s, PLAB remaining: " SIZE_FORMAT
+                               ", plab promotions %s, promotion reserve: " SIZE_FORMAT ", promotion expended: " SIZE_FORMAT,
+                               size, plab == nullptr? "no": "yes",
+                               words_remaining, promote_enabled, promotion_reserve, promotion_expended);
+            if ((gc_id == last_report_epoch) && (epoch_report_count >= MaxReportsPerEpoch)) {
+              log_info(gc, ergo)("Squelching additional promotion failure reports for epoch %d\n", last_report_epoch);
+            } else if (gc_id != last_report_epoch) {
+              last_report_epoch = gc_id;;
+              epoch_report_count = 1;
+            }
+          }
+        } else if (epoch_report_count < MaxReportsPerEpoch) {
+          // Unnamed threads are much less common than named threads.  In the rare case that an unnamed thread experiences
+          // a promotion failure before a named thread within a given epoch, the report for the unnamed thread will be squelched.
+          {
+            // Promotion failures should be very rare.  Invest in providing useful diagnostic info.
+            ShenandoahHeapLocker locker(lock());
+            promotion_reserve = get_promoted_reserve();
+            promotion_expended = get_promoted_expended();
+          }
+          log_info(gc, ergo)("Promotion failed (unfiltered), size " SIZE_FORMAT ", has plab? %s, PLAB remaining: " SIZE_FORMAT
+                             ", plab promotions %s, promotion reserve: " SIZE_FORMAT ", promotion expended: " SIZE_FORMAT,
+                             size, plab == nullptr? "no": "yes",
+                             words_remaining, promote_enabled, promotion_reserve, promotion_expended);
+        }
         handle_promotion_failure();
         return NULL;
       } else {
@@ -588,14 +668,14 @@ inline bool ShenandoahHeap::is_aging_cycle() const {
   return _is_aging_cycle.is_set();
 }
 
-inline size_t ShenandoahHeap::set_promotion_reserve(size_t new_val) {
-  size_t orig = _promotion_reserve;
-  _promotion_reserve = new_val;
+inline size_t ShenandoahHeap::set_promoted_reserve(size_t new_val) {
+  size_t orig = _promoted_reserve;
+  _promoted_reserve = new_val;
   return orig;
 }
 
-inline size_t ShenandoahHeap::get_promotion_reserve() const {
-  return _promotion_reserve;
+inline size_t ShenandoahHeap::get_promoted_reserve() const {
+  return _promoted_reserve;
 }
 
 // returns previous value
@@ -624,16 +704,31 @@ inline size_t ShenandoahHeap::get_old_evac_reserve() const {
 }
 
 inline void ShenandoahHeap::reset_old_evac_expended() {
-  _old_evac_expended = 0;
+  Atomic::store(&_old_evac_expended, (size_t) 0);
 }
 
 inline size_t ShenandoahHeap::expend_old_evac(size_t increment) {
-  _old_evac_expended += increment;
-  return _old_evac_expended;
+  return Atomic::add(&_old_evac_expended, increment);
 }
 
-inline size_t ShenandoahHeap::get_old_evac_expended() const {
-  return _old_evac_expended;
+inline size_t ShenandoahHeap::get_old_evac_expended() {
+  return Atomic::load(&_old_evac_expended);
+}
+
+inline void ShenandoahHeap::reset_promoted_expended() {
+  Atomic::store(&_promoted_expended, (size_t) 0);
+}
+
+inline size_t ShenandoahHeap::expend_promoted(size_t increment) {
+  return Atomic::add(&_promoted_expended, increment);
+}
+
+inline size_t ShenandoahHeap::unexpend_promoted(size_t decrement) {
+  return Atomic::sub(&_promoted_expended, decrement);
+}
+
+inline size_t ShenandoahHeap::get_promoted_expended() {
+  return Atomic::load(&_promoted_expended);
 }
 
 inline size_t ShenandoahHeap::set_young_evac_reserve(size_t new_val) {

--- a/src/hotspot/share/gc/shenandoah/shenandoah_globals.hpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoah_globals.hpp
@@ -521,6 +521,13 @@
           "subsequent concurrent mark phase of GC.")                        \
           range(0, 100)                                                     \
                                                                             \
+  product(uintx, ShenandoahOldCompactionReserve, 8, EXPERIMENTAL,           \
+          "During generational GC, prevent promotions from filling "        \
+          "this number of heap regions.  These regions are reserved "       \
+          "for the purpose of supporting compaction of old-gen "            \
+          "memory.  Otherwise, old-gen memory cannot be compacted.")        \
+          range(0, 128)                                                     \
+                                                                            \
   product(bool, ShenandoahPromoteTenuredObjects, true, DIAGNOSTIC,          \
           "Turn on/off evacuating individual tenured young objects "        \
           " to the old generation.")                                        \


### PR DESCRIPTION
This pull request includes several improvements to reduce the likelihood of evacuation failures and to reduce the frequency of old-gen collections.  Key contributions:
1. If a PLAB allocation fails, resize the the thread's preferred PLAB size to minimum size and retry the allocation request
2. Place a limit on how large the preferred PLAB size grows for individual threads.  Otherwise a small number of threads can consume the full promotion budget, leaving nothing left for the PLABs required by other threads.
3. If a PLAB promotion fails, and the remaining words within the PLAB is greater than minimum size, that means this is a request to promote a relatively large object.  In this case, do not retire the PLAB.  Instead, use a shared allocation to promote this large object.
4. If a PLAB promotion fails and the remaining words is less than the PLAB minimum size, try to replace the PLAB and then retry the PLAB allocation.  If this still fails, evacuate the object to young-gen using a GCLAB.  Don't try to promote with a shared allocation because that is too "expensive".

This commit has demonstrated fairly significant benefits on certain workloads.  For specjbb2015, we got a 17% improvement in critical jops, from 3093.847 to 3622.  For an extremem 2020 workload,
we improved p99.999 for customer preparation processing by more than four fold, from 607,107 microseconds to 142,286 microseconds, decreasing the number of concurrent GCs from 99 to 37, old GCs from 12 to 7, full GCs from 3 to 0.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed (1 review required, with at least 1 [Committer](https://openjdk.org/bylaws#committer))

### Reviewers
 * [William Kemper](https://openjdk.org/census#wkemper) (@earthling-amzn - Committer) ⚠️ Review applies to [d5263dcb](https://git.openjdk.org/shenandoah/pull/145/files/d5263dcbfc222fbafe5ac407735cfff6e07fcb10)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/shenandoah pull/145/head:pull/145` \
`$ git checkout pull/145`

Update a local copy of the PR: \
`$ git checkout pull/145` \
`$ git pull https://git.openjdk.org/shenandoah pull/145/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 145`

View PR using the GUI difftool: \
`$ git pr show -t 145`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/shenandoah/pull/145.diff">https://git.openjdk.org/shenandoah/pull/145.diff</a>

</details>
