### PR TITLE
Refactor budgeting to make the logic cleaner

### DIFF
--- a/src/hotspot/share/gc/shenandoah/heuristics/shenandoahAdaptiveHeuristics.cpp
+++ b/src/hotspot/share/gc/shenandoah/heuristics/shenandoahAdaptiveHeuristics.cpp
@@ -195,6 +195,11 @@ void ShenandoahAdaptiveHeuristics::choose_collection_set_from_regiondata(Shenand
     // Traditional Shenandoah (non-generational)
     size_t max_cset    = (size_t) (heap->get_young_evac_reserve() / ShenandoahEvacWaste);
     size_t cur_cset = 0;
+#undef KELVIN_DEBUG
+#ifdef KELVIN_DEBUG
+    printf("young_evac_reserve: " SIZE_FORMAT ", EvacWaste: %f\n", heap->get_young_evac_reserve(), ShenandoahEvacWaste);
+#endif
+
     log_info(gc, ergo)("Adaptive CSet Selection. Max CSet: " SIZE_FORMAT "%s, Actual Free: " SIZE_FORMAT "%s.",
                          byte_size_in_proper_unit(max_cset),    proper_unit_for_byte_size(max_cset),
                          byte_size_in_proper_unit(actual_free), proper_unit_for_byte_size(actual_free));

--- a/src/hotspot/share/gc/shenandoah/heuristics/shenandoahAdaptiveHeuristics.cpp
+++ b/src/hotspot/share/gc/shenandoah/heuristics/shenandoahAdaptiveHeuristics.cpp
@@ -162,11 +162,6 @@ void ShenandoahAdaptiveHeuristics::choose_collection_set_from_regiondata(Shenand
         }
 
         if (add_region) {
-#undef KELVIN_SEES_THIS
-#ifdef KELVIN_SEES_THIS
-          printf("Adding %s region " SIZE_FORMAT " to cset with garbage: " SIZE_FORMAT ", sorted at " SIZE_FORMAT " and age: %d\n",
-                 affiliation_name(r->affiliation()), r->index(), r->garbage(), data[idx]._garbage, r->age());
-#endif
           cset->add_region(r);
         }
       }
@@ -191,11 +186,6 @@ void ShenandoahAdaptiveHeuristics::choose_collection_set_from_regiondata(Shenand
         }
 
         if ((new_cset <= max_cset) && ((r->garbage() > garbage_threshold) || (r->age() >= InitialTenuringThreshold))) {
-#undef KELVIN_SEES_THIS
-#ifdef KELVIN_SEES_THIS
-          printf("Adding region " SIZE_FORMAT " to cset with garbage: " SIZE_FORMAT ", sorted at " SIZE_FORMAT " and age: %d\n",
-                 r->index(), r->garbage(), data[idx]._garbage, r->age());
-#endif
           cset->add_region(r);
           cur_cset = new_cset;
         }

--- a/src/hotspot/share/gc/shenandoah/heuristics/shenandoahAdaptiveHeuristics.cpp
+++ b/src/hotspot/share/gc/shenandoah/heuristics/shenandoahAdaptiveHeuristics.cpp
@@ -141,6 +141,11 @@ void ShenandoahAdaptiveHeuristics::choose_collection_set_from_regiondata(Shenand
     // (((new_garbage < min_garbage) && (r->garbage() > ShenandoahSmallerGarbageThreshold)) || (r->garbage() > garbage_threshold))
 
     if ((new_cset <= max_cset) && ((r->garbage() > garbage_threshold) || (r->age() >= InitialTenuringThreshold))) {
+#undef KELVIN_SEES_THIS
+#ifdef KELVIN_SEES_THIS
+      printf("Adding region " SIZE_FORMAT " to cset with garbage: " SIZE_FORMAT ", sorted at " SIZE_FORMAT " and age: %d\n",
+             r->index(), r->garbage(), data[idx]._garbage, r->age());
+#endif
       cset->add_region(r);
       cur_cset = new_cset;
       // cur_garbage = new_garbage;

--- a/src/hotspot/share/gc/shenandoah/heuristics/shenandoahAdaptiveHeuristics.cpp
+++ b/src/hotspot/share/gc/shenandoah/heuristics/shenandoahAdaptiveHeuristics.cpp
@@ -67,6 +67,8 @@ void ShenandoahAdaptiveHeuristics::choose_collection_set_from_regiondata(Shenand
                                                                          RegionData* data, size_t size,
                                                                          size_t actual_free) {
   size_t garbage_threshold = ShenandoahHeapRegion::region_size_bytes() * ShenandoahGarbageThreshold / 100;
+  size_t ignore_threshold = ShenandoahHeapRegion::region_size_bytes() * ShenandoahIgnoreGarbageThreshold / 100;
+  ShenandoahHeap* heap = ShenandoahHeap::heap();
 
   // The logic for cset selection in adaptive is as follows:
   //
@@ -85,44 +87,14 @@ void ShenandoahAdaptiveHeuristics::choose_collection_set_from_regiondata(Shenand
   // we hit max_cset. When max_cset is hit, we terminate the cset selection. Note that in this scheme,
   // ShenandoahGarbageThreshold is the soft threshold which would be ignored until min_garbage is hit.
 
-
-  // As currently implemented, we are not enforcing that new_garbage > min_garbage.  In a previous implementation
-  // of this code, we forced additional regions into the collection set in an attempt to satisfy this condition,
-  // even when regions had extremely low additional garbage to contribute.  This seemed counterproductive.
-
-  // size_t free_target = (capacity / 100) * ShenandoahMinFreeThreshold + max_cset;
-  // size_t min_garbage = (free_target > actual_free ? (free_target - actual_free) : 0);
-
-  // Note that live data bytes within a region is not the same as heap_region_size - garbage.  This is because
-  // each region contains a combination of used memory (which is garbage plus live) and unused memory, which has not
-  // yet been allocated.  It may be the case that the region on this iteration has too much live data to be added to
-  // the collection set while one or more regions seen on subsequent iterations of this loop can be added to the collection
-  // set because they have smaller live memory, even though they also have smaller garbage (and necessarily a larger
-  // amount of unallocated memory).
-
-  // BANDAID: In an earlier version of this code, this was written:
-  //   if ((new_cset <= max_cset) && ((new_garbage < min_garbage) || (r->garbage() > garbage_threshold)))
-  // The problem with the original code is that in some cases the collection set would include hundreds of regions,
-  // each with less than 100 bytes of garbage.  Evacuating these regions is counterproductive.
-
-  // TODO: Think about changing the description and defaults for ShenandoahGarbageThreshold and ShenandoahMinFreeThreshold.
-  // If "customers" want to evacuate regions with smaller amounts of garbage contained therein, they should specify a lower
-  // value of ShenandoahGarbageThreshold.  As implemented currently, we may experience back-to-back collections if there is
-  // not enough memory to be reclaimed.  Let's not let pursuit of min_garbage drive us to make poor decisions.  Maybe we
-  // want yet another global parameter to allow a region to be placed into the collection set if
-  //   (((new_garbage < min_garbage) && (r->garbage() > ShenandoahSmallerGarbageThreshold)) 
-  //     || (r->garbage() > garbage_threshold))
-
-
-  ShenandoahHeap* heap = ShenandoahHeap::heap();
-
-
   // In generational mode, the sort order within the data array is not strictly descending amounts of garbage.  In
   // particular, regions that have reached tenure age will be sorted into this array before younger regions that contain
   // more garbage.  This represents one of the reasons why we keep looking at regions even after we decide, for example,
   // to exclude one of the regions because it might require evacuation of too much live data.
   bool is_generational = heap->mode()->is_generational();
   bool is_global = (_generation->generation_mode() == GLOBAL);
+  size_t capacity = heap->young_generation()->max_capacity();
+  size_t cur_young_garbage = 0;
 
   // Better select garbage-first regions
   QuickSort::sort<RegionData>(data, (int)size, compare_by_garbage, false);
@@ -133,6 +105,8 @@ void ShenandoahAdaptiveHeuristics::choose_collection_set_from_regiondata(Shenand
       size_t young_cur_cset = 0;
       size_t max_old_cset    = (size_t) (heap->get_old_evac_reserve() / ShenandoahEvacWaste);
       size_t old_cur_cset = 0;
+      size_t free_target = (capacity * ShenandoahMinFreeThreshold) / 100 + max_young_cset;
+      size_t min_garbage = (free_target > actual_free) ? (free_target - actual_free) : 0;
 
       log_info(gc, ergo)("Adaptive CSet Selection for GLOBAL. Max Young Cset: " SIZE_FORMAT
                          "%s, Max Old CSet: " SIZE_FORMAT "%s, Actual Free: " SIZE_FORMAT "%s.",
@@ -153,11 +127,16 @@ void ShenandoahAdaptiveHeuristics::choose_collection_set_from_regiondata(Shenand
           // Entire region will be promoted, This region does not impact young-gen or old-gen evacuation reserve.
           // This region has been pre-selected and its impact on promotion reserve is already accounted for.
           add_region = true;
+          cur_young_garbage += r->garbage();
         } else {
           size_t new_cset = young_cur_cset + r->get_live_data_bytes();
-          if ((new_cset <= max_young_cset) && (r->garbage() > garbage_threshold)) {
+          size_t region_garbage = r->garbage();
+          size_t new_garbage = cur_young_garbage + region_garbage;
+          bool add_regardless = (region_garbage > ignore_threshold) && (new_garbage < min_garbage);
+          if ((new_cset <= max_young_cset) && (add_regardless || (region_garbage > garbage_threshold))) {
             add_region = true;
             young_cur_cset = new_cset;
+            cur_young_garbage = new_garbage;
           }
         }
 
@@ -169,6 +148,8 @@ void ShenandoahAdaptiveHeuristics::choose_collection_set_from_regiondata(Shenand
       // This is young-gen collection.
       size_t max_cset    = (size_t) (heap->get_young_evac_reserve() / ShenandoahEvacWaste);
       size_t cur_cset = 0;
+      size_t free_target = (capacity * ShenandoahMinFreeThreshold) / 100 + max_cset;
+      size_t min_garbage = (free_target > actual_free) ? (free_target - actual_free) : 0;
 
       log_info(gc, ergo)("Adaptive CSet Selection for YOUNG. Max CSet: " SIZE_FORMAT "%s, Actual Free: " SIZE_FORMAT "%s.",
                          byte_size_in_proper_unit(max_cset),    proper_unit_for_byte_size(max_cset),
@@ -177,6 +158,8 @@ void ShenandoahAdaptiveHeuristics::choose_collection_set_from_regiondata(Shenand
       for (size_t idx = 0; idx < size; idx++) {
         ShenandoahHeapRegion* r = data[idx]._region;
         size_t new_cset;
+        size_t region_garbage = r->garbage();
+        size_t new_garbage = cur_young_garbage + region_garbage;
         if (r->age() >= InitialTenuringThreshold) {
           // Entire region will be promoted, This region does not impact young-gen evacuation reserve.  Memory has already
           // been set aside to hold evacuation results as advance_promotion_reserve.
@@ -184,10 +167,12 @@ void ShenandoahAdaptiveHeuristics::choose_collection_set_from_regiondata(Shenand
         } else {
           new_cset = cur_cset + r->get_live_data_bytes();
         }
-
-        if ((new_cset <= max_cset) && ((r->garbage() > garbage_threshold) || (r->age() >= InitialTenuringThreshold))) {
+        bool add_regardless = (region_garbage > ignore_threshold) && (new_garbage < min_garbage);
+        if ((new_cset <= max_cset) &&
+            (add_regardless || (region_garbage > garbage_threshold) || (r->age() >= InitialTenuringThreshold))) {
           cset->add_region(r);
           cur_cset = new_cset;
+          cur_young_garbage = new_garbage;
         }
       }
     }
@@ -195,10 +180,8 @@ void ShenandoahAdaptiveHeuristics::choose_collection_set_from_regiondata(Shenand
     // Traditional Shenandoah (non-generational)
     size_t max_cset    = (size_t) (heap->get_young_evac_reserve() / ShenandoahEvacWaste);
     size_t cur_cset = 0;
-#undef KELVIN_DEBUG
-#ifdef KELVIN_DEBUG
-    printf("young_evac_reserve: " SIZE_FORMAT ", EvacWaste: %f\n", heap->get_young_evac_reserve(), ShenandoahEvacWaste);
-#endif
+    size_t free_target = (capacity * ShenandoahMinFreeThreshold) / 100 + max_cset;
+    size_t min_garbage = (free_target > actual_free) ? (free_target - actual_free) : 0;
 
     log_info(gc, ergo)("Adaptive CSet Selection. Max CSet: " SIZE_FORMAT "%s, Actual Free: " SIZE_FORMAT "%s.",
                          byte_size_in_proper_unit(max_cset),    proper_unit_for_byte_size(max_cset),
@@ -206,11 +189,14 @@ void ShenandoahAdaptiveHeuristics::choose_collection_set_from_regiondata(Shenand
 
     for (size_t idx = 0; idx < size; idx++) {
       ShenandoahHeapRegion* r = data[idx]._region;
-      size_t new_cset;
-      new_cset = cur_cset + r->get_live_data_bytes();
-      if ((new_cset <= max_cset) && (r->garbage() > garbage_threshold)) {
+      size_t new_cset = cur_cset + r->get_live_data_bytes();
+      size_t region_garbage = r->garbage();
+      size_t new_garbage = cur_young_garbage + region_garbage;
+      bool add_regardless = (region_garbage > ignore_threshold) && (new_garbage < min_garbage);
+      if ((new_cset <= max_cset) && (add_regardless || (region_garbage > garbage_threshold))) {
         cset->add_region(r);
         cur_cset = new_cset;
+        cur_young_garbage = new_garbage;
       }
     }
   }

--- a/src/hotspot/share/gc/shenandoah/heuristics/shenandoahAdaptiveHeuristics.cpp
+++ b/src/hotspot/share/gc/shenandoah/heuristics/shenandoahAdaptiveHeuristics.cpp
@@ -131,7 +131,7 @@ void ShenandoahAdaptiveHeuristics::choose_collection_set_from_regiondata(Shenand
     if (is_global) {
       size_t max_young_cset    = (size_t) (heap->get_young_evac_reserve() / ShenandoahEvacWaste);
       size_t young_cur_cset = 0;
-      size_t max_old_cset    = (size_t) (heap->get_young_evac_reserve() / ShenandoahEvacWaste);
+      size_t max_old_cset    = (size_t) (heap->get_old_evac_reserve() / ShenandoahEvacWaste);
       size_t old_cur_cset = 0;
 
       log_info(gc, ergo)("Adaptive CSet Selection for GLOBAL. Max Young Cset: " SIZE_FORMAT

--- a/src/hotspot/share/gc/shenandoah/heuristics/shenandoahHeuristics.cpp
+++ b/src/hotspot/share/gc/shenandoah/heuristics/shenandoahHeuristics.cpp
@@ -203,12 +203,14 @@ void ShenandoahHeuristics::choose_collection_set(ShenandoahCollectionSet* collec
           byte_size_in_proper_unit(total_garbage),     proper_unit_for_byte_size(total_garbage));
 
   size_t immediate_percent = (total_garbage == 0) ? 0 : (immediate_garbage * 100 / total_garbage);
+  collection_set->set_immediate_trash(immediate_garbage);
 
   if (immediate_percent <= ShenandoahImmediateThreshold) {
 
     if (old_heuristics != NULL) {
       old_heuristics->prime_collection_set(collection_set);
 
+      // We can shrink old_evac_reserve() if the chosen collection set is smaller than maximum allowed.
       size_t bytes_reserved_for_old_evacuation = collection_set->get_old_bytes_reserved_for_evacuation();
       if (bytes_reserved_for_old_evacuation * ShenandoahEvacWaste < heap->get_old_evac_reserve()) {
         size_t old_evac_reserve = (size_t) (bytes_reserved_for_old_evacuation * ShenandoahEvacWaste);
@@ -217,144 +219,9 @@ void ShenandoahHeuristics::choose_collection_set(ShenandoahCollectionSet* collec
     }
     // else, this is global collection and doesn't need to prime_collection_set
 
-    ShenandoahYoungGeneration* young_generation = heap->young_generation();
-    size_t young_evacuation_reserve = (young_generation->soft_max_capacity() * ShenandoahEvacReserve) / 100;
-
-    // At this point, young_generation->available() does not know about recently discovered immediate garbage.
-    // What memory it does think to be available is not entirely trustworthy because any available memory associated
-    // with a region that is placed into the collection set becomes unavailable when the region is chosen
-    // for the collection set.  We'll compute an approximation of young available.  If young_available is zero,
-    // we'll need to borrow from old-gen in order to evacuate.  If there's nothing to borrow, we're going to
-    // degenerate to full GC.
-
-    // TODO: young_available can include available (between top() and end()) within each young region that is not
-    // part of the collection set.  Making this memory available to the young_evacuation_reserve allows a larger
-    // young collection set to be chosen when available memory is under extreme pressure.  Implementing this "improvement"
-    // is tricky, because the incremental construction of the collection set actually changes the amount of memory
-    // available to hold evacuated young-gen objects.  As currently implemented, the memory that is available within
-    // non-empty regions that are not selected as part of the collection set can be allocated by the mutator while
-    // GC is evacuating and updating references.
-
-    size_t region_size_bytes = ShenandoahHeapRegion::region_size_bytes();
-    size_t free_affiliated_regions = immediate_regions + free_regions;
-    size_t young_available = (free_affiliated_regions + young_generation->free_unaffiliated_regions()) * region_size_bytes;
-
-    size_t regions_available_to_loan = 0;
-
-    if (heap->mode()->is_generational()) {
-      //  Now that we've primed the collection set, we can figure out how much memory to reserve for evacuation
-      //  of young-gen objects.
-      //
-      //  YoungEvacuationReserve for young generation: how much memory are we reserving to hold the results
-      //     of evacuating young collection set regions?  This is typically smaller than the total amount
-      //     of available memory, and is also smaller than the total amount of marked live memory within
-      //     young-gen.  This value is the minimum of:
-      //       1. young_gen->available() + (old_gen->available - (OldEvacuationReserve + PromotionReserve))
-      //       2. young_gen->capacity() * ShenandoahEvacReserve
-      //
-      //     Note that any region added to the collection set will be completely evacuated and its memory will
-      //     be completely recycled at the end of GC.  The recycled memory will be at least as great as the
-      //     memory borrowed from old-gen.  Enforce that the amount borrowed from old-gen for YoungEvacuationReserve
-      //     is an integral number of entire heap regions.
-      //
-      young_evacuation_reserve -= heap->get_old_evac_reserve();
-
-      // Though we cannot know the evacuation_supplement until after we have computed the collection set, we do
-      // know that every young-gen region added to the collection set will have a net positive impact on available
-      // memory within young-gen, since each contributes a positive amount of garbage to available.  Thus, even
-      // without knowing the exact composition of the collection set, we can allow young_evacuation_reserve to
-      // exceed young_available if there are empty regions available within old-gen to hold the results of evacuation.
-
-      ShenandoahGeneration* old_generation = heap->old_generation();
-
-      // Not all of what is currently available within young-gen can be reserved to hold the results of young-gen
-      // evacuation.  This is because memory available within any heap region that is placed into the collection set
-      // is not available to be allocated during evacuation.  To be safe, we assure that all memory required for evacuation
-      // is available within "virgin" heap regions.
-
-      const size_t available_young_regions = free_regions + immediate_regions + young_generation->free_unaffiliated_regions();
-      const size_t available_old_regions = old_generation->free_unaffiliated_regions();
-      size_t already_reserved_old_bytes = heap->get_old_evac_reserve() + heap->get_promoted_reserve();
-      size_t regions_reserved_for_evac_and_promotion = (already_reserved_old_bytes + region_size_bytes - 1) / region_size_bytes;
-      regions_available_to_loan = available_old_regions - regions_reserved_for_evac_and_promotion;
-
-      if (available_young_regions * region_size_bytes < young_evacuation_reserve) {
-        // Try to borrow old-gen regions in order to avoid shrinking young_evacuation_reserve
-        size_t loan_request = young_evacuation_reserve - available_young_regions * region_size_bytes;
-        size_t loaned_region_request = (loan_request + region_size_bytes - 1) / region_size_bytes;
-        if (loaned_region_request > regions_available_to_loan) {
-          // Scale back young_evacuation_reserve to consume all available young and old regions.  After the
-          // collection set is chosen, we may get some of this memory back for pacing allocations during evacuation
-          // and update refs.
-          loaned_region_request = regions_available_to_loan;
-          young_evacuation_reserve = (available_young_regions + loaned_region_request) * region_size_bytes;
-        } else {
-          // No need to scale back young_evacuation_reserve.
-        }
-      } else {
-        // No need scale back young_evacuation_reserve and no need to borrow from old-gen.  We may even have some
-        // available_young_regions to support allocation pacing.
-      }
-
-    } else if (young_evacuation_reserve > young_available) {
-      // In non-generational mode, there's no old-gen memory to borrow from
-      young_evacuation_reserve = young_available;
-    }
-
-    heap->set_young_evac_reserve(young_evacuation_reserve);
-
     // Add young-gen regions into the collection set.  This is a virtual call, implemented differently by each
     // of the heuristics subclasses.
     choose_collection_set_from_regiondata(collection_set, candidates, cand_idx, immediate_garbage + free);
-
-    // Now compute the evacuation supplement, which is extra memory borrowed from old-gen that can be allocated
-    // by mutators while GC is working on evacuation and update-refs.
-
-    // During evacuation and update refs, we will be able to allocate any memory that is currently available
-    // plus any memory that can be borrowed on the collateral of the current collection set, reserving a certain
-    // percentage of the anticipated replenishment from collection set memory to be allocated during the subsequent
-    // concurrent marking effort.  This is how much I can repay.
-    size_t potential_supplement_regions = collection_set->get_young_region_count();
-
-    // Though I can repay potential_supplement_regions, I can't borrow them unless they are available in old-gen.
-    if (potential_supplement_regions > regions_available_to_loan) {
-      potential_supplement_regions = regions_available_to_loan;
-    }
-
-    size_t potential_evac_supplement;
-
-    // How much of the potential_supplement_regions will be consumed by young_evacuation_reserve: borrowed_evac_regions.
-    const size_t available_unaffiliated_young_regions = young_generation->free_unaffiliated_regions();
-    const size_t available_affiliated_regions = free_regions + immediate_regions;
-    const size_t available_young_regions = available_unaffiliated_young_regions + available_affiliated_regions;
-    size_t young_evac_regions = (young_evacuation_reserve + region_size_bytes - 1) / region_size_bytes;
-    size_t borrowed_evac_regions = (young_evac_regions > available_young_regions)? young_evac_regions - available_young_regions: 0;
-
-    potential_supplement_regions -= borrowed_evac_regions;
-    potential_evac_supplement = potential_supplement_regions * region_size_bytes;
-
-    // Leave some allocation runway for subsequent concurrent mark phase.
-    potential_evac_supplement = (potential_evac_supplement * ShenandoahBorrowPercent) / 100;
-
-    heap->set_alloc_supplement_reserve(potential_evac_supplement);
-
-    size_t promotion_budget = heap->get_promoted_reserve();
-    size_t old_evac_budget = heap->get_old_evac_reserve();
-    size_t alloc_budget_evac_and_update = potential_evac_supplement + young_available;
-
-    // TODO: young_available, which feeds into alloc_budget_evac_and_update is lacking memory available within
-    // existing young-gen regions that were not selected for the collection set.  Add this in and adjust the
-    // log message (where it says "empty-region allocation budget").
-
-    log_info(gc, ergo)("Memory reserved for evacuation and update-refs includes promotion budget: " SIZE_FORMAT
-                       "%s, young evacuation budget: " SIZE_FORMAT "%s, old evacuation budget: " SIZE_FORMAT
-                       "%s, empty-region allocation budget: " SIZE_FORMAT "%s, including supplement: " SIZE_FORMAT "%s",
-                       byte_size_in_proper_unit(promotion_budget), proper_unit_for_byte_size(promotion_budget),
-                       byte_size_in_proper_unit(young_evacuation_reserve), proper_unit_for_byte_size(young_evacuation_reserve),
-                       byte_size_in_proper_unit(old_evac_budget), proper_unit_for_byte_size(old_evac_budget),
-                       byte_size_in_proper_unit(alloc_budget_evac_and_update),
-                       proper_unit_for_byte_size(alloc_budget_evac_and_update),
-                       byte_size_in_proper_unit(potential_evac_supplement), proper_unit_for_byte_size(potential_evac_supplement));
   } else {
     // we're going to skip evacuation and update refs because we reclaimed sufficient amounts of immediate garbage.
     heap->shenandoah_policy()->record_abbreviated_cycle();

--- a/src/hotspot/share/gc/shenandoah/heuristics/shenandoahHeuristics.cpp
+++ b/src/hotspot/share/gc/shenandoah/heuristics/shenandoahHeuristics.cpp
@@ -258,12 +258,17 @@ void ShenandoahHeuristics::choose_collection_set(ShenandoahCollectionSet* collec
       log_info(gc, ref)("choose_collection_set() back from prime_collectiON_set");
 #endif
 
+#ifdef KELVIN_DEPRECATE
+      // We don't shrink evac_reserve here.  That's done in
+      // adjust_evacuation_budgets() upon return from choose_collection_set()
+
       // We can shrink old_evac_reserve() if the chosen collection set is smaller than maximum allowed.
       size_t bytes_reserved_for_old_evacuation = collection_set->get_old_bytes_reserved_for_evacuation();
       if (bytes_reserved_for_old_evacuation * ShenandoahEvacWaste < heap->get_old_evac_reserve()) {
         size_t old_evac_reserve = (size_t) (bytes_reserved_for_old_evacuation * ShenandoahEvacWaste);
         heap->set_old_evac_reserve(old_evac_reserve);
       }
+#endif
     }
     // else, this is global collection and doesn't need to prime_collection_set
 

--- a/src/hotspot/share/gc/shenandoah/heuristics/shenandoahHeuristics.cpp
+++ b/src/hotspot/share/gc/shenandoah/heuristics/shenandoahHeuristics.cpp
@@ -118,6 +118,7 @@ size_t ShenandoahHeuristics::select_aged_regions(size_t old_available, size_t nu
 
 void ShenandoahHeuristics::choose_collection_set(ShenandoahCollectionSet* collection_set, ShenandoahOldHeuristics* old_heuristics) {
   ShenandoahHeap* heap = ShenandoahHeap::heap();
+  bool is_generational = heap->mode()->is_generational();
 
 #undef KELVIN_CHASE
 #ifdef KELVIN_CHASE
@@ -187,11 +188,11 @@ void ShenandoahHeuristics::choose_collection_set(ShenandoahCollectionSet* collec
         live_memory += region->get_live_data_bytes();
         // This is our candidate for later consideration.
         candidates[cand_idx]._region = region;
-        if (collection_set->is_preselected(i)) {
+        if (is_generational && collection_set->is_preselected(i)) {
           // If region is preselected, we know mode()->is_generational() and region->age() >= InitialTenuringThreshold)
           garbage = ShenandoahHeapRegion::region_size_bytes();
 #ifdef KELVIN_CHASE
-          log_info(gc, ergo)("Regular region is to be tenured at age: " SIZE_FORMAT, region->age());
+          log_info(gc, ergo)("Regular region is to be tenured at age: %d", region->age());
 #endif
         }
 #ifdef KELVIN_SEE_THIS
@@ -231,7 +232,6 @@ void ShenandoahHeuristics::choose_collection_set(ShenandoahCollectionSet* collec
 
   save_last_live_memory(live_memory);
 
-#undef KELVIN_CHASE
 #ifdef KELVIN_CHASE
     log_info(gc, ref)("choose_collection_set() finished step 1");
 #endif

--- a/src/hotspot/share/gc/shenandoah/heuristics/shenandoahHeuristics.cpp
+++ b/src/hotspot/share/gc/shenandoah/heuristics/shenandoahHeuristics.cpp
@@ -195,13 +195,12 @@ void ShenandoahHeuristics::choose_collection_set(ShenandoahCollectionSet* collec
 
   size_t immediate_percent = (total_garbage == 0) ? 0 : (immediate_garbage * 100 / total_garbage);
   collection_set->set_immediate_trash(immediate_garbage);
-  
+
   if (immediate_percent <= ShenandoahImmediateThreshold) {
     if (old_heuristics != NULL) {
       old_heuristics->prime_collection_set(collection_set);
-    } 
+    }
     // else, this is global collection and doesn't need to prime_collection_set
-
 
     // Add young-gen regions into the collection set.  This is a virtual call, implemented differently by each
     // of the heuristics subclasses.

--- a/src/hotspot/share/gc/shenandoah/heuristics/shenandoahHeuristics.cpp
+++ b/src/hotspot/share/gc/shenandoah/heuristics/shenandoahHeuristics.cpp
@@ -246,9 +246,8 @@ void ShenandoahHeuristics::choose_collection_set(ShenandoahCollectionSet* collec
 
   size_t immediate_percent = (total_garbage == 0) ? 0 : (immediate_garbage * 100 / total_garbage);
   collection_set->set_immediate_trash(immediate_garbage);
-
+  
   if (immediate_percent <= ShenandoahImmediateThreshold) {
-
     if (old_heuristics != NULL) {
 #ifdef KELVIN_CHASE
       log_info(gc, ref)("choose_collection_set() about to prime_collection_set");
@@ -269,8 +268,9 @@ void ShenandoahHeuristics::choose_collection_set(ShenandoahCollectionSet* collec
         heap->set_old_evac_reserve(old_evac_reserve);
       }
 #endif
-    }
+    } 
     // else, this is global collection and doesn't need to prime_collection_set
+
 
 #undef KELVIN_RETREAT
 #ifdef KELVIN_RETREAT

--- a/src/hotspot/share/gc/shenandoah/heuristics/shenandoahHeuristics.cpp
+++ b/src/hotspot/share/gc/shenandoah/heuristics/shenandoahHeuristics.cpp
@@ -219,9 +219,153 @@ void ShenandoahHeuristics::choose_collection_set(ShenandoahCollectionSet* collec
     }
     // else, this is global collection and doesn't need to prime_collection_set
 
+#define KELVIN_RETREAT
+#ifdef KELVIN_RETREAT
+    ShenandoahYoungGeneration* young_generation = heap->young_generation();
+    size_t young_evacuation_reserve = (young_generation->soft_max_capacity() * ShenandoahEvacReserve) / 100;
+
+    // At this point, young_generation->available() does not know about recently discovered immediate garbage.
+    // What memory it does think to be available is not entirely trustworthy because any available memory associated
+    // with a region that is placed into the collection set becomes unavailable when the region is chosen
+    // for the collection set.  We'll compute an approximation of young available.  If young_available is zero,
+    // we'll need to borrow from old-gen in order to evacuate.  If there's nothing to borrow, we're going to
+    // degenerate to full GC.
+
+    // TODO: young_available can include available (between top() and end()) within each young region that is not
+    // part of the collection set.  Making this memory available to the young_evacuation_reserve allows a larger
+    // young collection set to be chosen when available memory is under extreme pressure.  Implementing this "improvement"
+    // is tricky, because the incremental construction of the collection set actually changes the amount of memory
+    // available to hold evacuated young-gen objects.  As currently implemented, the memory that is available within
+    // non-empty regions that are not selected as part of the collection set can be allocated by the mutator while
+    // GC is evacuating and updating references.
+
+    size_t region_size_bytes = ShenandoahHeapRegion::region_size_bytes();
+    size_t free_affiliated_regions = immediate_regions + free_regions;
+    size_t young_available = (free_affiliated_regions + young_generation->free_unaffiliated_regions()) * region_size_bytes;
+
+    size_t regions_available_to_loan = 0;
+
+    if (heap->mode()->is_generational()) {
+      //  Now that we've primed the collection set, we can figure out how much memory to reserve for evacuation
+      //  of young-gen objects.
+      //
+      //  YoungEvacuationReserve for young generation: how much memory are we reserving to hold the results
+      //     of evacuating young collection set regions?  This is typically smaller than the total amount
+      //     of available memory, and is also smaller than the total amount of marked live memory within
+      //     young-gen.  This value is the minimum of:
+      //       1. young_gen->available() + (old_gen->available - (OldEvacuationReserve + PromotionReserve))
+      //       2. young_gen->capacity() * ShenandoahEvacReserve
+      //
+      //     Note that any region added to the collection set will be completely evacuated and its memory will
+      //     be completely recycled at the end of GC.  The recycled memory will be at least as great as the
+      //     memory borrowed from old-gen.  Enforce that the amount borrowed from old-gen for YoungEvacuationReserve
+      //     is an integral number of entire heap regions.
+      //
+      young_evacuation_reserve -= heap->get_old_evac_reserve();
+
+      // Though we cannot know the evacuation_supplement until after we have computed the collection set, we do
+      // know that every young-gen region added to the collection set will have a net positive impact on available
+      // memory within young-gen, since each contributes a positive amount of garbage to available.  Thus, even
+      // without knowing the exact composition of the collection set, we can allow young_evacuation_reserve to
+      // exceed young_available if there are empty regions available within old-gen to hold the results of evacuation.
+
+      ShenandoahGeneration* old_generation = heap->old_generation();
+
+      // Not all of what is currently available within young-gen can be reserved to hold the results of young-gen
+      // evacuation.  This is because memory available within any heap region that is placed into the collection set
+      // is not available to be allocated during evacuation.  To be safe, we assure that all memory required for evacuation
+      // is available within "virgin" heap regions.
+
+      const size_t available_young_regions = free_regions + immediate_regions + young_generation->free_unaffiliated_regions();
+      const size_t available_old_regions = old_generation->free_unaffiliated_regions();
+      size_t already_reserved_old_bytes = heap->get_old_evac_reserve() + heap->get_promoted_reserve();
+      size_t regions_reserved_for_evac_and_promotion = (already_reserved_old_bytes + region_size_bytes - 1) / region_size_bytes;
+      regions_available_to_loan = available_old_regions - regions_reserved_for_evac_and_promotion;
+
+      if (available_young_regions * region_size_bytes < young_evacuation_reserve) {
+        // Try to borrow old-gen regions in order to avoid shrinking young_evacuation_reserve
+        size_t loan_request = young_evacuation_reserve - available_young_regions * region_size_bytes;
+        size_t loaned_region_request = (loan_request + region_size_bytes - 1) / region_size_bytes;
+        if (loaned_region_request > regions_available_to_loan) {
+          // Scale back young_evacuation_reserve to consume all available young and old regions.  After the
+          // collection set is chosen, we may get some of this memory back for pacing allocations during evacuation
+          // and update refs.
+          loaned_region_request = regions_available_to_loan;
+          young_evacuation_reserve = (available_young_regions + loaned_region_request) * region_size_bytes;
+        } else {
+          // No need to scale back young_evacuation_reserve.
+        }
+      } else {
+        // No need scale back young_evacuation_reserve and no need to borrow from old-gen.  We may even have some
+        // available_young_regions to support allocation pacing.
+      }
+
+    } else if (young_evacuation_reserve > young_available) {
+      // In non-generational mode, there's no old-gen memory to borrow from
+      young_evacuation_reserve = young_available;
+    }
+
+    if (heap->get_young_evac_reserve() != young_evacuation_reserve) {
+      // This was heap->set_young_evac_reserve(young_evacuation_reserve)
+      printf("DEVIANT BEHAVIOR DETECTED: get_young_evac_reserve() [" SIZE_FORMAT "] != young_evacuation_reserve ["
+             SIZE_FORMAT "]\n", heap->get_young_evac_reserve(), young_evacuation_reserve);
+      heap->set_young_evac_reserve(young_evacuation_reserve);
+    }
+#endif
     // Add young-gen regions into the collection set.  This is a virtual call, implemented differently by each
     // of the heuristics subclasses.
     choose_collection_set_from_regiondata(collection_set, candidates, cand_idx, immediate_garbage + free);
+#ifdef KELVIN_RETREAT
+
+    // Now compute the evacuation supplement, which is extra memory borrowed from old-gen that can be allocated
+    // by mutators while GC is working on evacuation and update-refs.
+
+    // During evacuation and update refs, we will be able to allocate any memory that is currently available
+    // plus any memory that can be borrowed on the collateral of the current collection set, reserving a certain
+    // percentage of the anticipated replenishment from collection set memory to be allocated during the subsequent
+    // concurrent marking effort.  This is how much I can repay.
+    size_t potential_supplement_regions = collection_set->get_young_region_count();
+
+    // Though I can repay potential_supplement_regions, I can't borrow them unless they are available in old-gen.
+    if (potential_supplement_regions > regions_available_to_loan) {
+      potential_supplement_regions = regions_available_to_loan;
+    }
+
+    size_t potential_evac_supplement;
+
+    // How much of the potential_supplement_regions will be consumed by young_evacuation_reserve: borrowed_evac_regions.
+    const size_t available_unaffiliated_young_regions = young_generation->free_unaffiliated_regions();
+    const size_t available_affiliated_regions = free_regions + immediate_regions;
+    const size_t available_young_regions = available_unaffiliated_young_regions + available_affiliated_regions;
+    size_t young_evac_regions = (young_evacuation_reserve + region_size_bytes - 1) / region_size_bytes;
+    size_t borrowed_evac_regions = (young_evac_regions > available_young_regions)? young_evac_regions - available_young_regions: 0;
+
+    potential_supplement_regions -= borrowed_evac_regions;
+    potential_evac_supplement = potential_supplement_regions * region_size_bytes;
+
+    // Leave some allocation runway for subsequent concurrent mark phase.
+    potential_evac_supplement = (potential_evac_supplement * ShenandoahBorrowPercent) / 100;
+
+    heap->set_alloc_supplement_reserve(potential_evac_supplement);
+
+    size_t promotion_budget = heap->get_promoted_reserve();
+    size_t old_evac_budget = heap->get_old_evac_reserve();
+    size_t alloc_budget_evac_and_update = potential_evac_supplement + young_available;
+
+    // TODO: young_available, which feeds into alloc_budget_evac_and_update is lacking memory available within
+    // existing young-gen regions that were not selected for the collection set.  Add this in and adjust the
+    // log message (where it says "empty-region allocation budget").
+
+    log_info(gc, ergo)("Memory reserved for evacuation and update-refs includes promotion budget: " SIZE_FORMAT
+                       "%s, young evacuation budget: " SIZE_FORMAT "%s, old evacuation budget: " SIZE_FORMAT
+                       "%s, empty-region allocation budget: " SIZE_FORMAT "%s, including supplement: " SIZE_FORMAT "%s",
+                       byte_size_in_proper_unit(promotion_budget), proper_unit_for_byte_size(promotion_budget),
+                       byte_size_in_proper_unit(young_evacuation_reserve), proper_unit_for_byte_size(young_evacuation_reserve),
+                       byte_size_in_proper_unit(old_evac_budget), proper_unit_for_byte_size(old_evac_budget),
+                       byte_size_in_proper_unit(alloc_budget_evac_and_update),
+                       proper_unit_for_byte_size(alloc_budget_evac_and_update),
+                       byte_size_in_proper_unit(potential_evac_supplement), proper_unit_for_byte_size(potential_evac_supplement));
+#endif
   } else {
     // we're going to skip evacuation and update refs because we reclaimed sufficient amounts of immediate garbage.
     heap->shenandoah_policy()->record_abbreviated_cycle();

--- a/src/hotspot/share/gc/shenandoah/heuristics/shenandoahHeuristics.cpp
+++ b/src/hotspot/share/gc/shenandoah/heuristics/shenandoahHeuristics.cpp
@@ -88,29 +88,10 @@ size_t ShenandoahHeuristics::select_aged_regions(size_t old_available, size_t nu
         if (old_consumed + promotion_need < old_available) {
           old_consumed += promotion_need;
           preselected_regions[i] = true;
-#undef KELVIN_SEE_THIS
-#ifdef KELVIN_SEE_THIS
-          printf("preselecting region " SIZE_FORMAT " with live data: " SIZE_FORMAT ", garbage: " SIZE_FORMAT
-                 " old_consumed: " SIZE_FORMAT " of available " SIZE_FORMAT "\n",
-                 region->index(), region->get_live_data_bytes(), region->garbage(), old_consumed, old_available);
-#endif
         }
-#ifdef KELVIN_SEE_THIS
-        else {
-          printf("Region " SIZE_FORMAT " of age %d not preselected due to consumed, check: %s\n",
-                 region->index(), region->age(), preselected_regions[i]? "true": "false");
-        }
-#endif
         // Note that we keep going even if one region is excluded from selection.  Subsequent regions may be selected
         // if they have smaller live data.
       }
-#ifdef KELVIN_SEE_THIS
-      else {
-        printf("Region " SIZE_FORMAT " of age %d not preselected due to age or empty or generation, check: %s\n",
-               region->index(), region->age(), preselected_regions[i]? "true": "false");
-      }
-#endif
-
     }
   }
   return old_consumed;
@@ -120,10 +101,6 @@ void ShenandoahHeuristics::choose_collection_set(ShenandoahCollectionSet* collec
   ShenandoahHeap* heap = ShenandoahHeap::heap();
   bool is_generational = heap->mode()->is_generational();
 
-#undef KELVIN_CHASE
-#ifdef KELVIN_CHASE
-    log_info(gc, ref)("choose_collection_set() begins");
-#endif
   assert(collection_set->count() == 0, "Must be empty");
   assert(_generation->generation_mode() != OLD, "Old GC invokes ShenandoahOldHeuristics::choose_collection_set()");
 
@@ -156,13 +133,8 @@ void ShenandoahHeuristics::choose_collection_set(ShenandoahCollectionSet* collec
       continue;
     }
 
-#undef KELVIN_CHASE
     size_t garbage = region->garbage();
     total_garbage += garbage;
-#ifdef KELVIN_CHASE
-    log_info(gc, ergo)("Region " SIZE_FORMAT " with garbage: " SIZE_FORMAT " is in generation\n", region->index(), garbage);
-#endif
-
     if (region->is_empty()) {
       free_regions++;
       free += ShenandoahHeapRegion::region_size_bytes();
@@ -172,33 +144,15 @@ void ShenandoahHeuristics::choose_collection_set(ShenandoahCollectionSet* collec
         immediate_regions++;
         immediate_garbage += garbage;
         region->make_trash_immediate();
-#ifdef KELVIN_CHASE
-        log_info(gc, ergo)("Regular region is immediate trash");
-#endif
-#ifdef KELVIN_SEE_THIS
-        printf("Treating regular region " SIZE_FORMAT " as trash\n", region->index());
-#endif
       } else {
         assert (_generation->generation_mode() != OLD, "OLD is handled elsewhere");
-
-#ifdef KELVIN_CHASE
-        log_info(gc, ergo)("Regular region is not trash, has " SIZE_FORMAT " live bytes",
-                           region->get_live_data_bytes());
-#endif
         live_memory += region->get_live_data_bytes();
         // This is our candidate for later consideration.
         candidates[cand_idx]._region = region;
         if (is_generational && collection_set->is_preselected(i)) {
           // If region is preselected, we know mode()->is_generational() and region->age() >= InitialTenuringThreshold)
           garbage = ShenandoahHeapRegion::region_size_bytes();
-#ifdef KELVIN_CHASE
-          log_info(gc, ergo)("Regular region is to be tenured at age: %d", region->age());
-#endif
         }
-#ifdef KELVIN_SEE_THIS
-        printf("Adding %sregion " SIZE_FORMAT " (" SIZE_FORMAT ") at index " SIZE_FORMAT " with perceived garbage " SIZE_FORMAT ", actual garbage: " SIZE_FORMAT "\n",
-               collection_set->is_preselected(i)? "preselected ": "", region->index(), i, cand_idx, garbage, region->garbage());
-#endif
         candidates[cand_idx]._garbage = garbage;
         cand_idx++;
       }
@@ -232,10 +186,6 @@ void ShenandoahHeuristics::choose_collection_set(ShenandoahCollectionSet* collec
 
   save_last_live_memory(live_memory);
 
-#ifdef KELVIN_CHASE
-    log_info(gc, ref)("choose_collection_set() finished step 1");
-#endif
-
   // Step 2. Look back at garbage statistics, and decide if we want to collect anything,
   // given the amount of immediately reclaimable garbage. If we do, figure out the collection set.
 
@@ -249,184 +199,14 @@ void ShenandoahHeuristics::choose_collection_set(ShenandoahCollectionSet* collec
   
   if (immediate_percent <= ShenandoahImmediateThreshold) {
     if (old_heuristics != NULL) {
-#ifdef KELVIN_CHASE
-      log_info(gc, ref)("choose_collection_set() about to prime_collection_set");
-#endif
       old_heuristics->prime_collection_set(collection_set);
-#ifdef KELVIN_CHASE
-      log_info(gc, ref)("choose_collection_set() back from prime_collectiON_set");
-#endif
-
-#ifdef KELVIN_DEPRECATE
-      // We don't shrink evac_reserve here.  That's done in
-      // adjust_evacuation_budgets() upon return from choose_collection_set()
-
-      // We can shrink old_evac_reserve() if the chosen collection set is smaller than maximum allowed.
-      size_t bytes_reserved_for_old_evacuation = collection_set->get_old_bytes_reserved_for_evacuation();
-      if (bytes_reserved_for_old_evacuation * ShenandoahEvacWaste < heap->get_old_evac_reserve()) {
-        size_t old_evac_reserve = (size_t) (bytes_reserved_for_old_evacuation * ShenandoahEvacWaste);
-        heap->set_old_evac_reserve(old_evac_reserve);
-      }
-#endif
     } 
     // else, this is global collection and doesn't need to prime_collection_set
 
 
-#undef KELVIN_RETREAT
-#ifdef KELVIN_RETREAT
-    ShenandoahYoungGeneration* young_generation = heap->young_generation();
-    size_t young_evacuation_reserve = (young_generation->soft_max_capacity() * ShenandoahEvacReserve) / 100;
-
-    // At this point, young_generation->available() does not know about recently discovered immediate garbage.
-    // What memory it does think to be available is not entirely trustworthy because any available memory associated
-    // with a region that is placed into the collection set becomes unavailable when the region is chosen
-    // for the collection set.  We'll compute an approximation of young available.  If young_available is zero,
-    // we'll need to borrow from old-gen in order to evacuate.  If there's nothing to borrow, we're going to
-    // degenerate to full GC.
-
-    // TODO: young_available can include available (between top() and end()) within each young region that is not
-    // part of the collection set.  Making this memory available to the young_evacuation_reserve allows a larger
-    // young collection set to be chosen when available memory is under extreme pressure.  Implementing this "improvement"
-    // is tricky, because the incremental construction of the collection set actually changes the amount of memory
-    // available to hold evacuated young-gen objects.  As currently implemented, the memory that is available within
-    // non-empty regions that are not selected as part of the collection set can be allocated by the mutator while
-    // GC is evacuating and updating references.
-
-    size_t region_size_bytes = ShenandoahHeapRegion::region_size_bytes();
-    size_t free_affiliated_regions = immediate_regions + free_regions;
-    size_t young_available = (free_affiliated_regions + young_generation->free_unaffiliated_regions()) * region_size_bytes;
-
-    size_t regions_available_to_loan = 0;
-
-    if (heap->mode()->is_generational()) {
-      //  Now that we've primed the collection set, we can figure out how much memory to reserve for evacuation
-      //  of young-gen objects.
-      //
-      //  YoungEvacuationReserve for young generation: how much memory are we reserving to hold the results
-      //     of evacuating young collection set regions?  This is typically smaller than the total amount
-      //     of available memory, and is also smaller than the total amount of marked live memory within
-      //     young-gen.  This value is the minimum of:
-      //       1. young_gen->available() + (old_gen->available - (OldEvacuationReserve + PromotionReserve))
-      //       2. young_gen->capacity() * ShenandoahEvacReserve
-      //
-      //     Note that any region added to the collection set will be completely evacuated and its memory will
-      //     be completely recycled at the end of GC.  The recycled memory will be at least as great as the
-      //     memory borrowed from old-gen.  Enforce that the amount borrowed from old-gen for YoungEvacuationReserve
-      //     is an integral number of entire heap regions.
-      //
-      young_evacuation_reserve -= heap->get_old_evac_reserve();
-
-      // Though we cannot know the evacuation_supplement until after we have computed the collection set, we do
-      // know that every young-gen region added to the collection set will have a net positive impact on available
-      // memory within young-gen, since each contributes a positive amount of garbage to available.  Thus, even
-      // without knowing the exact composition of the collection set, we can allow young_evacuation_reserve to
-      // exceed young_available if there are empty regions available within old-gen to hold the results of evacuation.
-
-      ShenandoahGeneration* old_generation = heap->old_generation();
-
-      // Not all of what is currently available within young-gen can be reserved to hold the results of young-gen
-      // evacuation.  This is because memory available within any heap region that is placed into the collection set
-      // is not available to be allocated during evacuation.  To be safe, we assure that all memory required for evacuation
-      // is available within "virgin" heap regions.
-
-      const size_t available_young_regions = free_regions + immediate_regions + young_generation->free_unaffiliated_regions();
-      const size_t available_old_regions = old_generation->free_unaffiliated_regions();
-      size_t already_reserved_old_bytes = heap->get_old_evac_reserve() + heap->get_promoted_reserve();
-      size_t regions_reserved_for_evac_and_promotion = (already_reserved_old_bytes + region_size_bytes - 1) / region_size_bytes;
-      regions_available_to_loan = available_old_regions - regions_reserved_for_evac_and_promotion;
-
-      if (available_young_regions * region_size_bytes < young_evacuation_reserve) {
-        // Try to borrow old-gen regions in order to avoid shrinking young_evacuation_reserve
-        size_t loan_request = young_evacuation_reserve - available_young_regions * region_size_bytes;
-        size_t loaned_region_request = (loan_request + region_size_bytes - 1) / region_size_bytes;
-        if (loaned_region_request > regions_available_to_loan) {
-          // Scale back young_evacuation_reserve to consume all available young and old regions.  After the
-          // collection set is chosen, we may get some of this memory back for pacing allocations during evacuation
-          // and update refs.
-          loaned_region_request = regions_available_to_loan;
-          young_evacuation_reserve = (available_young_regions + loaned_region_request) * region_size_bytes;
-        } else {
-          // No need to scale back young_evacuation_reserve.
-        }
-      } else {
-        // No need scale back young_evacuation_reserve and no need to borrow from old-gen.  We may even have some
-        // available_young_regions to support allocation pacing.
-      }
-
-    } else if (young_evacuation_reserve > young_available) {
-      // In non-generational mode, there's no old-gen memory to borrow from
-      young_evacuation_reserve = young_available;
-    }
-
-    if (heap->get_young_evac_reserve() != young_evacuation_reserve) {
-      // This was heap->set_young_evac_reserve(young_evacuation_reserve)
-      printf("DEVIANT BEHAVIOR DETECTED: get_young_evac_reserve() [" SIZE_FORMAT "] != young_evacuation_reserve ["
-             SIZE_FORMAT "]\n", heap->get_young_evac_reserve(), young_evacuation_reserve);
-      heap->set_young_evac_reserve(young_evacuation_reserve);
-    }
-#endif
-#ifdef KELVIN_CHASE
-    log_info(gc, ref)("choose_collection_set() finished step 2");
-#endif
     // Add young-gen regions into the collection set.  This is a virtual call, implemented differently by each
     // of the heuristics subclasses.
     choose_collection_set_from_regiondata(collection_set, candidates, cand_idx, immediate_garbage + free);
-
-#ifdef KELVIN_CHASE
-    log_info(gc, ref)("choose_collection_set() finished choosing collection set");
-#endif
-
-#ifdef KELVIN_RETREAT
-
-    // Now compute the evacuation supplement, which is extra memory borrowed from old-gen that can be allocated
-    // by mutators while GC is working on evacuation and update-refs.
-
-    // During evacuation and update refs, we will be able to allocate any memory that is currently available
-    // plus any memory that can be borrowed on the collateral of the current collection set, reserving a certain
-    // percentage of the anticipated replenishment from collection set memory to be allocated during the subsequent
-    // concurrent marking effort.  This is how much I can repay.
-    size_t potential_supplement_regions = collection_set->get_young_region_count();
-
-    // Though I can repay potential_supplement_regions, I can't borrow them unless they are available in old-gen.
-    if (potential_supplement_regions > regions_available_to_loan) {
-      potential_supplement_regions = regions_available_to_loan;
-    }
-
-    size_t potential_evac_supplement;
-
-    // How much of the potential_supplement_regions will be consumed by young_evacuation_reserve: borrowed_evac_regions.
-    const size_t available_unaffiliated_young_regions = young_generation->free_unaffiliated_regions();
-    const size_t available_affiliated_regions = free_regions + immediate_regions;
-    const size_t available_young_regions = available_unaffiliated_young_regions + available_affiliated_regions;
-    size_t young_evac_regions = (young_evacuation_reserve + region_size_bytes - 1) / region_size_bytes;
-    size_t borrowed_evac_regions = (young_evac_regions > available_young_regions)? young_evac_regions - available_young_regions: 0;
-
-    potential_supplement_regions -= borrowed_evac_regions;
-    potential_evac_supplement = potential_supplement_regions * region_size_bytes;
-
-    // Leave some allocation runway for subsequent concurrent mark phase.
-    potential_evac_supplement = (potential_evac_supplement * ShenandoahBorrowPercent) / 100;
-
-    heap->set_alloc_supplement_reserve(potential_evac_supplement);
-
-    size_t promotion_budget = heap->get_promoted_reserve();
-    size_t old_evac_budget = heap->get_old_evac_reserve();
-    size_t alloc_budget_evac_and_update = potential_evac_supplement + young_available;
-
-    // TODO: young_available, which feeds into alloc_budget_evac_and_update is lacking memory available within
-    // existing young-gen regions that were not selected for the collection set.  Add this in and adjust the
-    // log message (where it says "empty-region allocation budget").
-
-    log_info(gc, ergo)("Memory reserved for evacuation and update-refs includes promotion budget: " SIZE_FORMAT
-                       "%s, young evacuation budget: " SIZE_FORMAT "%s, old evacuation budget: " SIZE_FORMAT
-                       "%s, empty-region allocation budget: " SIZE_FORMAT "%s, including supplement: " SIZE_FORMAT "%s",
-                       byte_size_in_proper_unit(promotion_budget), proper_unit_for_byte_size(promotion_budget),
-                       byte_size_in_proper_unit(young_evacuation_reserve), proper_unit_for_byte_size(young_evacuation_reserve),
-                       byte_size_in_proper_unit(old_evac_budget), proper_unit_for_byte_size(old_evac_budget),
-                       byte_size_in_proper_unit(alloc_budget_evac_and_update),
-                       proper_unit_for_byte_size(alloc_budget_evac_and_update),
-                       byte_size_in_proper_unit(potential_evac_supplement), proper_unit_for_byte_size(potential_evac_supplement));
-#endif
   } else {
     // we're going to skip evacuation and update refs because we reclaimed sufficient amounts of immediate garbage.
     heap->shenandoah_policy()->record_abbreviated_cycle();

--- a/src/hotspot/share/gc/shenandoah/heuristics/shenandoahOldHeuristics.cpp
+++ b/src/hotspot/share/gc/shenandoah/heuristics/shenandoahOldHeuristics.cpp
@@ -106,7 +106,7 @@ bool ShenandoahOldHeuristics::prime_collection_set(ShenandoahCollectionSet* coll
 #ifdef KELVIN_RETREAT
   size_t old_evacuation_budget = (size_t) (max_old_evacuation_bytes / ShenandoahEvacWaste);
 
-#define KELVIN_FIXUP
+#undef KELVIN_FIXUP
 #ifdef KELVIN_FIXUP
   size_t minimum_evacuation_reserve = ShenandoahOldCompactionReserve * ShenandoahHeapRegion::region_size_bytes();
   if (minimum_evacuation_reserve > heap->old_generation()->available()) {

--- a/src/hotspot/share/gc/shenandoah/heuristics/shenandoahOldHeuristics.cpp
+++ b/src/hotspot/share/gc/shenandoah/heuristics/shenandoahOldHeuristics.cpp
@@ -53,93 +53,12 @@ bool ShenandoahOldHeuristics::prime_collection_set(ShenandoahCollectionSet* coll
   size_t evacuated_old_bytes = 0;
   size_t collected_old_bytes = 0;
 
-#undef KELVIN_RETREAT
-#ifdef KELVIN_RETREAT
-  // TODO:
-  // The max_old_evacuation_bytes and promotion_budget_bytes constants represent a first
-  // approximation to desired operating parameters.  Eventually, these values should be determined
-  // by heuristics and should adjust dynamically based on most current execution behavior.  In the
-  // interim, we offer command-line options to set the values of these configuration parameters.
-
-  // max_old_evacuation_bytes represents a bound on how much evacuation effort is dedicated
-  // to old-gen regions.
-  size_t max_old_evacuation_bytes = (heap->old_generation()->soft_max_capacity() * ShenandoahOldEvacReserve) / 100;
-  const size_t young_evacuation_bytes = (heap->young_generation()->soft_max_capacity() * ShenandoahEvacReserve) / 100;
-  const size_t ratio_bound_on_old_evac_bytes = (young_evacuation_bytes * ShenandoahOldEvacRatioPercent) / 100;
-  if (max_old_evacuation_bytes > ratio_bound_on_old_evac_bytes) {
-    max_old_evacuation_bytes = ratio_bound_on_old_evac_bytes;
-  }
-
-  // Usually, old-evacuation is limited by the CPU bounds on effort.  However, it can also be bounded by available
-  // memory within old-gen to hold the results of evacuation.  When we are bound by memory availability, we need
-  // to account below for the loss of available memory from within each region that is added to the old-gen collection
-  // set.
-  size_t old_available = heap->old_generation()->available();
-  size_t excess_old_capacity_for_evacuation;
-  if (max_old_evacuation_bytes > old_available) {
-    max_old_evacuation_bytes = old_available;
-    excess_old_capacity_for_evacuation = 0;
-  } else {
-    excess_old_capacity_for_evacuation = old_available - max_old_evacuation_bytes;
-  }
-
-  // promotion_budget_bytes represents an "arbitrary" bound on how many bytes can be consumed by young-gen
-  // objects promoted into old-gen memory.  We need to avoid a scenario under which promotion of objects
-  // depletes old-gen available memory to the point that there is insufficient memory to hold old-gen objects
-  // that need to be evacuated from within the old-gen collection set.
-  //
-  // Key idea: if there is not sufficient memory within old-gen to hold an object that wants to be promoted, defer
-  // promotion until a subsequent evacuation pass.  Enforcement is provided at the time PLABs and shared allocations
-  // in old-gen memory are requested.
-
-  const size_t promotion_budget_bytes = heap->get_promoted_reserve();
-
-  // old_evacuation_budget is an upper bound on the amount of live memory that can be evacuated.
-  //
-#endif
   // If a region is put into the collection set, then this region's free (not yet used) bytes are no longer
   // "available" to hold the results of other evacuations.  This may cause a decrease in the remaining amount
   // of memory that can still be evacuated.  We address this by reducing the evacuation budget by the amount
   // of live memory in that region and by the amount of unallocated memory in that region if the evacuation
   // budget is constrained by availability of free memory.
-
-#ifdef KELVIN_RETREAT
-  size_t old_evacuation_budget = (size_t) (max_old_evacuation_bytes / ShenandoahEvacWaste);
-
-#undef KELVIN_FIXUP
-#ifdef KELVIN_FIXUP
-  size_t minimum_evacuation_reserve = ShenandoahOldCompactionReserve * ShenandoahHeapRegion::region_size_bytes();
-  if (minimum_evacuation_reserve > heap->old_generation()->available()) {
-    // Due to round-off errors during enforcement of minimum_evacuation_reserve during previous GC passes,
-    // there can be slight discrepancies here.
-    minimum_evacuation_reserve = heap->old_generation()->available();
-  }
-  if (old_evacuation_budget < minimum_evacuation_reserve) {
-    // Even if there's nothing to be evacuated on this cycle, we still need to reserve this memory for future
-    // evacuations.
-    old_evacuation_budget = minimum_evacuation_reserve;
-  }
-#endif
-  
-  if (old_evacuation_budget != (size_t) (heap->get_old_evac_reserve() / ShenandoahEvacWaste)) {
-    printf("DEVIANT BEHAVIOR DETECTED: old_evacuation_budget [" SIZE_FORMAT
-           "]!= (heap->get_old_evac_reserve() / ShenandoahEvacWaste)[" SIZE_FORMAT "])\n",
-           old_evacuation_budget, (size_t) (heap->get_old_evac_reserve() / ShenandoahEvacWaste));
-    printf("old_evacuation_budget computed from:\n");
-    printf(" capacity * ShenandoahOldEvacReserve: " SIZE_FORMAT "\n",
-           (heap->old_generation()->soft_max_capacity() * ShenandoahOldEvacReserve) / 100);
-    printf("       ratio_bound_on_old_evac_bytes: " SIZE_FORMAT "\n", ratio_bound_on_old_evac_bytes);
-    printf("                       old_available: " SIZE_FORMAT "\n", old_available);
-    printf("  DO NOT care about promotion_budget: " SIZE_FORMAT "\n", promotion_budget_bytes);
-    printf("            max_old_evacuation_bytes: " SIZE_FORMAT "\n", max_old_evacuation_bytes);
-    printf("  max_old_evacuation_bytes/EvacWaste: " SIZE_FORMAT "\n", (size_t) (max_old_evacuation_bytes / ShenandoahEvacWaste));
-  }
-  log_info(gc)("Choose old regions for mixed collection: old evacuation budget: " SIZE_FORMAT "%s",
-                byte_size_in_proper_unit(old_evacuation_budget), proper_unit_for_byte_size(old_evacuation_budget));
-#else
   size_t old_evacuation_budget = (size_t) (heap->get_old_evac_reserve() / ShenandoahEvacWaste);
-#endif
-
   size_t remaining_old_evacuation_budget = old_evacuation_budget;
   size_t lost_evacuation_capacity = 0;
   log_info(gc)("Choose old regions for mixed collection: old evacuation budget: " SIZE_FORMAT "%s, candidates: %u",
@@ -154,53 +73,19 @@ bool ShenandoahOldHeuristics::prime_collection_set(ShenandoahCollectionSet* coll
 
     // If we choose region r to be collected, then we need to decrease the capacity to hold other evacuations by
     // the size of r's free memory.
-#ifdef KELVIN_RETREAT
-    if ((r->get_live_data_bytes() <= remaining_old_evacuation_budget) &&
-        ((lost_evacuation_capacity + r->free() <= excess_old_capacity_for_evacuation)
-         || (r->get_live_data_bytes() + r->free() <= remaining_old_evacuation_budget))) {
-      if (r->get_live_data_bytes() > remaining_old_evacuation_budget) {
-        printf("DEVIANT BEHAVIOR DETECTED: original code would include region " SIZE_FORMAT ", but new code does not\n",
-               r->index());
-      }
-#else
+
     // It's probably overkill to compensate with lost_evacuation_capacity.  But it's the safe thing to do and
     //  has minimal impact on content of primed collection set.
     if (r->get_live_data_bytes() + lost_evacuation_capacity <= remaining_old_evacuation_budget) {
-#endif
       // Decrement remaining evacuation budget by bytes that will be copied.
       lost_evacuation_capacity += r->free();
       remaining_old_evacuation_budget -= r->get_live_data_bytes();
-#ifdef KELVIN_RETREAT
-      // KELVIN WANTS TO KEEP THIS CODE IN FINAL REFACTOR: BUT IT'S NOT SO EASY, BECAUSE EXCESS_OLD_CAPACITY_FOR_EVACUATION
-      // IS A CONCEPT ONLY DEFINED UNDER KELVIN_RETREAT CONDITIONAL COMPILATION.  SO I DON'T NEED IT AFTER ALL.
-      // If the cumulative loss of free memory from
-      // regions that are to be collected exceeds excess_old_capacity_for_evacuation,  decrease
-      // remaining_old_evacuation_budget by this loss as well.
-      if (lost_evacuation_capacity > excess_old_capacity_for_evacuation) {
-        // This is slightly conservative because we really only need to remove from the remaining evacuation budget
-        // the amount by which lost_evacution_capacity exceeds excess_old_capacity_for_evacuation, but this is relatively
-        // rare event and current thought is to be a bit conservative rather than mess up the math on code that is so
-        // difficult to test and maintain...
-
-        // Once we have crossed the threshold of lost_evacuation_capacity exceeding excess_old_capacity_for_evacuation,
-        // every subsequent iteration of this loop will further decrease remaining_old_evacuation_budget.
-        printf("NOT SO DEVIANT BEHAVIOR DETECTED: subtracting free [" SIZE_FORMAT "] for region " SIZE_FORMAT
-               " from remaining_old_evacuation_buget: " SIZE_FORMAT "\n", r->free(), r->index(), remaining_old_evacuation_budget);
-        remaining_old_evacuation_budget -= r->free();
-      }
-#endif
       collection_set->add_region(r);
       included_old_regions++;
       evacuated_old_bytes += r->get_live_data_bytes();
       collected_old_bytes += r->garbage();
       consume_old_collection_candidate();
     } else {
-#ifdef KELVIN_RETREAT
-      if (r->get_live_data_bytes() <= remaining_old_evacuation_budget) {
-        printf("DEVIANT BEHAVIOR DETECTED: original code would not include region " SIZE_FORMAT ", but new code does\n",
-               r->index());
-      }
-#endif
       break;
     }
   }

--- a/src/hotspot/share/gc/shenandoah/heuristics/shenandoahOldHeuristics.cpp
+++ b/src/hotspot/share/gc/shenandoah/heuristics/shenandoahOldHeuristics.cpp
@@ -51,94 +51,39 @@ bool ShenandoahOldHeuristics::prime_collection_set(ShenandoahCollectionSet* coll
   ShenandoahHeap* heap = ShenandoahHeap::heap();
   uint included_old_regions = 0;
   size_t evacuated_old_bytes = 0;
+  size_t collected_old_bytes = 0;
 
-  // TODO:
-  // The max_old_evacuation_bytes and promotion_budget_bytes constants represent a first
-  // approximation to desired operating parameters.  Eventually, these values should be determined
-  // by heuristics and should adjust dynamically based on most current execution behavior.  In the
-  // interim, we offer command-line options to set the values of these configuration parameters.
-
-  // max_old_evacuation_bytes represents a bound on how much evacuation effort is dedicated
-  // to old-gen regions.
-  size_t max_old_evacuation_bytes = (heap->old_generation()->soft_max_capacity() * ShenandoahOldEvacReserve) / 100;
-  const size_t young_evacuation_bytes = (heap->young_generation()->soft_max_capacity() * ShenandoahEvacReserve) / 100;
-  const size_t ratio_bound_on_old_evac_bytes = (young_evacuation_bytes * ShenandoahOldEvacRatioPercent) / 100;
-  if (max_old_evacuation_bytes > ratio_bound_on_old_evac_bytes) {
-    max_old_evacuation_bytes = ratio_bound_on_old_evac_bytes;
-  }
-
-  // Usually, old-evacuation is limited by the CPU bounds on effort.  However, it can also be bounded by available
-  // memory within old-gen to hold the results of evacuation.  When we are bound by memory availability, we need
-  // to account below for the loss of available memory from within each region that is added to the old-gen collection
-  // set.
-  size_t old_available = heap->old_generation()->available();
-  size_t excess_old_capacity_for_evacuation;
-  if (max_old_evacuation_bytes > old_available) {
-    max_old_evacuation_bytes = old_available;
-    excess_old_capacity_for_evacuation = 0;
-  } else {
-    excess_old_capacity_for_evacuation = old_available - max_old_evacuation_bytes;
-  }
-
-  // promotion_budget_bytes represents an "arbitrary" bound on how many bytes can be consumed by young-gen
-  // objects promoted into old-gen memory.  We need to avoid a scenario under which promotion of objects
-  // depletes old-gen available memory to the point that there is insufficient memory to hold old-gen objects
-  // that need to be evacuated from within the old-gen collection set.
-  //
-  // Key idea: if there is not sufficient memory within old-gen to hold an object that wants to be promoted, defer
-  // promotion until a subsequent evacuation pass.  Enforcement is provided at the time PLABs and shared allocations
-  // in old-gen memory are requested.
-
-  const size_t promotion_budget_bytes = heap->get_promoted_reserve();
-
-  // old_evacuation_budget is an upper bound on the amount of live memory that can be evacuated.
-  //
   // If a region is put into the collection set, then this region's free (not yet used) bytes are no longer
   // "available" to hold the results of other evacuations.  This may cause a decrease in the remaining amount
   // of memory that can still be evacuated.  We address this by reducing the evacuation budget by the amount
   // of live memory in that region and by the amount of unallocated memory in that region if the evacuation
-  // budget is constrained by availability of free memory.  See remaining_old_evacuation_budget below.
+  // budget is constrained by availability of free memory.
 
-  size_t old_evacuation_budget = (size_t) (max_old_evacuation_bytes / ShenandoahEvacWaste);
-
-  log_info(gc)("Choose old regions for mixed collection: old evacuation budget: " SIZE_FORMAT "%s",
-                byte_size_in_proper_unit(old_evacuation_budget), proper_unit_for_byte_size(old_evacuation_budget));
-
+  size_t old_evacuation_budget = (size_t) (heap->get_old_evac_reserve() / ShenandoahEvacWaste);
   size_t remaining_old_evacuation_budget = old_evacuation_budget;
   size_t lost_evacuation_capacity = 0;
+  log_info(gc)("Choose old regions for mixed collection: old evacuation budget: " SIZE_FORMAT "%s, candidates: %u",
+               byte_size_in_proper_unit(old_evacuation_budget), proper_unit_for_byte_size(old_evacuation_budget),
+               unprocessed_old_collection_candidates());
 
-  // The number of old-gen regions that were selected as candidates for collection at the end of the most recent
-  // old-gen concurrent marking phase and have not yet been collected is represented by
-  // unprocessed_old_collection_candidates()
+  // The number of old-gen regions that were selected as candidates for collection at the end of the most recent old-gen
+  // concurrent marking phase and have not yet been collected is represented by unprocessed_old_collection_candidates()
   while (unprocessed_old_collection_candidates() > 0) {
     // Old collection candidates are sorted in order of decreasing garbage contained therein.
     ShenandoahHeapRegion* r = next_old_collection_candidate();
 
-
     // If we choose region r to be collected, then we need to decrease the capacity to hold other evacuations by
     // the size of r's free memory.
-    if ((r->get_live_data_bytes() <= remaining_old_evacuation_budget) &&
-        ((lost_evacuation_capacity + r->free() <= excess_old_capacity_for_evacuation)
-         || (r->get_live_data_bytes() + r->free() <= remaining_old_evacuation_budget))) {
-
+    if (r->get_live_data_bytes() <= remaining_old_evacuation_budget) {
       // Decrement remaining evacuation budget by bytes that will be copied.  If the cumulative loss of free memory from
       // regions that are to be collected exceeds excess_old_capacity_for_evacuation,  decrease
       // remaining_old_evacuation_budget by this loss as well.
       lost_evacuation_capacity += r->free();
       remaining_old_evacuation_budget -= r->get_live_data_bytes();
-      if (lost_evacuation_capacity > excess_old_capacity_for_evacuation) {
-        // This is slightly conservative because we really only need to remove from the remaining evacuation budget
-        // the amount by which lost_evacution_capacity exceeds excess_old_capacity_for_evacuation, but this is relatively
-        // rare event and current thought is to be a bit conservative rather than mess up the math on code that is so
-        // difficult to test and maintain...
-
-        // Once we have crossed the threshold of lost_evacuation_capacity exceeding excess_old_capacity_for_evacuation,
-        // every subsequent iteration of this loop will further decrease remaining_old_evacuation_budget.
-        remaining_old_evacuation_budget -= r->free();
-      }
       collection_set->add_region(r);
       included_old_regions++;
       evacuated_old_bytes += r->get_live_data_bytes();
+      collected_old_bytes += r->garbage();
       consume_old_collection_candidate();
     } else {
       break;
@@ -146,8 +91,10 @@ bool ShenandoahOldHeuristics::prime_collection_set(ShenandoahCollectionSet* coll
   }
 
   if (included_old_regions > 0) {
-    log_info(gc)("Old-gen piggyback evac (" UINT32_FORMAT " regions, " SIZE_FORMAT " %s)",
-                 included_old_regions, byte_size_in_proper_unit(evacuated_old_bytes), proper_unit_for_byte_size(evacuated_old_bytes));
+    log_info(gc)("Old-gen piggyback evac (" UINT32_FORMAT " regions, evacuating " SIZE_FORMAT "%s, reclaiming: " SIZE_FORMAT "%s)",
+                 included_old_regions,
+                 byte_size_in_proper_unit(evacuated_old_bytes), proper_unit_for_byte_size(evacuated_old_bytes),
+                 byte_size_in_proper_unit(collected_old_bytes), proper_unit_for_byte_size(collected_old_bytes));
   }
   return (included_old_regions > 0);
 }

--- a/src/hotspot/share/gc/shenandoah/heuristics/shenandoahOldHeuristics.cpp
+++ b/src/hotspot/share/gc/shenandoah/heuristics/shenandoahOldHeuristics.cpp
@@ -53,13 +53,71 @@ bool ShenandoahOldHeuristics::prime_collection_set(ShenandoahCollectionSet* coll
   size_t evacuated_old_bytes = 0;
   size_t collected_old_bytes = 0;
 
+#define KELVIN_RETREAT
+#ifdef KELVIN_RETREAT
+  // TODO:
+  // The max_old_evacuation_bytes and promotion_budget_bytes constants represent a first
+  // approximation to desired operating parameters.  Eventually, these values should be determined
+  // by heuristics and should adjust dynamically based on most current execution behavior.  In the
+  // interim, we offer command-line options to set the values of these configuration parameters.
+
+  // max_old_evacuation_bytes represents a bound on how much evacuation effort is dedicated
+  // to old-gen regions.
+  size_t max_old_evacuation_bytes = (heap->old_generation()->soft_max_capacity() * ShenandoahOldEvacReserve) / 100;
+  const size_t young_evacuation_bytes = (heap->young_generation()->soft_max_capacity() * ShenandoahEvacReserve) / 100;
+  const size_t ratio_bound_on_old_evac_bytes = (young_evacuation_bytes * ShenandoahOldEvacRatioPercent) / 100;
+  if (max_old_evacuation_bytes > ratio_bound_on_old_evac_bytes) {
+    max_old_evacuation_bytes = ratio_bound_on_old_evac_bytes;
+  }
+
+  // Usually, old-evacuation is limited by the CPU bounds on effort.  However, it can also be bounded by available
+  // memory within old-gen to hold the results of evacuation.  When we are bound by memory availability, we need
+  // to account below for the loss of available memory from within each region that is added to the old-gen collection
+  // set.
+  size_t old_available = heap->old_generation()->available();
+  size_t excess_old_capacity_for_evacuation;
+  if (max_old_evacuation_bytes > old_available) {
+    max_old_evacuation_bytes = old_available;
+    excess_old_capacity_for_evacuation = 0;
+  } else {
+    excess_old_capacity_for_evacuation = old_available - max_old_evacuation_bytes;
+  }
+
+  // promotion_budget_bytes represents an "arbitrary" bound on how many bytes can be consumed by young-gen
+  // objects promoted into old-gen memory.  We need to avoid a scenario under which promotion of objects
+  // depletes old-gen available memory to the point that there is insufficient memory to hold old-gen objects
+  // that need to be evacuated from within the old-gen collection set.
+  //
+  // Key idea: if there is not sufficient memory within old-gen to hold an object that wants to be promoted, defer
+  // promotion until a subsequent evacuation pass.  Enforcement is provided at the time PLABs and shared allocations
+  // in old-gen memory are requested.
+
+  const size_t promotion_budget_bytes = heap->get_promoted_reserve();
+
+  // old_evacuation_budget is an upper bound on the amount of live memory that can be evacuated.
+  //
+#endif
   // If a region is put into the collection set, then this region's free (not yet used) bytes are no longer
   // "available" to hold the results of other evacuations.  This may cause a decrease in the remaining amount
   // of memory that can still be evacuated.  We address this by reducing the evacuation budget by the amount
   // of live memory in that region and by the amount of unallocated memory in that region if the evacuation
   // budget is constrained by availability of free memory.
+#ifdef KELVIN_RETREAT
 
+  size_t old_evacuation_budget = (size_t) (max_old_evacuation_bytes / ShenandoahEvacWaste);
+
+  if (old_evacuation_budget != (size_t) (heap->get_old_evac_reserve() / ShenandoahEvacWaste)) {
+    printf("DEVIANT BEHAVIOR DETECTED: old_evacuation_budget [" SIZE_FORMAT
+           "]!= (heap->get_old_evac_reserve() / ShenandoahEvacWaste)[" SIZE_FORMAT "])\n",
+           old_evacuation_budget, (size_t) (heap->get_old_evac_reserve() / ShenandoahEvacWaste));
+  }
+  log_info(gc)("Choose old regions for mixed collection: old evacuation budget: " SIZE_FORMAT "%s",
+                byte_size_in_proper_unit(old_evacuation_budget), proper_unit_for_byte_size(old_evacuation_budget));
+#else
+  // squelch this for now
   size_t old_evacuation_budget = (size_t) (heap->get_old_evac_reserve() / ShenandoahEvacWaste);
+#endif
+
   size_t remaining_old_evacuation_budget = old_evacuation_budget;
   size_t lost_evacuation_capacity = 0;
   log_info(gc)("Choose old regions for mixed collection: old evacuation budget: " SIZE_FORMAT "%s, candidates: %u",
@@ -74,18 +132,48 @@ bool ShenandoahOldHeuristics::prime_collection_set(ShenandoahCollectionSet* coll
 
     // If we choose region r to be collected, then we need to decrease the capacity to hold other evacuations by
     // the size of r's free memory.
+#ifdef KELVIN_RETREAT
+    if ((r->get_live_data_bytes() <= remaining_old_evacuation_budget) &&
+        ((lost_evacuation_capacity + r->free() <= excess_old_capacity_for_evacuation)
+         || (r->get_live_data_bytes() + r->free() <= remaining_old_evacuation_budget))) {
+      if (r->get_live_data_bytes() > remaining_old_evacuation_budget) {
+        printf("DEVIANT BEHAVIOR DETECTED: original code would include region " SIZE_FORMAT ", but new code does not\n",
+               r->index());
+      }
+#else
     if (r->get_live_data_bytes() <= remaining_old_evacuation_budget) {
+#endif
       // Decrement remaining evacuation budget by bytes that will be copied.  If the cumulative loss of free memory from
       // regions that are to be collected exceeds excess_old_capacity_for_evacuation,  decrease
       // remaining_old_evacuation_budget by this loss as well.
       lost_evacuation_capacity += r->free();
       remaining_old_evacuation_budget -= r->get_live_data_bytes();
+#ifdef KELVIN_RETREAT
+      if (lost_evacuation_capacity > excess_old_capacity_for_evacuation) {
+        // This is slightly conservative because we really only need to remove from the remaining evacuation budget
+        // the amount by which lost_evacution_capacity exceeds excess_old_capacity_for_evacuation, but this is relatively
+        // rare event and current thought is to be a bit conservative rather than mess up the math on code that is so
+        // difficult to test and maintain...
+
+        // Once we have crossed the threshold of lost_evacuation_capacity exceeding excess_old_capacity_for_evacuation,
+        // every subsequent iteration of this loop will further decrease remaining_old_evacuation_budget.
+        printf("NOT SO DEVIANT BEHAVIOR DETECTED: subtracting free [" SIZE_FORMAT "] for region " SIZE_FORMAT
+               " from remaining_old_evacuation_buget: " SIZE_FORMAT "\n", r->free(), r->index(), remaining_old_evacuation_budget);
+        remaining_old_evacuation_budget -= r->free();
+      }
+#endif
       collection_set->add_region(r);
       included_old_regions++;
       evacuated_old_bytes += r->get_live_data_bytes();
       collected_old_bytes += r->garbage();
       consume_old_collection_candidate();
     } else {
+#ifdef KELVIN_RETREAT
+      if (r->get_live_data_bytes() <= remaining_old_evacuation_budget) {
+        printf("DEVIANT BEHAVIOR DETECTED: original code would not include region " SIZE_FORMAT ", but new code does\n",
+               r->index());
+      }
+#endif
       break;
     }
   }

--- a/src/hotspot/share/gc/shenandoah/heuristics/shenandoahOldHeuristics.cpp
+++ b/src/hotspot/share/gc/shenandoah/heuristics/shenandoahOldHeuristics.cpp
@@ -164,7 +164,7 @@ bool ShenandoahOldHeuristics::prime_collection_set(ShenandoahCollectionSet* coll
       }
 #else
     // It's probably overkill to compensate with lost_evacuation_capacity.  But it's the safe thing to do and
-    // probably has little impact on contenty of primed collection set.
+    //  has minimal impact on content of primed collection set.
     if (r->get_live_data_bytes() + lost_evacuation_capacity <= remaining_old_evacuation_budget) {
 #endif
       // Decrement remaining evacuation budget by bytes that will be copied.
@@ -172,7 +172,7 @@ bool ShenandoahOldHeuristics::prime_collection_set(ShenandoahCollectionSet* coll
       remaining_old_evacuation_budget -= r->get_live_data_bytes();
 #ifdef KELVIN_RETREAT
       // KELVIN WANTS TO KEEP THIS CODE IN FINAL REFACTOR: BUT IT'S NOT SO EASY, BECAUSE EXCESS_OLD_CAPACITY_FOR_EVACUATION
-      // IS A CONCEPT ONLY DEFINED UNDER KELVIN_RETREAT CONDITIONAL COPILATION
+      // IS A CONCEPT ONLY DEFINED UNDER KELVIN_RETREAT CONDITIONAL COMPILATION.  SO I DON'T NEED IT AFTER ALL.
       // If the cumulative loss of free memory from
       // regions that are to be collected exceeds excess_old_capacity_for_evacuation,  decrease
       // remaining_old_evacuation_budget by this loss as well.

--- a/src/hotspot/share/gc/shenandoah/shenandoahConcurrentGC.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahConcurrentGC.cpp
@@ -754,7 +754,7 @@ void ShenandoahConcurrentGC::op_final_mark() {
         // loaned for young-gen allocations or evacuations.
         size_t old_available = heap->old_generation()->adjust_available(-heap->get_alloc_supplement_reserve());
 
-        log_info(gc, ergo)("After generational memory budget adjustments, old avaiable: " SIZE_FORMAT
+        log_info(gc, ergo)("After generational memory budget adjustments, old available: " SIZE_FORMAT
                            "%s, young_available: " SIZE_FORMAT "%s",
                            byte_size_in_proper_unit(old_available), proper_unit_for_byte_size(old_available),
                            byte_size_in_proper_unit(young_available), proper_unit_for_byte_size(young_available));

--- a/src/hotspot/share/gc/shenandoah/shenandoahConcurrentGC.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahConcurrentGC.cpp
@@ -158,40 +158,24 @@ bool ShenandoahConcurrentGC::collect(GCCause::Cause cause) {
   // Process weak roots that might still point to regions that would be broken by cleanup
   if (heap->is_concurrent_weak_root_in_progress()) {
     entry_weak_refs();
-#undef KELVIN_CHASE
-#ifdef KELVIN_CHASE
-    log_info(gc, ref)("Done with weak refs, looking at weak roots");
-#endif
     entry_weak_roots();
-#ifdef KELVIN_CHASE
-    log_info(gc, ref)("Done with weak roots");
-#endif
   }
 
   // Final mark might have reclaimed some immediate garbage, kick cleanup to reclaim
   // the space. This would be the last action if there is nothing to evacuate.  Note that
   // we will not age young-gen objects in the case that we skip evacuation.
   entry_cleanup_early();
-#ifdef KELVIN_CHASE
-  log_info(gc, ref)("Done with entry_cleanup_early");
-#endif
 
   {
     ShenandoahHeapLocker locker(heap->lock());
     heap->free_set()->log_status();
   }
-#ifdef KELVIN_CHASE
-  log_info(gc, ref)("Done with free set log_status");
-#endif
 
   // Perform concurrent class unloading
   if (heap->unload_classes() &&
       heap->is_concurrent_weak_root_in_progress()) {
     entry_class_unloading();
   }
-#ifdef KELVIN_CHASE
-  log_info(gc, ref)("Done with class unloading");
-#endif
 
   // Processing strong roots
   // This may be skipped if there is nothing to update/evacuate.
@@ -199,17 +183,11 @@ bool ShenandoahConcurrentGC::collect(GCCause::Cause cause) {
   if (heap->is_concurrent_strong_root_in_progress()) {
     entry_strong_roots();
   }
-#ifdef KELVIN_CHASE
-  log_info(gc, ref)("Done with strong roots");
-#endif
 
   // Global marking has completed. We need to fill in any unmarked objects in the old generation
   // so that subsequent remembered set scans will not walk pointers into reclaimed memory.
   if (!heap->cancelled_gc() && heap->mode()->is_generational() && _generation->generation_mode() == GLOBAL) {
     entry_global_coalesce_and_fill();
-#ifdef KELVIN_CHASE
-    log_info(gc, ref)("Done with entry_global_coalesce_and_fill");
-#endif
   }
 
   // Continue the cycle with evacuation and optional update-refs.

--- a/src/hotspot/share/gc/shenandoah/shenandoahFreeSet.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahFreeSet.cpp
@@ -73,6 +73,14 @@ HeapWord* ShenandoahFreeSet::allocate_with_affiliation(ShenandoahRegionAffiliati
       if (r->affiliation() == affiliation) {
         HeapWord* result = try_allocate_in(r, req, in_new_region);
         if (result != NULL) {
+#undef KELVIN_DESPERADO
+#ifdef KELVIN_DESPERADO
+          // I'm puzzed as to how I can start out a tradishen collection with zero available because
+          // my tlab and shared mutator allocations are supposed to avoid using the gc reserve
+          printf("After allocate_with_affiliation %s of size " SIZE_FORMAT " in new region? %s, young available is: " SIZE_FORMAT "\n",
+                 affiliation_name(affiliation), req.size(), in_new_region? "yes": "no",
+                 _heap->young_generation()->available());
+#endif
           return result;
         }
       }
@@ -105,6 +113,14 @@ HeapWord* ShenandoahFreeSet::allocate_single(ShenandoahAllocRequest& req, bool& 
           // try_allocate_in() increases used if the allocation is successful.
           HeapWord* result = try_allocate_in(_heap->get_region(idx), req, in_new_region);
           if (result != NULL) {
+#ifdef KELVIN_DESPERADO
+            // I'm puzzed as to how I can start out a tradishen collection with zero available because
+            // my tlab and shared mutator allocations are supposed to avoid using the gc reserve
+            printf("After allocate_single of %s size " SIZE_FORMAT " for region " SIZE_FORMAT " between mutator_left " SIZE_FORMAT
+                   " amd mutator_right " SIZE_FORMAT ", in new region? %s, available is: " SIZE_FORMAT "\n",
+                   (req.type() == ShenandoahAllocRequest::_alloc_tlab)? "TLAB": "Shared", req.size(), idx, _mutator_leftmost,
+                   _mutator_rightmost, in_new_region? "yes": "no", _heap->young_generation()->available());
+#endif
             return result;
           }
         }
@@ -350,6 +366,10 @@ void ShenandoahFreeSet::recompute_bounds() {
 
 void ShenandoahFreeSet::adjust_bounds() {
   // Rewind both mutator bounds until the next bit.
+#ifdef KELVIN_DESPERADO
+  printf("At adjust_bounds, _mutator [" SIZE_FORMAT " , " SIZE_FORMAT "], _collector [" SIZE_FORMAT ", " SIZE_FORMAT "], _max: " SIZE_FORMAT "\n",
+         _mutator_leftmost, _mutator_rightmost, _collector_leftmost, _collector_rightmost, _max);
+#endif
   while (_mutator_leftmost < _max && !is_mutator_free(_mutator_leftmost)) {
     _mutator_leftmost++;
   }
@@ -363,6 +383,10 @@ void ShenandoahFreeSet::adjust_bounds() {
   while (_collector_rightmost > 0 && !is_collector_free(_collector_rightmost)) {
     _collector_rightmost--;
   }
+#ifdef KELVIN_DESPERADO
+  printf("After adjust_bounds, _mutator [" SIZE_FORMAT " , " SIZE_FORMAT "], _collector [" SIZE_FORMAT ", " SIZE_FORMAT "]\n",
+         _mutator_leftmost, _mutator_rightmost, _collector_leftmost, _collector_rightmost);
+#endif
 }
 
 HeapWord* ShenandoahFreeSet::allocate_contiguous(ShenandoahAllocRequest& req) {
@@ -468,6 +492,15 @@ HeapWord* ShenandoahFreeSet::allocate_contiguous(ShenandoahAllocRequest& req) {
     adjust_bounds();
   }
   assert_bounds();
+
+#ifdef KELVIN_DESPERADO
+  // I'm puzzed as to how I can start out a tradishen collection with zero available because
+  // my tlab and shared mutator allocations are supposed to avoid using the gc reserve
+  // BTW, I think affiliation is always going to be young because we promote humongous by relabel.
+  printf("After allocate_contiguous of size " SIZE_FORMAT " spanning regions " SIZE_FORMAT " to " SIZE_FORMAT
+         ", young available is: " SIZE_FORMAT "\n",
+         req.size(), beg, end, _heap->young_generation()->available());
+#endif
 
   req.set_actual_size(words_size);
   return _heap->get_region(beg)->bottom();
@@ -575,12 +608,21 @@ void ShenandoahFreeSet::rebuild() {
   // Evac reserve: reserve trailing space for evacuations
   if (!_heap->mode()->is_generational()) {
     size_t to_reserve = (_heap->max_capacity() / 100) * ShenandoahEvacReserve;
+#ifdef KELVIN_DESPERADO
+    printf("Rebuilding FreeSet with reserve: " SIZE_FORMAT ", free_set capacity: " SIZE_FORMAT "\n", to_reserve, _capacity);
+#endif
     reserve_regions(to_reserve);
+#ifdef KELVIN_DESPERADO
+    printf(" After reserve, free_set capacity: " SIZE_FORMAT "\n", _capacity);
+    _heap->young_generation()->available();  // side effect of call prints current value
+#endif
   } else {
     size_t young_reserve = (_heap->young_generation()->max_capacity() / 100) * ShenandoahEvacReserve;
-    // size_t old_reserve = (_heap->old_generation()->max_capacity() / 100) * ShenandoahOldEvacReserve;
-    // In order to enable regions to be loaned from old-gen to young-gen, we do not reserve old-gen regions.
-    // Enforcement of ShenandoahOldEvacReserve does not require ShenandoahnFreeSet involvement.
+    // Note that all allocations performed from old-gen are performed by GC, generally using PLABs for both
+    // promotions and evacuations.  The partition between which old memory is reserved for evacuation and
+    // which is reserved for promotion is enforced using thread-local variables that prescribe intentons within
+    // each PLAB.  We do not reserve any of old-gen memory in order to facilitate the loaning of old-gen memory
+    // to young-gen purposes.
     size_t old_reserve = 0;
     size_t to_reserve = young_reserve + old_reserve;
     reserve_regions(to_reserve);

--- a/src/hotspot/share/gc/shenandoah/shenandoahFreeSet.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahFreeSet.cpp
@@ -578,7 +578,10 @@ void ShenandoahFreeSet::rebuild() {
     reserve_regions(to_reserve);
   } else {
     size_t young_reserve = (_heap->young_generation()->max_capacity() / 100) * ShenandoahEvacReserve;
-    size_t old_reserve = (_heap->old_generation()->max_capacity() / 100) * ShenandoahOldEvacReserve;
+    // size_t old_reserve = (_heap->old_generation()->max_capacity() / 100) * ShenandoahOldEvacReserve;
+    // In order to enable regions to be loaned from old-gen to young-gen, we do not reserve old-gen regions.
+    // Enforcement of ShenandoahOldEvacReserve does not require ShenandoahnFreeSet involvement.
+    size_t old_reserve = 0;
     size_t to_reserve = young_reserve + old_reserve;
     reserve_regions(to_reserve);
   }

--- a/src/hotspot/share/gc/shenandoah/shenandoahGeneration.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahGeneration.cpp
@@ -436,7 +436,7 @@ void ShenandoahGeneration::adjust_evacuation_budgets(ShenandoahHeap* heap, Shena
     assert(consumed_by_advance_promotion <= (collection_set->get_young_bytes_to_be_promoted() * ShenandoahEvacWaste * 33) / 32,
            "Round-off errors should be less than 3.125%%, consumed by advance: " SIZE_FORMAT ", promoted: " SIZE_FORMAT,
            consumed_by_advance_promotion, (size_t) (collection_set->get_young_bytes_to_be_promoted() * ShenandoahEvacWaste));
-  
+
     collection_set->abandon_preselected();
     if (old_evacuated_committed > old_evacuation_reserve) {
       // This should only happen due to round-off errors when enforcing ShenandoahEvacWaste
@@ -520,7 +520,7 @@ void ShenandoahGeneration::adjust_evacuation_budgets(ShenandoahHeap* heap, Shena
                                                 old_bytes_loaned_for_young_evac + old_bytes_reserved_for_alloc_supplement);
 
     // We experimented with constraining promoted_reserve to be no larger than 4 times the size of previously_promoted,
-    // but this constraint was too limiting, resulting in failure of legitimate promotions.  This was tried before we 
+    // but this constraint was too limiting, resulting in failure of legitimate promotions.  This was tried before we
     // had special handling in place for advance promotion.  We should retry now that advance promotion is handled
     // specially.
 
@@ -608,7 +608,7 @@ void ShenandoahGeneration::adjust_evacuation_budgets(ShenandoahHeap* heap, Shena
                   proper_unit_for_byte_size(young_evacuated_reserve_used),
                   byte_size_in_proper_unit(young_evacuated), proper_unit_for_byte_size(young_evacuated),
                   byte_size_in_proper_unit(young_available), proper_unit_for_byte_size(young_available));
-  
+
     log_debug(gc)("Memory reserved for old evacuation: " SIZE_FORMAT "%s for evacuating " SIZE_FORMAT
                   "%s out of old available: " SIZE_FORMAT "%s",
                   byte_size_in_proper_unit(old_evacuated), proper_unit_for_byte_size(old_evacuated),

--- a/src/hotspot/share/gc/shenandoah/shenandoahGeneration.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahGeneration.cpp
@@ -221,7 +221,7 @@ void ShenandoahGeneration::prepare_gc(bool do_old_gc_bootstrap) {
   }
 }
 
-void  ShenandoahGeneration::prepare_regions_and_collection_set(bool concurrent) {
+void ShenandoahGeneration::prepare_regions_and_collection_set(bool concurrent) {
   ShenandoahHeap* heap = ShenandoahHeap::heap();
   ShenandoahCollectionSet* collection_set = heap->collection_set();
   size_t region_size_bytes = ShenandoahHeapRegion::region_size_bytes();
@@ -247,12 +247,13 @@ void  ShenandoahGeneration::prepare_regions_and_collection_set(bool concurrent) 
     ShenandoahGCPhase phase(concurrent ? ShenandoahPhaseTimings::choose_cset :
                             ShenandoahPhaseTimings::degen_gc_choose_cset);
     ShenandoahHeapLocker locker(heap->lock());
-    heap->collection_set()->clear();
+    collection_set->clear();
 
     size_t minimum_evacuation_reserve = ShenandoahOldCompactionReserve * region_size_bytes;
     size_t avail_evac_reserve_for_loan_to_young_gen = 0;
     size_t old_regions_loaned_for_young_evac = 0;
     size_t regions_available_to_loan = 0;
+
     size_t old_evacuation_reserve = 0;
     size_t num_regions = heap->num_regions();
     size_t consumed_by_advance_promotion = 0;

--- a/src/hotspot/share/gc/shenandoah/shenandoahGeneration.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahGeneration.cpp
@@ -542,7 +542,15 @@ void ShenandoahGeneration::adjust_evacuation_budgets(ShenandoahHeap* heap, Shena
     }
 
     size_t allocation_supplement = regions_for_runway * region_size_bytes;
+#ifdef KELVIN_RETREAT
+    if (heap->get_alloc_supplement_reserve() != allocation_supplement) {
+      printf("DEVIANT BEHAVIOR DETECTED: get_alloc_supplement_reserve() [" SIZE_FORMAT "] != allocation_supplement ["
+             SIZE_FORMAT "]\n", heap->get_alloc_supplement_reserve(), allocation_supplement);
+    }
+#else
+    // squelching this for right now, because we seem to run better with different allocation_supplement
     heap->set_alloc_supplement_reserve(allocation_supplement);
+#endif
 
     size_t promotion_budget = heap->get_promoted_reserve();
     size_t old_evac_budget = heap->get_old_evac_reserve();

--- a/src/hotspot/share/gc/shenandoah/shenandoahGeneration.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahGeneration.cpp
@@ -221,6 +221,351 @@ void ShenandoahGeneration::prepare_gc(bool do_old_gc_bootstrap) {
   }
 }
 
+void ShenandoahGeneration::compute_evacuation_budgets(ShenandoahHeap* heap, ShenandoahCollectionSet* collection_set,
+                                                      size_t &old_regions_loaned_for_young_evac, size_t &regions_available_to_loan,
+                                                      size_t &minimum_evacuation_reserve, size_t &consumed_by_advance_promotion) {
+  size_t region_size_bytes = ShenandoahHeapRegion::region_size_bytes();
+  minimum_evacuation_reserve = ShenandoahOldCompactionReserve * region_size_bytes;
+  old_regions_loaned_for_young_evac = 0;
+  regions_available_to_loan = 0;
+  consumed_by_advance_promotion = 0;
+  if (heap->mode()->is_generational()) {
+    ShenandoahGeneration* old_generation = heap->old_generation();
+    ShenandoahYoungGeneration* young_generation = heap->young_generation();
+    size_t avail_evac_reserve_for_loan_to_young_gen = 0;
+    size_t old_evacuation_reserve = 0;
+    size_t num_regions = heap->num_regions();
+    bool preselected_regions[num_regions];
+    for (unsigned int i = 0; i < num_regions; i++) {
+      preselected_regions[i] = false;
+    }
+
+    // During initialization and phase changes, it is more likely that fewer objects die young and old-gen
+    // memory is not yet full (or is in the process of being replaced).  During these times especially, it
+    // is beneficial to loan memory from old-gen to young-gen during the evacuation and update-refs phases
+    // of execution.
+
+    // Calculate EvacuationReserve before PromotionReserve.  Evacuation is more critical than promotion.
+    // If we cannot evacuate old-gen, we will not be able to reclaim old-gen memory.  Promotions are less
+    // critical.  If we cannot promote, there may be degradation of young-gen memory because old objects
+    // accumulate there until they can be promoted.  This increases the young-gen marking and evacuation work.
+
+    // Do not fill up old-gen memory with promotions.  Reserve some amount of memory for compaction purposes.
+    ShenandoahOldHeuristics* old_heuristics = heap->old_heuristics();
+    if (old_heuristics->unprocessed_old_collection_candidates() > 0) {
+      // Compute old_evacuation_reserve: how much memory are we reserving to hold the results of
+      // evacuating old-gen heap regions?  In order to sustain a consistent pace of young-gen collections,
+      // the goal is to maintain a consistent value for this parameter (when the candidate set is not
+      // empty).  This value is the minimum of:
+      //   1. old_gen->available()
+      //   2. old-gen->capacity() * ShenandoahOldEvacReserve) / 100
+      //       (e.g. old evacuation should be no larger than 5% of old_gen capacity)
+      //   3. ((young_gen->capacity * ShenandoahEvacReserve / 100) * ShenandoahOldEvacRatioPercent) / 100
+      //       (e.g. old evacuation should be no larger than 12% of young-gen evacuation)
+      old_evacuation_reserve = old_generation->available();
+      assert(old_evacuation_reserve > minimum_evacuation_reserve, "Old-gen available has not been preserved!");
+      size_t old_evac_reserve_max = old_generation->soft_max_capacity() * ShenandoahOldEvacReserve / 100;
+      if (old_evac_reserve_max < old_evacuation_reserve) {
+        old_evacuation_reserve = old_evac_reserve_max;
+      }
+      size_t young_evac_reserve_max =
+        (((young_generation->soft_max_capacity() * ShenandoahEvacReserve) / 100) * ShenandoahOldEvacRatioPercent) / 100;
+      if (young_evac_reserve_max < old_evacuation_reserve) {
+        old_evacuation_reserve = young_evac_reserve_max;
+      }
+    }
+
+    if (minimum_evacuation_reserve > old_generation->available()) {
+      // Due to round-off errors during enforcement of minimum_evacuation_reserve during previous GC passes,
+      // there can be slight discrepancies here.
+      minimum_evacuation_reserve = old_generation->available();
+    }
+    if (old_evacuation_reserve < minimum_evacuation_reserve) {
+      // Even if there's nothing to be evacuated on this cycle, we still need to reserve this memory for future
+      // evacuations.  It is ok to loan this memory to young-gen if we don't need it for evacuation on this pass.
+      avail_evac_reserve_for_loan_to_young_gen = minimum_evacuation_reserve - old_evacuation_reserve;
+      old_evacuation_reserve = minimum_evacuation_reserve;
+    }
+
+    heap->set_old_evac_reserve(old_evacuation_reserve);
+    heap->reset_old_evac_expended();
+
+    // Compute the young evauation reserve: This is how much memory is available for evacuating young-gen objects.
+    // We ignore the possible effect of promotions, which reduce demand for young-gen evacuation memory.
+    //
+    // TODO: We could give special treatment to the regions that have reached promotion age, because we know their
+    // live data is entirely eligible for promotion.  This knowledge can feed both into calculations of young-gen
+    // evacuation reserve and promotion reserve.
+    //
+    //  young_evacuation_reserve for young generation: how much memory are we reserving to hold the results
+    //  of evacuating young collection set regions?  This is typically smaller than the total amount
+    //  of available memory, and is also smaller than the total amount of marked live memory within
+    //  young-gen.  This value is the smaller of
+    //
+    //    1. (young_gen->capacity() * ShenandoahEvacReserve) / 100
+    //    2. (young_gen->available() + old_gen_memory_available_to_be_loaned
+    //
+    //  ShenandoahEvacReserve represents the configured taget size of the evacuation region.  We can only honor
+    //  this target if there is memory available to hold the evacuations.  Memory is available if it is already
+    //  free within young gen, or if it can be borrowed from old gen.  Since we have not yet chosen the collection
+    //  sets, we do not yet know the exact accounting of how many regions will be freed by this collection pass.
+    //  What we do know is that there will be at least one evacuated young-gen region for each old-gen region that
+    //  is loaned to the evacuation effort (because regions to be collected consume more memory than the compacted
+    //  regions that will replace them).  In summary, if there are old-gen regions that are available to hold the
+    //  results of young-gen evacuations, it is safe to loan them for this purpose.  At this point, we have not yet
+    //  established a promoted_reserve.  We'll do that after we choose the collection set and analyze its impact
+    //  on available memory.
+    //
+    // We do not know the evacuation_supplement until after we have computed the collection set.  It is not always
+    // the case that young-regions inserted into the collection set will result in net decrease of in-use regions
+    // because ShenandoahEvacWaste times multiplied by memory within the region may be larger than the region size.
+    // The problem is especially relevant to regions that have been inserted into the collection set because they have
+    // reached tenure age.  These regions tend to have much higher utilization (e.g. 95%).  These regions also offer
+    // a unique opportunity because we know that every live object contained within the region is elgible to be
+    // promoted.  Thus, the following implementation treats these regions specially:
+    //
+    //  1. Before beginning collection set selection, we tally the total amount of live memory held within regions
+    //     that are known to have reached tenure age.  If this memory times ShenandoahEvacWaste is available within
+    //     old-gen memory, establish an advance promotion reserve to hold all or some percentage of these objects.
+    //     This advance promotion reserve is excluded from memory available for holding old-gen evacuations and cannot
+    //     be "loaned" to young gen.
+    //
+    //  2. Tenure-aged regions are included in the collection set iff their evacuation size * ShenandoahEvacWaste fits
+    //     within the advance promotion reserve.  It is counter productive to evacuate these regions if they cannot be
+    //     evacuated directly into old-gen memory.  So if there is not sufficient memory to hold copies of their
+    //     live data right now, we'll just let these regions remain in young for now, to be evacuated by a subsequent
+    //     evacuation pass.
+    //
+    //  3. Next, we calculate a young-gen evacuation budget, which is the smaller of the two quantities mentioned
+    //     above.  old_gen_memory_available_to_be_loaned is calculated as:
+    //       old_gen->available - (advance-promotion-reserve + old-gen_evacuation_reserve)
+    //
+    //  4. When choosing the collection set, special care is taken to assure that the amount of loaned memory required to
+    //     hold the results of evacuation is smaller than the total memory occupied by the regions added to the collection
+    //     set.  We need to take these precautions because we do not know how much memory will be reclaimed by evacuation
+    //     until after the collection set has been constructed.  The algorithm is as follows:
+    //
+    //     a. We feed into the algorithm (i) young available at the start of evacuation and (ii) the amount of memory
+    //        loaned from old-gen that is available to hold the results of evacuation.
+    //     b. As candidate regions are added into the young-gen collection set, we maintain accumulations of the amount
+    //        of memory spanned by the collection set regions and the amount of memory that must be reserved to hold
+    //        evacuation results (by multiplying live-data size by ShenandoahEvacWaste).  We process candidate regions
+    //        in order of decreasing amounts of garbage.  We skip over (and do not include into the collection set) any
+    //        regions that do not satisfy all of the following conditions:
+    //
+    //          i. The amount of live data within the region as scaled by ShenandoahEvacWaste must fit within the
+    //             relevant evacuation reserve (live data of old-gen regions must fit within the old-evac-reserve, live
+    //             data of young-gen tenure-aged regions must fit within the advance promotion reserve, live data within
+    //             other young-gen regions must fit within the youn-gen evacuation reserve).
+    //         ii. The accumulation of memory consumed by evacuation must not exceed the accumulation of memory reclaimed
+    //             through evacuation by more than young-gen available.
+    //        iii. Other conditions may be enforced as appropriate for specific heuristics.
+    //
+    //       Note that regions are considered for inclusion in the selection set in order of decreasing amounts of garbage.
+    //       It is possible that a region with a larger amount of garbage will be rejected because it also has a larger
+    //       amount of live data and some region that follows this region in candidate order is included in the collection
+    //       set (because it has less live data and thus can fit within the evacuation limits even though it has less
+    //       garbage).
+
+    size_t young_evacuation_reserve = (young_generation->max_capacity() * ShenandoahEvacReserve) / 100;
+    // old evacuation can pack into existing partially used regions.  young evacuation and loans for young allocations
+    // need to target regions that do not already hold any old-gen objects.  Round down.
+    regions_available_to_loan = old_generation->free_unaffiliated_regions();
+    consumed_by_advance_promotion = _heuristics->select_aged_regions(old_generation->available() - old_evacuation_reserve,
+                                                                     num_regions, preselected_regions);
+    size_t net_available_old_regions =
+      (old_generation->available() - old_evacuation_reserve - consumed_by_advance_promotion) / region_size_bytes;
+
+    if (regions_available_to_loan > net_available_old_regions) {
+      regions_available_to_loan = net_available_old_regions;
+    }
+    // Otherwise, regions_available_to_loan is less than net_available_old_regions because available memory is
+    // scattered between multiple partially used regions.
+
+    if (young_evacuation_reserve > young_generation->available()) {
+      size_t short_fall = young_evacuation_reserve - young_generation->available();
+      if (regions_available_to_loan * region_size_bytes >= short_fall) {
+        old_regions_loaned_for_young_evac = (short_fall + region_size_bytes - 1) / region_size_bytes;
+        regions_available_to_loan -= old_regions_loaned_for_young_evac;
+      } else {
+        old_regions_loaned_for_young_evac = regions_available_to_loan;
+        regions_available_to_loan = 0;
+        young_evacuation_reserve = young_generation->available() + old_regions_loaned_for_young_evac * region_size_bytes;
+      }
+    } else {
+      old_regions_loaned_for_young_evac = 0;
+    }
+    // In generational mode, we may end up choosing a young collection set that contains so many promotable objects
+    // that there is not sufficient space in old generation to hold the promoted objects.  That is ok because we have
+    // assured there is sufficient space in young generation to hold the rejected promotion candidates.  These rejected
+    // promotion candidates will presumably be promoted in a future evacuation cycle.
+    heap->set_young_evac_reserve(young_evacuation_reserve);
+    collection_set->establish_preselected(preselected_regions);
+  } else {
+    // Not generational mode: limit young evac reserve by young available; no need to establish old_evac_reserve.
+    ShenandoahYoungGeneration* young_generation = heap->young_generation();
+    size_t young_evac_reserve = (young_generation->soft_max_capacity() * ShenandoahEvacReserve) / 100;
+    if (young_evac_reserve > young_generation->available()) {
+      young_evac_reserve = young_generation->available();
+    }
+    heap->set_young_evac_reserve(young_evac_reserve);
+  }
+}
+
+// Having chosen the collection set, adjust the budgets for generatioal mode based on its composition.  Note
+// that young_generation->available() now knows about recently discovered immediate garbage.
+void ShenandoahGeneration::adjust_evacuation_budgets(ShenandoahHeap* heap, ShenandoahCollectionSet* collection_set,
+                                                     size_t old_regions_loaned_for_young_evac, size_t regions_available_to_loan,
+                                                     size_t minimum_evacuation_reserve, size_t consumed_by_advance_promotion) {
+  if (heap->mode()->is_generational()) {
+    size_t region_size_bytes = ShenandoahHeapRegion::region_size_bytes();
+    ShenandoahGeneration* old_generation = heap->old_generation();
+    ShenandoahYoungGeneration* young_generation = heap->young_generation();
+    size_t old_evacuation_committed = (size_t) (ShenandoahEvacWaste *
+                                                collection_set->get_old_bytes_reserved_for_evacuation());
+    size_t old_evacuation_reserve = heap->get_old_evac_reserve();
+    size_t immediate_garbage_regions = collection_set->get_immediate_trash() / region_size_bytes;
+
+    collection_set->abandon_preselected();
+    if (old_evacuation_committed > old_evacuation_reserve) {
+      // This should only happen due to round-off errors when enforcing ShenandoahEvacWaste
+      assert(old_evacuation_committed < (33 * old_evacuation_reserve) / 32, "Round-off errors should be less than 3.125%%");
+      old_evacuation_committed = old_evacuation_reserve;
+    }
+
+    // Recompute old_regions_loaned_for_young_evac because young-gen collection set may not need all the memory
+    // originally reserved.
+    size_t young_evacuation_reserve_used =
+      collection_set->get_young_bytes_reserved_for_evacuation() - collection_set->get_young_bytes_to_be_promoted();
+    young_evacuation_reserve_used = (size_t) (ShenandoahEvacWaste * young_evacuation_reserve_used);
+    heap->set_young_evac_reserve(young_evacuation_reserve_used);
+
+    // Adjust old_regions_loaned_for_young_evac to feed into calculations of promoted_reserve
+    if (young_evacuation_reserve_used > young_generation->available()) {
+      size_t short_fall = young_evacuation_reserve_used - young_generation->available();
+
+      // region_size_bytes is a power of 2.  loan an integral number of regions.
+      size_t revised_loan_for_young_evacuation = (short_fall + region_size_bytes - 1) / region_size_bytes;
+
+      // Undo the previous loan
+      regions_available_to_loan += old_regions_loaned_for_young_evac;
+      old_regions_loaned_for_young_evac = revised_loan_for_young_evacuation;
+      // And make a new loan
+      assert(regions_available_to_loan > old_regions_loaned_for_young_evac, "Cannot loan regions that we do not have");
+      regions_available_to_loan -= old_regions_loaned_for_young_evac;
+    } else {
+      // Undo the prevous loan
+      regions_available_to_loan += old_regions_loaned_for_young_evac;
+      old_regions_loaned_for_young_evac = 0;
+    }
+
+    size_t old_bytes_loaned = old_regions_loaned_for_young_evac * region_size_bytes;
+    // Need to enforce that old_evacuation_committed + old_bytes_loaned >= minimum_evacuation_reserve
+    // in order to prevent promotion reserve from violating minimum evacuation reserve.
+    if (old_evacuation_committed + old_bytes_loaned < minimum_evacuation_reserve) {
+      // Pretend the old_evacuation_commitment is larger than what will be evacuated to assure that promotions
+      // do not fill the minimum_evacuation_reserve.  Note that regions loaned from old-gen will be returned
+      // to old-gen before we start a subsequent evacuation.
+      old_evacuation_committed = minimum_evacuation_reserve - old_bytes_loaned;
+    }
+
+    // Limit promoted_reserve so that we can set aside memory to be loaned from old-gen to young-gen.  This
+    // value is not "critical".  If we underestimate, certain promotions will simply be deferred.  If we put
+    // "all the rest" of old-gen memory into the promotion reserve, we'll have nothing left to loan to young-gen
+    // during the evac and update phases of GC.  So we "limit" the sizes of the promotion budget to be the smaller of:
+    //
+    //  1. old_gen->available - (old_evacuation_committed + old_bytes_loaned + consumed_by_advance_promotion)
+    //  2. young bytes reserved for evacuation
+
+    assert(old_generation->available() > old_evacuation_committed, "Cannot evacuate more than available");
+    assert(old_generation->available() > old_evacuation_committed + old_bytes_loaned, "Cannot loan more than available");
+    assert(old_generation->available() > old_evacuation_committed + old_bytes_loaned + consumed_by_advance_promotion,
+           "Cannot promote more than available");
+
+    size_t old_avail = old_generation->available();
+    size_t promotion_reserve = old_avail - (old_evacuation_committed + consumed_by_advance_promotion + old_bytes_loaned);
+
+    // We experimented with constraining promoted_reserve to be no larger than 4 times the size of previously_promoted,
+    // but this constraint was too limiting, resulting in failure of legitimate promotions.
+
+    // We had also experimented with constraining promoted_reserve to be no more than young_evacuation_committed
+    // divided by promotion_divisor, where:
+    //  size_t promotion_divisor = (0x02 << InitialTenuringThreshold) - 1;
+    // This also was found to be too limiting, resulting in failure of legitimate promotions.
+    //
+    // Both experiments were conducted in the presence of other bugs which could have been the root cause for
+    // the failures identified above as being "too limiting".  TODO: conduct new experiments with the more limiting
+    // values of young_evacuation_reserved_used.
+    young_evacuation_reserve_used -= consumed_by_advance_promotion;
+    if (young_evacuation_reserve_used < promotion_reserve) {
+      // Shrink promotion_reserve if its larger than the memory to be consumed by evacuating all young objects in
+      // collection set, including anticipated waste.  There's no benefit in using a larger promotion_reserve.
+      promotion_reserve = young_evacuation_reserve_used;
+    }
+
+    assert(old_avail >= promotion_reserve + old_evacuation_committed + old_bytes_loaned + consumed_by_advance_promotion,
+           "Budget exceeds available old-gen memory");
+    log_info(gc, ergo)("Old available: " SIZE_FORMAT ", Original promotion reserve: " SIZE_FORMAT ", Old evacuation reserve: "
+                       SIZE_FORMAT ", Advance promotion reserve supplement: " SIZE_FORMAT ", Old loaned to young: " SIZE_FORMAT,
+                       old_avail, promotion_reserve, old_evacuation_committed, consumed_by_advance_promotion,
+                       old_regions_loaned_for_young_evac * region_size_bytes);
+    promotion_reserve += consumed_by_advance_promotion;
+    heap->set_promoted_reserve(promotion_reserve);
+    heap->reset_promoted_expended();
+    if (collection_set->get_old_bytes_reserved_for_evacuation() == 0) {
+      // Setting old evacuation reserve to zero denotes that there is no old-gen evacuation in this pass.
+      heap->set_old_evac_reserve(0);
+    }
+
+    size_t old_gen_usage_base = old_generation->used() - collection_set->get_old_garbage();
+    heap->capture_old_usage(old_gen_usage_base);
+
+    // Compute the evacuation supplement, which is extra memory borrowed from old-gen that can be allocated
+    // by mutators while GC is working on evacuation and update-refs.  This memory can be temporarily borrowed
+    // from old-gen allotment, then repaid at the end of update-refs from the recycled collection set.  After
+    // we have computed the collection set based on the parameters established above, we can make additional
+    // loans based on our knowledge of the collection set to determine how much allocation we can allow
+    // during the evacuation and update-refs phases of execution.  The total available supplement is the smaller of:
+    //
+    //   1. old_gen->available() -
+    //        (promotion_reserve + old_evacuation_commitment + old_bytes_loaned)
+    //   2. The replenishment budget (number of regions in collection set - the number of regions already
+    //         under lien for the young_evacuation_reserve)
+    //
+
+    size_t young_regions_evacuated = collection_set->get_young_region_count();
+    size_t regions_for_runway = 0;
+    if (young_regions_evacuated > old_regions_loaned_for_young_evac) {
+      regions_for_runway = young_regions_evacuated - old_regions_loaned_for_young_evac;
+      old_regions_loaned_for_young_evac = young_regions_evacuated;
+      regions_available_to_loan -= regions_for_runway;
+    }
+
+    size_t allocation_supplement = regions_for_runway * region_size_bytes;
+    heap->set_alloc_supplement_reserve(allocation_supplement);
+
+    size_t promotion_budget = heap->get_promoted_reserve();
+    size_t old_evac_budget = heap->get_old_evac_reserve();
+    size_t alloc_budget_evac_and_update = allocation_supplement + young_generation->available();
+
+    // TODO: young_available, which feeds into alloc_budget_evac_and_update is lacking memory available within
+    // existing young-gen regions that were not selected for the collection set.  Add this in and adjust the
+    // log message (where it says "empty-region allocation budget").
+
+    log_info(gc, ergo)("Memory reserved for evacuation and update-refs includes promotion budget: " SIZE_FORMAT
+                       "%s, young evacuation budget: " SIZE_FORMAT "%s, old evacuation budget: " SIZE_FORMAT
+                       "%s, empty-region allocation budget: " SIZE_FORMAT "%s, including supplement: " SIZE_FORMAT "%s",
+                       byte_size_in_proper_unit(promotion_budget), proper_unit_for_byte_size(promotion_budget),
+                       byte_size_in_proper_unit(young_evacuation_reserve_used),
+                       proper_unit_for_byte_size(young_evacuation_reserve_used),
+                       byte_size_in_proper_unit(old_evac_budget), proper_unit_for_byte_size(old_evac_budget),
+                       byte_size_in_proper_unit(alloc_budget_evac_and_update),
+                       proper_unit_for_byte_size(alloc_budget_evac_and_update),
+                       byte_size_in_proper_unit(allocation_supplement), proper_unit_for_byte_size(allocation_supplement));
+  }
+  // else, not generational: no evacuation budget adjustments required
+}
+
 void ShenandoahGeneration::prepare_regions_and_collection_set(bool concurrent) {
   ShenandoahHeap* heap = ShenandoahHeap::heap();
   ShenandoahCollectionSet* collection_set = heap->collection_set();
@@ -244,199 +589,11 @@ void ShenandoahGeneration::prepare_regions_and_collection_set(bool concurrent) {
   }
 
   {
+    size_t old_regions_loaned_for_young_evac, regions_available_to_loan, minimum_evacuation_reserve, consumed_by_advance_promotion;
     ShenandoahGCPhase phase(concurrent ? ShenandoahPhaseTimings::choose_cset :
                             ShenandoahPhaseTimings::degen_gc_choose_cset);
     ShenandoahHeapLocker locker(heap->lock());
     collection_set->clear();
-
-    size_t minimum_evacuation_reserve = ShenandoahOldCompactionReserve * region_size_bytes;
-    size_t avail_evac_reserve_for_loan_to_young_gen = 0;
-    size_t old_regions_loaned_for_young_evac = 0;
-    size_t regions_available_to_loan = 0;
-
-    size_t old_evacuation_reserve = 0;
-    size_t num_regions = heap->num_regions();
-    size_t consumed_by_advance_promotion = 0;
-    bool preselected_regions[num_regions];
-    for (unsigned int i = 0; i < num_regions; i++) {
-      preselected_regions[i] = false;
-    }
-    if (heap->mode()->is_generational()) {
-      ShenandoahGeneration* old_generation = heap->old_generation();
-      ShenandoahYoungGeneration* young_generation = heap->young_generation();
-
-      // During initialization and phase changes, it is more likely that fewer objects die young and old-gen
-      // memory is not yet full (or is in the process of being replaced).  During these times especially, it
-      // is beneficial to loan memory from old-gen to young-gen during the evacuation and update-refs phases
-      // of execution.
-
-      // Calculate EvacuationReserve before PromotionReserve.  Evacuation is more critical than promotion.
-      // If we cannot evacuate old-gen, we will not be able to reclaim old-gen memory.  Promotions are less
-      // critical.  If we cannot promote, there may be degradation of young-gen memory because old objects
-      // accumulate there until they can be promoted.  This increases the young-gen marking and evacuation work.
-
-      // Do not fill up old-gen memory with promotions.  Reserve some amount of memory for compaction purposes.
-      ShenandoahOldHeuristics* old_heuristics = heap->old_heuristics();
-      if (old_heuristics->unprocessed_old_collection_candidates() > 0) {
-
-        // Compute old_evacuation_reserve: how much memory are we reserving to hold the results of
-        // evacuating old-gen heap regions?  In order to sustain a consistent pace of young-gen collections,
-        // the goal is to maintain a consistent value for this parameter (when the candidate set is not
-        // empty).  This value is the minimum of:
-        //   1. old_gen->available()
-        //   2. old-gen->capacity() * ShenandoahOldEvacReserve) / 100
-        //       (e.g. old evacuation should be no larger than 5% of old_gen capacity)
-        //   3. ((young_gen->capacity * ShenandoahEvacReserve / 100) * ShenandoahOldEvacRatioPercent) / 100
-        //       (e.g. old evacuation should be no larger than 12% of young-gen evacuation)
-
-        old_evacuation_reserve = old_generation->available();
-        assert(old_evacuation_reserve > minimum_evacuation_reserve, "Old-gen available has not been preserved!");
-        size_t old_evac_reserve_max = old_generation->soft_max_capacity() * ShenandoahOldEvacReserve / 100;
-        if (old_evac_reserve_max < old_evacuation_reserve) {
-          old_evacuation_reserve = old_evac_reserve_max;
-        }
-        size_t young_evac_reserve_max =
-          (((young_generation->soft_max_capacity() * ShenandoahEvacReserve) / 100) * ShenandoahOldEvacRatioPercent) / 100;
-        if (young_evac_reserve_max < old_evacuation_reserve) {
-          old_evacuation_reserve = young_evac_reserve_max;
-        }
-      }
-
-      if (minimum_evacuation_reserve > old_generation->available()) {
-        // Due to round-off errors during enforcement of minimum_evacuation_reserve during previous GC passes,
-        // there can be slight discrepancies here.
-        minimum_evacuation_reserve = old_generation->available();
-      }
-      if (old_evacuation_reserve < minimum_evacuation_reserve) {
-        // Even if there's nothing to be evacuated on this cycle, we still need to reserve this memory for future
-        // evacuations.  It is ok to loan this memory to young-gen if we don't need it for evacuation on this pass.
-        avail_evac_reserve_for_loan_to_young_gen = minimum_evacuation_reserve - old_evacuation_reserve;
-        old_evacuation_reserve = minimum_evacuation_reserve;
-      }
-
-      heap->set_old_evac_reserve(old_evacuation_reserve);
-      heap->reset_old_evac_expended();
-
-      // Compute the young evauation reserve: This is how much memory is available for evacuating young-gen objects.
-      // We ignore the possible effect of promotions, which reduce demand for young-gen evacuation memory.
-      //
-      // TODO: We could give special treatment to the regions that have reached promotion age, because we know their
-      // live data is entirely eligible for promotion.  This knowledge can feed both into calculations of young-gen
-      // evacuation reserve and promotion reserve.
-      //
-      //  young_evacuation_reserve for young generation: how much memory are we reserving to hold the results
-      //  of evacuating young collection set regions?  This is typically smaller than the total amount
-      //  of available memory, and is also smaller than the total amount of marked live memory within
-      //  young-gen.  This value is the smaller of
-      //
-      //    1. (young_gen->capacity() * ShenandoahEvacReserve) / 100
-      //    2. (young_gen->available() + old_gen_memory_available_to_be_loaned
-      //
-      //  ShenandoahEvacReserve represents the configured taget size of the evacuation region.  We can only honor
-      //  this target if there is memory available to hold the evacuations.  Memory is available if it is already
-      //  free within young gen, or if it can be borrowed from old gen.  Since we have not yet chosen the collection
-      //  sets, we do not yet know the exact accounting of how many regions will be freed by this collection pass.
-      //  What we do know is that there will be at least one evacuated young-gen region for each old-gen region that
-      //  is loaned to the evacuation effort (because regions to be collected consume more memory than the compacted
-      //  regions that will replace them).  In summary, if there are old-gen regions that are available to hold the
-      //  results of young-gen evacuations, it is safe to loan them for this purpose.  At this point, we have not yet
-      //  established a promoted_reserve.  We'll do that after we choose the collection set and analyze its impact
-      //  on available memory.
-      //
-      // We do not know the evacuation_supplement until after we have computed the collection set.  It is not always
-      // the case that young-regions inserted into the collection set will result in net decrease of in-use regions
-      // because ShenandoahEvacWaste times multiplied by memory within the region may be larger than the region size.
-      // The problem is especially relevant to regions that have been inserted into the collection set because they have
-      // reached tenure age.  These regions tend to have much higher utilization (e.g. 95%).  These regions also offer
-      // a unique opportunity because we know that every live object contained within the region is elgible to be
-      // promoted.  Thus, the following implementation treats these regions specially:
-      //
-      //  1. Before beginning collection set selection, we tally the total amount of live memory held within regions
-      //     that are known to have reached tenure age.  If this memory times ShenandoahEvacWaste is available within
-      //     old-gen memory, establish an advance promotion reserve to hold all or some percentage of these objects.
-      //     This advance promotion reserve is excluded from memory available for holding old-gen evacuations and cannot
-      //     be "loaned" to young gen.
-      //
-      //  2. Tenure-aged regions are included in the collection set iff their evacuation size * ShenandoahEvacWaste fits
-      //     within the advance promotion reserve.  It is counter productive to evacuate these regions if they cannot be
-      //     evacuated directly into old-gen memory.  So if there is not sufficient memory to hold copies of their
-      //     live data right now, we'll just let these regions remain in young for now, to be evacuated by a subsequent
-      //     evacuation pass.
-      //
-      //  3. Next, we calculate a young-gen evacuation budget, which is the smaller of the two quantities mentioned
-      //     above.  old_gen_memory_available_to_be_loaned is calculated as:
-      //       old_gen->available - (advance-promotion-reserve + old-gen_evacuation_reserve)
-      //
-      //  4. When choosing the collection set, special care is taken to assure that the amount of loaned memory required to
-      //     hold the results of evacuation is smaller than the total memory occupied by the regions added to the collection
-      //     set.  We need to take these precautions because we do not know how much memory will be reclaimed by evacuation
-      //     until after the collection set has been constructed.  The algorithm is as follows:
-      //
-      //     a. We feed into the algorithm (i) young available at the start of evacuation and (ii) the amount of memory
-      //        loaned from old-gen that is available to hold the results of evacuation.
-      //     b. As candidate regions are added into the young-gen collection set, we maintain accumulations of the amount
-      //        of memory spanned by the collection set regions and the amount of memory that must be reserved to hold
-      //        evacuation results (by multiplying live-data size by ShenandoahEvacWaste).  We process candidate regions
-      //        in order of decreasing amounts of garbage.  We skip over (and do not include into the collection set) any
-      //        regions that do not satisfy all of the following conditions:
-      //
-      //          i. The amount of live data within the region as scaled by ShenandoahEvacWaste must fit within the
-      //             relevant evacuation reserve (live data of old-gen regions must fit within the old-evac-reserve, live
-      //             data of young-gen tenure-aged regions must fit within the advance promotion reserve, live data within
-      //             other young-gen regions must fit within the youn-gen evacuation reserve).
-      //         ii. The accumulation of memory consumed by evacuation must not exceed the accumulation of memory reclaimed
-      //             through evacuation by more than young-gen available.
-      //        iii. Other conditions may be enforced as appropriate for specific heuristics.
-      //
-      //       Note that regions are considered for inclusion in the selection set in order of decreasing amounts of garbage.
-      //       It is possible that a region with a larger amount of garbage will be rejected because it also has a larger
-      //       amount of live data and some region that follows this region in candidate order is included in the collection
-      //       set (because it has less live data and thus can fit within the evacuation limits even though it has less
-      //       garbage).
-
-      size_t young_evacuation_reserve = (young_generation->max_capacity() * ShenandoahEvacReserve) / 100;
-      // old evacuation can pack into existing partially used regions.  young evacuation and loans for young allocations
-      // need to target regions that do not already hold any old-gen objects.  Round down.
-      regions_available_to_loan = old_generation->free_unaffiliated_regions();
-      consumed_by_advance_promotion = _heuristics->select_aged_regions(old_generation->available() - old_evacuation_reserve,
-                                                                       num_regions, preselected_regions);
-      size_t net_available_old_regions =
-        (old_generation->available() - old_evacuation_reserve - consumed_by_advance_promotion) / region_size_bytes;
-
-      if (regions_available_to_loan > net_available_old_regions) {
-        regions_available_to_loan = net_available_old_regions;
-      }
-      // Otherwise, regions_available_to_loan is less than net_available_old_regions because available memory is
-      // scattered between multiple partially used regions.
-
-      if (young_evacuation_reserve > young_generation->available()) {
-        size_t short_fall = young_evacuation_reserve - young_generation->available();
-        if (regions_available_to_loan * region_size_bytes >= short_fall) {
-          old_regions_loaned_for_young_evac = (short_fall + region_size_bytes - 1) / region_size_bytes;
-          regions_available_to_loan -= old_regions_loaned_for_young_evac;
-        } else {
-          old_regions_loaned_for_young_evac = regions_available_to_loan;
-          regions_available_to_loan = 0;
-          young_evacuation_reserve = young_generation->available() + old_regions_loaned_for_young_evac * region_size_bytes;
-        }
-      } else {
-        old_regions_loaned_for_young_evac = 0;
-      }
-      // In generational mode, we may end up choosing a young collection set that contains so many promotable objects
-      // that there is not sufficient space in old generation to hold the promoted objects.  That is ok because we have
-      // assured there is sufficient space in young generation to hold the rejected promotion candidates.  These rejected
-      // promotion candidates will presumably be promoted in a future evacuation cycle.
-      heap->set_young_evac_reserve(young_evacuation_reserve);
-    } else {
-      // Not generational mode: limit young evac reserve by young available; no need to establish old_evac_reserve.
-      ShenandoahYoungGeneration* young_generation = heap->young_generation();
-      size_t young_evac_reserve = (young_generation->soft_max_capacity() * ShenandoahEvacReserve) / 100;
-      if (young_evac_reserve > young_generation->available()) {
-        young_evac_reserve = young_generation->available();
-      }
-      heap->set_young_evac_reserve(young_evac_reserve);
-    }
-
     // TODO: young_available can include available (between top() and end()) within each young region that is not
     // part of the collection set.  Making this memory available to the young_evacuation_reserve allows a larger
     // young collection set to be chosen when available memory is under extreme pressure.  Implementing this "improvement"
@@ -445,157 +602,12 @@ void ShenandoahGeneration::prepare_regions_and_collection_set(bool concurrent) {
     // non-empty regions that are not selected as part of the collection set can be allocated by the mutator while
     // GC is evacuating and updating references.
 
-    collection_set->establish_preselected(preselected_regions);
+    // Budgeting parameters to compute_evacuation_budgets are passed by reference.
+    compute_evacuation_budgets(heap, collection_set, old_regions_loaned_for_young_evac, regions_available_to_loan,
+                               minimum_evacuation_reserve, consumed_by_advance_promotion);
     _heuristics->choose_collection_set(heap->collection_set(), heap->old_heuristics());
-    collection_set->abandon_preselected();
-
-    // At this point, young_generation->available() knows about recently discovered immediate garbage.  We also
-    // know the composition of the chosen collection set.
-
-    if (heap->mode()->is_generational()) {
-      ShenandoahGeneration* old_generation = heap->old_generation();
-      ShenandoahYoungGeneration* young_generation = heap->young_generation();
-      size_t old_evacuation_committed = (size_t) (ShenandoahEvacWaste *
-                                                  collection_set->get_old_bytes_reserved_for_evacuation());
-      size_t immediate_garbage_regions = collection_set->get_immediate_trash() / region_size_bytes;
-
-      if (old_evacuation_committed > old_evacuation_reserve) {
-        // This should only happen due to round-off errors when enforcing ShenandoahEvacWaste
-        assert(old_evacuation_committed < (33 * old_evacuation_reserve) / 32, "Round-off errors should be less than 3.125%%");
-        old_evacuation_committed = old_evacuation_reserve;
-      }
-
-      // Recompute old_regions_loaned_for_young_evac because young-gen collection set may not need all the memory
-      // originally reserved.
-
-      size_t young_evacuation_reserve_used =
-        collection_set->get_young_bytes_reserved_for_evacuation() - collection_set->get_young_bytes_to_be_promoted();
-      young_evacuation_reserve_used = (size_t) (ShenandoahEvacWaste * young_evacuation_reserve_used);
-      heap->set_young_evac_reserve(young_evacuation_reserve_used);
-
-      // Adjust old_regions_loaned_for_young_evac to feed into calculations of promoted_reserve
-      if (young_evacuation_reserve_used > young_generation->available()) {
-        size_t short_fall = young_evacuation_reserve_used - young_generation->available();
-
-        // region_size_bytes is a power of 2.  loan an integral number of regions.
-        size_t revised_loan_for_young_evacuation = (short_fall + region_size_bytes - 1) / region_size_bytes;
-
-        // Undo the previous loan
-        regions_available_to_loan += old_regions_loaned_for_young_evac;
-        old_regions_loaned_for_young_evac = revised_loan_for_young_evacuation;
-        // And make a new loan
-        assert(regions_available_to_loan > old_regions_loaned_for_young_evac, "Cannot loan regions that we do not have");
-        regions_available_to_loan -= old_regions_loaned_for_young_evac;
-      } else {
-        // Undo the prevous loan
-        regions_available_to_loan += old_regions_loaned_for_young_evac;
-        old_regions_loaned_for_young_evac = 0;
-      }
-
-      size_t old_bytes_loaned = old_regions_loaned_for_young_evac * region_size_bytes;
-      // Need to enforce that old_evacuation_committed + old_bytes_loaned >= minimum_evacuation_reserve
-      // in order to prevent promotion reserve from violating minimum evacuation reserve.
-      if (old_evacuation_committed + old_bytes_loaned < minimum_evacuation_reserve) {
-        // Pretend the old_evacuation_commitment is larger than what will be evacuated to assure that promotions
-        // do not fill the minimum_evacuation_reserve.  Note that regions loaned from old-gen will be returned
-        // to old-gen before we start a subsequent evacuation.
-        old_evacuation_committed = minimum_evacuation_reserve - old_bytes_loaned;
-      }
-
-      // Limit promoted_reserve so that we can set aside memory to be loaned from old-gen to young-gen.  This
-      // value is not "critical".  If we underestimate, certain promotions will simply be deferred.  If we put
-      // "all the rest" of old-gen memory into the promotion reserve, we'll have nothing left to loan to young-gen
-      // during the evac and update phases of GC.  So we "limit" the sizes of the promotion budget to be the smaller of:
-      //
-      //  1. old_gen->available - (old_evacuation_committed + old_bytes_loaned + consumed_by_advance_promotion)
-      //  2. young bytes reserved for evacuation
-
-      assert(old_generation->available() > old_evacuation_committed, "Cannot evacuate more than available");
-      assert(old_generation->available() > old_evacuation_committed + old_bytes_loaned, "Cannot loan more than available");
-      assert(old_generation->available() > old_evacuation_committed + old_bytes_loaned + consumed_by_advance_promotion,
-             "Cannot promote more than available");
-
-      size_t old_avail = old_generation->available();
-      size_t promotion_reserve = old_avail - (old_evacuation_committed + consumed_by_advance_promotion + old_bytes_loaned);
-
-      // We experimented with constraining promoted_reserve to be no larger than 4 times the size of previously_promoted,
-      // but this constraint was too limiting, resulting in failure of legitimate promotions.
-
-      // We had also experimented with constraining promoted_reserve to be no more than young_evacuation_committed
-      // divided by promotion_divisor, where:
-      //  size_t promotion_divisor = (0x02 << InitialTenuringThreshold) - 1;
-      // This also was found to be too limiting, resulting in failure of legitimate promotions.
-      //
-      // Both experiments were conducted in the presence of other bugs which could have been the root cause for
-      // the failures identified above as being "too limiting".  TODO: conduct new experiments with the more limiting
-      // values of young_evacuation_reserved_used.
-      young_evacuation_reserve_used -= consumed_by_advance_promotion;
-      if (young_evacuation_reserve_used < promotion_reserve) {
-        // Shrink promotion_reserve if its larger than the memory to be consumed by evacuating all young objects in
-        // collection set, including anticipated waste.  There's no benefit in using a larger promotion_reserve.
-        promotion_reserve = young_evacuation_reserve_used;
-      }
-
-      assert(old_avail >= promotion_reserve + old_evacuation_committed + old_bytes_loaned + consumed_by_advance_promotion,
-             "Budget exceeds available old-gen memory");
-      log_info(gc, ergo)("Old available: " SIZE_FORMAT ", Original promotion reserve: " SIZE_FORMAT ", Old evacuation reserve: "
-                         SIZE_FORMAT ", Advance promotion reserve supplement: " SIZE_FORMAT ", Old loaned to young: " SIZE_FORMAT,
-                         old_avail, promotion_reserve, old_evacuation_committed, consumed_by_advance_promotion,
-                         old_regions_loaned_for_young_evac * region_size_bytes);
-      promotion_reserve += consumed_by_advance_promotion;
-      heap->set_promoted_reserve(promotion_reserve);
-      heap->reset_promoted_expended();
-      if (collection_set->get_old_bytes_reserved_for_evacuation() == 0) {
-        // Setting old evacuation reserve to zero denotes that there is no old-gen evacuation in this pass.
-        heap->set_old_evac_reserve(0);
-      }
-
-      size_t old_gen_usage_base = old_generation->used() - collection_set->get_old_garbage();
-      heap->capture_old_usage(old_gen_usage_base);
-
-      // Compute the evacuation supplement, which is extra memory borrowed from old-gen that can be allocated
-      // by mutators while GC is working on evacuation and update-refs.  This memory can be temporarily borrowed
-      // from old-gen allotment, then repaid at the end of update-refs from the recycled collection set.  After
-      // we have computed the collection set based on the parameters established above, we can make additional
-      // loans based on our knowledge of the collection set to determine how much allocation we can allow
-      // during the evacuation and update-refs phases of execution.  The total available supplement is the smaller of:
-      //
-      //   1. old_gen->available() -
-      //        (promotion_reserve + old_evacuation_commitment + old_bytes_loaned)
-      //   2. The replenishment budget (number of regions in collection set - the number of regions already
-      //         under lien for the young_evacuation_reserve)
-      //
-
-      size_t young_regions_evacuated = collection_set->get_young_region_count();
-      size_t regions_for_runway = 0;
-      if (young_regions_evacuated > old_regions_loaned_for_young_evac) {
-        regions_for_runway = young_regions_evacuated - old_regions_loaned_for_young_evac;
-        old_regions_loaned_for_young_evac = young_regions_evacuated;
-        regions_available_to_loan -= regions_for_runway;
-      }
-
-      size_t allocation_supplement = regions_for_runway * region_size_bytes;
-      heap->set_alloc_supplement_reserve(allocation_supplement);
-
-      size_t promotion_budget = heap->get_promoted_reserve();
-      size_t old_evac_budget = heap->get_old_evac_reserve();
-      size_t alloc_budget_evac_and_update = allocation_supplement + young_generation->available();
-
-      // TODO: young_available, which feeds into alloc_budget_evac_and_update is lacking memory available within
-      // existing young-gen regions that were not selected for the collection set.  Add this in and adjust the
-      // log message (where it says "empty-region allocation budget").
-
-      log_info(gc, ergo)("Memory reserved for evacuation and update-refs includes promotion budget: " SIZE_FORMAT
-                         "%s, young evacuation budget: " SIZE_FORMAT "%s, old evacuation budget: " SIZE_FORMAT
-                         "%s, empty-region allocation budget: " SIZE_FORMAT "%s, including supplement: " SIZE_FORMAT "%s",
-                         byte_size_in_proper_unit(promotion_budget), proper_unit_for_byte_size(promotion_budget),
-                         byte_size_in_proper_unit(young_evacuation_reserve_used),
-                         proper_unit_for_byte_size(young_evacuation_reserve_used),
-                         byte_size_in_proper_unit(old_evac_budget), proper_unit_for_byte_size(old_evac_budget),
-                         byte_size_in_proper_unit(alloc_budget_evac_and_update),
-                         proper_unit_for_byte_size(alloc_budget_evac_and_update),
-                         byte_size_in_proper_unit(allocation_supplement), proper_unit_for_byte_size(allocation_supplement));
-    }
+    adjust_evacuation_budgets(heap, collection_set, old_regions_loaned_for_young_evac, regions_available_to_loan,
+                              minimum_evacuation_reserve, consumed_by_advance_promotion);
   }
 
   {

--- a/src/hotspot/share/gc/shenandoah/shenandoahGeneration.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahGeneration.cpp
@@ -412,11 +412,6 @@ void ShenandoahGeneration::compute_evacuation_budgets(ShenandoahHeap* heap, bool
     if (young_evac_reserve > young_generation->available()) {
       young_evac_reserve = young_generation->available();
     }
-#undef KELVIN_DEBUG
-#ifdef KELVIN_DEBUG
-    printf("setting young evac reserve to " SIZE_FORMAT ", young available; " SIZE_FORMAT  "\n",
-           young_evac_reserve, young_generation->available());
-#endif
     heap->set_young_evac_reserve(young_evac_reserve);
   }
 }
@@ -811,24 +806,15 @@ void ShenandoahGeneration::clear_used() {
   assert(ShenandoahSafepoint::is_at_shenandoah_safepoint(), "must be at a safepoint");
   // Do this atomically to assure visibility to other threads, even though these other threads may be idle "right now"..
   Atomic::store(&_used, (size_t)0);
-#ifdef KELVIN_DESPERADO
-  printf("%s::clear_used() yields " SIZE_FORMAT "\n", generation_name(_generation_mode),  _used);
-#endif
 }
 
 void ShenandoahGeneration::increase_used(size_t bytes) {
   Atomic::add(&_used, bytes);
-#ifdef KELVIN_DESPERADO
-  printf("%s::increase_used(" SIZE_FORMAT " bytes) yields " SIZE_FORMAT "\n", generation_name(_generation_mode),  bytes, _used);
-#endif
 }
 
 void ShenandoahGeneration::decrease_used(size_t bytes) {
   assert(_used >= bytes, "cannot reduce bytes used by generation below zero");
   Atomic::sub(&_used, bytes);
-#ifdef KELVIN_DESPERADO
-  printf("%s::decrease_used(" SIZE_FORMAT " bytes) yields " SIZE_FORMAT "\n", generation_name(_generation_mode), bytes, _used);
-#endif
 }
 
 size_t ShenandoahGeneration::used_regions() const {
@@ -852,37 +838,21 @@ size_t ShenandoahGeneration::used_regions_size() const {
 size_t ShenandoahGeneration::available() const {
   size_t in_use = used();
   size_t soft_capacity = soft_max_capacity();
-#undef KELVIN_DESPERADO
-#ifdef KELVIN_DESPERADO
-  printf("%s::available() soft_capacity: " SIZE_FORMAT ", in_use: " SIZE_FORMAT " returning " SIZE_FORMAT "\n",
-         generation_name(_generation_mode), soft_capacity, in_use, in_use > soft_capacity ? 0 : soft_capacity - in_use);
-#endif
   return in_use > soft_capacity ? 0 : soft_capacity - in_use;
 }
 
 size_t ShenandoahGeneration::adjust_available(intptr_t adjustment) {
   _adjusted_capacity = soft_max_capacity() + adjustment;
-#ifdef KELVIN_DESPERADO
-  printf("%s::adjusting available by %ld, result is " SIZE_FORMAT "\n",
-         generation_name(_generation_mode), adjustment, _adjusted_capacity);
-#endif
   return _adjusted_capacity;
 }
 
 size_t ShenandoahGeneration::unadjust_available() {
   _adjusted_capacity = soft_max_capacity();
-#ifdef KELVIN_DESPERADO
-  printf("%s::unadjusting available, result is " SIZE_FORMAT "\n", generation_name(_generation_mode), _adjusted_capacity);
-#endif
   return _adjusted_capacity;
 }
 
 size_t ShenandoahGeneration::adjusted_available() const {
   size_t in_use = used();
   size_t capacity = _adjusted_capacity;
-#ifdef KELVIN_DESPERADO
-  printf("%s::adjusted_available() returning " SIZE_FORMAT "\n",
-         generation_name(_generation_mode), in_use > capacity ? 0 : capacity - in_use);
-#endif
   return in_use > capacity ? 0 : capacity - in_use;
 }

--- a/src/hotspot/share/gc/shenandoah/shenandoahGeneration.hpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahGeneration.hpp
@@ -111,6 +111,16 @@ protected:
   // Used by concurrent and degenerated GC to reset regions.
   void prepare_gc(bool do_old_gc_bootstrap);
 
+  // Compute evacuation budgets prior to choosing collection set.
+  void compute_evacuation_budgets(ShenandoahHeap* heap, ShenandoahCollectionSet* collection_set,
+                                  size_t &old_regions_loaned_for_young_evac, size_t &regions_available_to_loan,
+                                  size_t &minimum_evacuation_reserve, size_t &consumed_by_advance_promotion);
+
+  // Adjust evacuation budgets after choosing collection set.
+  void adjust_evacuation_budgets(ShenandoahHeap* heap, ShenandoahCollectionSet* collection_set,
+                                 size_t old_regions_loaned_for_young_evac, size_t regions_available_to_loan,
+                                 size_t minimum_evacuation_reserve, size_t consumed_by_advance_promotion);
+
   // Return true iff prepared collection set includes at least one old-gen HeapRegion.
   virtual void prepare_regions_and_collection_set(bool concurrent);
 

--- a/src/hotspot/share/gc/shenandoah/shenandoahGeneration.hpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahGeneration.hpp
@@ -56,6 +56,18 @@ protected:
   size_t _adjusted_capacity;
 
   ShenandoahHeuristics* _heuristics;
+
+private:
+  // Compute evacuation budgets prior to choosing collection set.
+  void compute_evacuation_budgets(ShenandoahHeap* heap, bool* preselected_regions, ShenandoahCollectionSet* collection_set,
+                                  size_t &old_regions_loaned_for_young_evac, size_t &regions_available_to_loan,
+                                  size_t &minimum_evacuation_reserve, size_t &consumed_by_advance_promotion);
+
+  // Adjust evacuation budgets after choosing collection set.
+  void adjust_evacuation_budgets(ShenandoahHeap* heap, ShenandoahCollectionSet* collection_set,
+                                 size_t old_regions_loaned_for_young_evac, size_t regions_available_to_loan,
+                                 size_t minimum_evacuation_reserve, size_t consumed_by_advance_promotion);
+
  public:
   ShenandoahGeneration(GenerationMode generation_mode, uint max_workers, size_t max_capacity, size_t soft_max_capacity);
   ~ShenandoahGeneration();
@@ -110,16 +122,6 @@ protected:
 
   // Used by concurrent and degenerated GC to reset regions.
   void prepare_gc(bool do_old_gc_bootstrap);
-
-  // Compute evacuation budgets prior to choosing collection set.
-  void compute_evacuation_budgets(ShenandoahHeap* heap, bool* preselected_regions, ShenandoahCollectionSet* collection_set,
-                                  size_t &old_regions_loaned_for_young_evac, size_t &regions_available_to_loan,
-                                  size_t &minimum_evacuation_reserve, size_t &consumed_by_advance_promotion);
-
-  // Adjust evacuation budgets after choosing collection set.
-  void adjust_evacuation_budgets(ShenandoahHeap* heap, ShenandoahCollectionSet* collection_set,
-                                 size_t old_regions_loaned_for_young_evac, size_t regions_available_to_loan,
-                                 size_t minimum_evacuation_reserve, size_t consumed_by_advance_promotion);
 
   // Return true iff prepared collection set includes at least one old-gen HeapRegion.
   virtual void prepare_regions_and_collection_set(bool concurrent);

--- a/src/hotspot/share/gc/shenandoah/shenandoahGeneration.hpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahGeneration.hpp
@@ -112,7 +112,7 @@ protected:
   void prepare_gc(bool do_old_gc_bootstrap);
 
   // Compute evacuation budgets prior to choosing collection set.
-  void compute_evacuation_budgets(ShenandoahHeap* heap, bool* preselected_regions, ShenandoahCollectionSet* collection_set, 
+  void compute_evacuation_budgets(ShenandoahHeap* heap, bool* preselected_regions, ShenandoahCollectionSet* collection_set,
                                   size_t &old_regions_loaned_for_young_evac, size_t &regions_available_to_loan,
                                   size_t &minimum_evacuation_reserve, size_t &consumed_by_advance_promotion);
 

--- a/src/hotspot/share/gc/shenandoah/shenandoahGeneration.hpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahGeneration.hpp
@@ -112,7 +112,7 @@ protected:
   void prepare_gc(bool do_old_gc_bootstrap);
 
   // Compute evacuation budgets prior to choosing collection set.
-  void compute_evacuation_budgets(ShenandoahHeap* heap, ShenandoahCollectionSet* collection_set,
+  void compute_evacuation_budgets(ShenandoahHeap* heap, bool* preselected_regions, ShenandoahCollectionSet* collection_set, 
                                   size_t &old_regions_loaned_for_young_evac, size_t &regions_available_to_loan,
                                   size_t &minimum_evacuation_reserve, size_t &consumed_by_advance_promotion);
 

--- a/src/hotspot/share/gc/shenandoah/shenandoahHeap.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahHeap.cpp
@@ -657,11 +657,6 @@ bool ShenandoahHeap::is_gc_generation_young() const {
 // If this bound is smaller than NewSize, it supersedes,
 // resulting in a fixed size given by MaxNewSize.
 size_t ShenandoahHeap::young_generation_capacity(size_t capacity) {
-#undef KELVIN_DESPERADO
-#ifdef KELVIN_DESPERADO
-  printf("Computing young-generation_capacity from input: " SIZE_FORMAT ", NewSize: " SIZE_FORMAT ", MaxNewSize: " SIZE_FORMAT
-         ", NewRatio: " SIZE_FORMAT "\n", capacity, NewSize, MaxNewSize, NewRatio);
-#endif
   if (strcmp(ShenandoahGCMode, "generational") == 0) {
     if (FLAG_IS_CMDLINE(NewSize) && !FLAG_IS_CMDLINE(MaxNewSize) && !FLAG_IS_CMDLINE(NewRatio)) {
       capacity = MIN2(NewSize, capacity);
@@ -676,9 +671,6 @@ size_t ShenandoahHeap::young_generation_capacity(size_t capacity) {
     }
   }
   // else, make no adjustment to global capacity
-#ifdef KELVIN_DESPERADO
-  printf("Computed young-generation_capacity is " SIZE_FORMAT "\n", capacity);
-#endif
   return capacity;
 }
 

--- a/src/hotspot/share/gc/shenandoah/shenandoahHeap.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahHeap.cpp
@@ -657,17 +657,28 @@ bool ShenandoahHeap::is_gc_generation_young() const {
 // If this bound is smaller than NewSize, it supersedes,
 // resulting in a fixed size given by MaxNewSize.
 size_t ShenandoahHeap::young_generation_capacity(size_t capacity) {
-  if (FLAG_IS_CMDLINE(NewSize) && !FLAG_IS_CMDLINE(MaxNewSize) && !FLAG_IS_CMDLINE(NewRatio)) {
-    capacity = MIN2(NewSize, capacity);
-  } else {
-    capacity /= NewRatio + 1;
-    if (FLAG_IS_CMDLINE(NewSize)) {
-      capacity = MAX2(NewSize, capacity);
-    }
-    if (FLAG_IS_CMDLINE(MaxNewSize)) {
-      capacity = MIN2(MaxNewSize, capacity);
+#undef KELVIN_DESPERADO
+#ifdef KELVIN_DESPERADO
+  printf("Computing young-generation_capacity from input: " SIZE_FORMAT ", NewSize: " SIZE_FORMAT ", MaxNewSize: " SIZE_FORMAT
+         ", NewRatio: " SIZE_FORMAT "\n", capacity, NewSize, MaxNewSize, NewRatio);
+#endif
+  if (strcmp(ShenandoahGCMode, "generational") == 0) {
+    if (FLAG_IS_CMDLINE(NewSize) && !FLAG_IS_CMDLINE(MaxNewSize) && !FLAG_IS_CMDLINE(NewRatio)) {
+      capacity = MIN2(NewSize, capacity);
+    } else {
+      capacity /= NewRatio + 1;
+      if (FLAG_IS_CMDLINE(NewSize)) {
+        capacity = MAX2(NewSize, capacity);
+      }
+      if (FLAG_IS_CMDLINE(MaxNewSize)) {
+        capacity = MIN2(MaxNewSize, capacity);
+      }
     }
   }
+  // else, make no adjustment to global capacity
+#ifdef KELVIN_DESPERADO
+  printf("Computed young-generation_capacity is " SIZE_FORMAT "\n", capacity);
+#endif
   return capacity;
 }
 

--- a/src/hotspot/share/gc/shenandoah/shenandoahHeap.inline.hpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahHeap.inline.hpp
@@ -696,6 +696,10 @@ size_t ShenandoahHeap::get_previous_promotion() const {
 
 inline size_t ShenandoahHeap::set_old_evac_reserve(size_t new_val) {
   size_t orig = _old_evac_reserve;
+#undef KELVIN_DESPARADO
+#ifdef KELVIN_DESPARADO
+  printf("setting old evac reserve to " SIZE_FORMAT "\n", new_val);
+#endif
   _old_evac_reserve = new_val;
   return orig;
 }

--- a/src/hotspot/share/gc/shenandoah/shenandoahHeap.inline.hpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahHeap.inline.hpp
@@ -686,6 +686,7 @@ size_t ShenandoahHeap::capture_old_usage(size_t old_usage) {
 }
 
 void ShenandoahHeap::set_previous_promotion(size_t promoted_bytes) {
+  shenandoah_assert_heaplocked();
   _previous_promotion = promoted_bytes;
 }
 

--- a/src/hotspot/share/gc/shenandoah/shenandoahHeap.inline.hpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahHeap.inline.hpp
@@ -696,10 +696,6 @@ size_t ShenandoahHeap::get_previous_promotion() const {
 
 inline size_t ShenandoahHeap::set_old_evac_reserve(size_t new_val) {
   size_t orig = _old_evac_reserve;
-#undef KELVIN_DESPARADO
-#ifdef KELVIN_DESPARADO
-  printf("setting old evac reserve to " SIZE_FORMAT "\n", new_val);
-#endif
   _old_evac_reserve = new_val;
   return orig;
 }

--- a/src/hotspot/share/gc/shenandoah/shenandoahReferenceProcessor.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahReferenceProcessor.cpp
@@ -537,7 +537,10 @@ void ShenandoahReferenceProcessor::enqueue_references(bool concurrent) {
     // Nothing to enqueue
     return;
   }
-
+#undef KELVIN_CHASE
+#ifdef KELVIN_CHASE
+  log_info(gc,ref)("starting enqueue_references(%s)", concurrent? "concurrent": "non-concurrent");
+#endif
   if (!concurrent) {
     // When called from mark-compact or degen-GC, the locking is done by the VMOperation,
     enqueue_references_locked();
@@ -554,6 +557,9 @@ void ShenandoahReferenceProcessor::enqueue_references(bool concurrent) {
   // Reset internal pending list
   _pending_list = NULL;
   _pending_list_tail = &_pending_list;
+#ifdef KELVIN_CHASE
+  log_info(gc,ref)("all done with enqueue_references()");
+#endif
 }
 
 template<typename T>

--- a/src/hotspot/share/gc/shenandoah/shenandoahReferenceProcessor.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahReferenceProcessor.cpp
@@ -537,10 +537,6 @@ void ShenandoahReferenceProcessor::enqueue_references(bool concurrent) {
     // Nothing to enqueue
     return;
   }
-#undef KELVIN_CHASE
-#ifdef KELVIN_CHASE
-  log_info(gc,ref)("starting enqueue_references(%s)", concurrent? "concurrent": "non-concurrent");
-#endif
   if (!concurrent) {
     // When called from mark-compact or degen-GC, the locking is done by the VMOperation,
     enqueue_references_locked();
@@ -557,9 +553,6 @@ void ShenandoahReferenceProcessor::enqueue_references(bool concurrent) {
   // Reset internal pending list
   _pending_list = NULL;
   _pending_list_tail = &_pending_list;
-#ifdef KELVIN_CHASE
-  log_info(gc,ref)("all done with enqueue_references()");
-#endif
 }
 
 template<typename T>

--- a/src/hotspot/share/gc/shenandoah/shenandoah_globals.hpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoah_globals.hpp
@@ -101,6 +101,15 @@
           "be taken for collection.")                                       \
           range(0,100)                                                      \
                                                                             \
+  product(uintx, ShenandoahIgnoreGarbageThreshold, 5, EXPERIMENTAL,         \
+          "When less than this amount of garbage (as a percentage of "      \
+          "region size) exists within a region, the region will not be "    \
+          "added to the collection set, even if when the heuristic has "    \
+          "chosen to aggressively add regions with less than "              \
+          "ShenandoahGarbageThreshold amount of garbage into the "          \
+          "collection set.")                                                \
+          range(0,100)                                                      \
+                                                                            \
   product(uintx, ShenandoahInitFreeThreshold, 70, EXPERIMENTAL,             \
           "When less than this amount of memory is free within the"         \
           "heap or generation, trigger a learning cycle if we are "         \

--- a/src/hotspot/share/gc/shenandoah/shenandoah_globals.hpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoah_globals.hpp
@@ -104,7 +104,7 @@
   product(uintx, ShenandoahIgnoreGarbageThreshold, 5, EXPERIMENTAL,         \
           "When less than this amount of garbage (as a percentage of "      \
           "region size) exists within a region, the region will not be "    \
-          "added to the collection set, even if when the heuristic has "    \
+          "added to the collection set, even when the heuristic has "       \
           "chosen to aggressively add regions with less than "              \
           "ShenandoahGarbageThreshold amount of garbage into the "          \
           "collection set.")                                                \

--- a/src/hotspot/share/gc/shenandoah/shenandoah_globals.hpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoah_globals.hpp
@@ -491,22 +491,6 @@
           "Fix references with load reference barrier. Disabling this "     \
           "might degrade performance.")                                     \
                                                                             \
-  product(uintx, ShenandoahTenuredRegionUsageBias, 16, EXPERIMENTAL,        \
-          "The collection set is comprised of heap regions that contain "   \
-          "the greatest amount of garbage.  "                               \
-          "For purposes of selecting regions to be included in the "        \
-          "collection set, regions that have reached the tenure age will "  \
-          "be treated as if their contained garbage is the contained "      \
-          "garbage multiplied by ShenandoahTenuredRegionUsageBias as "      \
-          "many times as the age of the region meets or exceeds "           \
-          "tenure age.  For example, if tenure age is 7, "                  \
-          "the region age is 9, ShenandoahTenuredRegionUsageBias is "       \
-          "16, and the region is 12.5% garbage, this region "               \
-          "will by treated as if its garbage content is "                   \
-          "12.5% * 16 * 16 * 16 = 51,200% when comparing this region "      \
-          " to untenured regions.")                                         \
-          range(1,128)                                                      \
-                                                                            \
   product(uintx, ShenandoahBorrowPercent, 30, EXPERIMENTAL,                 \
           "During evacuation and reference updating in generational "       \
           "mode, new allocations are allowed to borrow from old-gen "       \


### PR DESCRIPTION
This commit consolidates computations related to budgeting of reserves for old-gen evacuation and old-gen promotion within shenandoahGeneration::prepare_regions_and_collection_set().  Previously, these computations had been scattered between several functional units, including shenandoahHeuristics::choose_collection_set() and shenandoahOldHeuristics::prime_collection_set().  A previous pull request brought some of the redundant functionality into prepare_regions_and_collection_set().  This pull request removes the redundant computations from the other locations.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed (1 review required, with at least 1 [Committer](https://openjdk.org/bylaws#committer))

### Reviewers
 * [Roman Kennke](https://openjdk.org/census#rkennke) (@rkennke - **Reviewer**) ⚠️ Review applies to [be1fb125](https://git.openjdk.org/shenandoah/pull/148/files/be1fb125ea0c2856f38f165d71f64baa2b7d573b)
 * [William Kemper](https://openjdk.org/census#wkemper) (@earthling-amzn - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/shenandoah pull/148/head:pull/148` \
`$ git checkout pull/148`

Update a local copy of the PR: \
`$ git checkout pull/148` \
`$ git pull https://git.openjdk.org/shenandoah pull/148/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 148`

View PR using the GUI difftool: \
`$ git pr show -t 148`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/shenandoah/pull/148.diff">https://git.openjdk.org/shenandoah/pull/148.diff</a>

</details>
