### PR TITLE
cli options for young/old ShenandoahMinFreeThreshold

### DIFF
--- a/src/hotspot/share/gc/shenandoah/heuristics/shenandoahAdaptiveHeuristics.cpp
+++ b/src/hotspot/share/gc/shenandoah/heuristics/shenandoahAdaptiveHeuristics.cpp
@@ -241,7 +241,7 @@ bool ShenandoahAdaptiveHeuristics::should_start_gc() {
   double rate = _allocation_rate.sample(allocated);
   _last_trigger = OTHER;
 
-  size_t min_threshold = capacity / 100 * ShenandoahMinFreeThreshold;
+  size_t min_threshold = min_free_threshold();
 
   if (available < min_threshold) {
     log_info(gc)("Trigger (%s): Free (" SIZE_FORMAT "%s) is below minimum threshold (" SIZE_FORMAT "%s)",

--- a/src/hotspot/share/gc/shenandoah/heuristics/shenandoahCompactHeuristics.cpp
+++ b/src/hotspot/share/gc/shenandoah/heuristics/shenandoahCompactHeuristics.cpp
@@ -55,7 +55,7 @@ bool ShenandoahCompactHeuristics::should_start_gc() {
   available = (available > soft_tail) ? (available - soft_tail) : 0;
 
   size_t threshold_bytes_allocated = capacity / 100 * ShenandoahAllocationThreshold;
-  size_t min_threshold = capacity / 100 * ShenandoahMinFreeThreshold;
+  size_t min_threshold = min_free_threshold();
 
   if (available < min_threshold) {
     log_info(gc)("Trigger: Free (" SIZE_FORMAT "%s) is below minimum threshold (" SIZE_FORMAT "%s)",

--- a/src/hotspot/share/gc/shenandoah/heuristics/shenandoahHeuristics.cpp
+++ b/src/hotspot/share/gc/shenandoah/heuristics/shenandoahHeuristics.cpp
@@ -512,6 +512,14 @@ bool ShenandoahHeuristics::in_generation(ShenandoahHeapRegion* region) {
           || (_generation->generation_mode() == OLD && region->affiliation() == OLD_GENERATION));
 }
 
+size_t ShenandoahHeuristics::min_free_threshold() {
+  size_t min_free_threshold =
+      _generation->generation_mode() == GenerationMode::OLD
+          ? ShenandoahOldMinFreeThreshold
+          : ShenandoahMinFreeThreshold;
+  return _generation->soft_max_capacity() / 100 * min_free_threshold;
+}
+
 void ShenandoahHeuristics::save_last_live_memory(size_t live_memory) {
   _live_memory_penultimate_cycle = _live_memory_last_cycle;
   _live_memory_last_cycle = live_memory;

--- a/src/hotspot/share/gc/shenandoah/heuristics/shenandoahHeuristics.hpp
+++ b/src/hotspot/share/gc/shenandoah/heuristics/shenandoahHeuristics.hpp
@@ -119,6 +119,8 @@ protected:
 
   bool in_generation(ShenandoahHeapRegion* region);
 
+  size_t min_free_threshold();
+
 public:
   ShenandoahHeuristics(ShenandoahGeneration* generation);
   virtual ~ShenandoahHeuristics();

--- a/src/hotspot/share/gc/shenandoah/heuristics/shenandoahStaticHeuristics.cpp
+++ b/src/hotspot/share/gc/shenandoah/heuristics/shenandoahStaticHeuristics.cpp
@@ -49,7 +49,7 @@ bool ShenandoahStaticHeuristics::should_start_gc() {
   size_t soft_tail = max_capacity - capacity;
   available = (available > soft_tail) ? (available - soft_tail) : 0;
 
-  size_t threshold_available = capacity / 100 * ShenandoahMinFreeThreshold;
+  size_t threshold_available = min_free_threshold();
 
   if (available < threshold_available) {
     log_info(gc)("Trigger: Free (" SIZE_FORMAT "%s) is below minimum threshold (" SIZE_FORMAT "%s)",

--- a/src/hotspot/share/gc/shenandoah/shenandoah_globals.hpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoah_globals.hpp
@@ -117,6 +117,13 @@
           "max heap size.")                                                 \
           range(0,100)                                                      \
                                                                             \
+  product(uintx, ShenandoahOldMinFreeThreshold, 5, EXPERIMENTAL,            \
+          "Percentage of free heap memory below which most heuristics "     \
+          "old generation trigger collection independent of other   "       \
+          "triggers. Provides a safety margin for many heuristics. In "     \
+          "percents of (soft) max heap size.")                              \
+          range(0,100)                                                      \
+                                                                            \
   product(uintx, ShenandoahAllocationThreshold, 0, EXPERIMENTAL,            \
           "How many new allocations should happen since the last GC cycle " \
           "before some heuristics trigger the collection. In percents of "  \

--- a/src/hotspot/share/gc/shenandoah/shenandoah_globals.hpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoah_globals.hpp
@@ -111,17 +111,18 @@
           range(0,100)                                                      \
                                                                             \
   product(uintx, ShenandoahMinFreeThreshold, 10, EXPERIMENTAL,              \
-          "Percentage of free heap memory below which most heuristics "     \
-          "trigger collection independent of other triggers. Provides "     \
-          "a safety margin for many heuristics. In percents of (soft) "     \
-          "max heap size.")                                                 \
+          "Percentage of free heap memory (or young generation, in "        \
+          "generational mode) below which most heuristics trigger "         \
+          "collection independent of other triggers. Provides a safety "    \
+          "margin for many heuristics. In percents of (soft) max heap "     \
+          "size.")                                                          \
           range(0,100)                                                      \
                                                                             \
   product(uintx, ShenandoahOldMinFreeThreshold, 5, EXPERIMENTAL,            \
-          "Percentage of free heap memory below which most heuristics "     \
-          "old generation trigger collection independent of other   "       \
-          "triggers. Provides a safety margin for many heuristics. In "     \
-          "percents of (soft) max heap size.")                              \
+          "Percentage of free old generation heap memory below which most " \
+          "heuristics trigger collection independent of other triggers. "   \
+          "Provides a safety margin for many heuristics. In percents of "   \
+          "(soft) max heap size.")                                          \
           range(0,100)                                                      \
                                                                             \
   product(uintx, ShenandoahAllocationThreshold, 0, EXPERIMENTAL,            \


### PR DESCRIPTION
We currently can set only a single `ShenandoahMinFreeThreshold`, which will run a GC cycle if an allocation space fills up to a certain capacity. This PR allows us to specify separate thresholds for young and old generations.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed (1 review required, with at least 1 [Committer](https://openjdk.org/bylaws#committer))

### Reviewers
 * [William Kemper](https://openjdk.org/census#wkemper) (@earthling-amzn - Committer) ⚠️ Review applies to [92adffa0](https://git.openjdk.org/shenandoah/pull/150/files/92adffa0501de7590f87be66217a9fa9fe40c6ac)
 * [Y. Srinivas Ramakrishna](https://openjdk.org/census#ysr) (@ysramakrishna - no project role) ⚠️ Review applies to [92adffa0](https://git.openjdk.org/shenandoah/pull/150/files/92adffa0501de7590f87be66217a9fa9fe40c6ac)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/shenandoah pull/150/head:pull/150` \
`$ git checkout pull/150`

Update a local copy of the PR: \
`$ git checkout pull/150` \
`$ git pull https://git.openjdk.org/shenandoah pull/150/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 150`

View PR using the GUI difftool: \
`$ git pr show -t 150`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/shenandoah/pull/150.diff">https://git.openjdk.org/shenandoah/pull/150.diff</a>

</details>
