### PR TITLE
Windows compiler does not support variable length arrays

### DIFF
--- a/src/hotspot/share/gc/shenandoah/heuristics/shenandoahHeuristics.cpp
+++ b/src/hotspot/share/gc/shenandoah/heuristics/shenandoahHeuristics.cpp
@@ -123,7 +123,6 @@ void ShenandoahHeuristics::choose_collection_set(ShenandoahCollectionSet* collec
 
   ShenandoahMarkingContext* const ctx = _generation->complete_marking_context();
 
-  size_t remnant_available = 0;
   for (size_t i = 0; i < num_regions; i++) {
     ShenandoahHeapRegion* region = heap->get_region(i);
     if (!in_generation(region)) {
@@ -149,7 +148,7 @@ void ShenandoahHeuristics::choose_collection_set(ShenandoahCollectionSet* collec
         // This is our candidate for later consideration.
         candidates[cand_idx]._region = region;
         if (collection_set->is_preselected(i)) {
-          // If regions is presected, we know mode()->is_generational() and region->age() >= InitialTenuringThreshold)
+          // If region is preselected, we know mode()->is_generational() and region->age() >= InitialTenuringThreshold)
 
           // TODO: Deprecate and/or refine ShenandoahTenuredRegionUsageBias.  If we preselect the regions, we can just
           // set garbage to "max" value, which is the region size rather than doing this extra work to bias selection.

--- a/src/hotspot/share/gc/shenandoah/shenandoahCollectionSet.hpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahCollectionSet.hpp
@@ -119,7 +119,7 @@ public:
 
   void establish_preselected(bool *preselected) { _preselected_regions = preselected; }
   void abandon_preselected() { _preselected_regions = nullptr; }
-  bool is_preselected(int region_idx) { return (_preselected_regions != nullptr) && _preselected_regions[region_idx]; }
+  bool is_preselected(size_t region_idx) { return (_preselected_regions != nullptr) && _preselected_regions[region_idx]; }
 
   bool has_old_regions() const { return _has_old_regions; }
   size_t used()          const { return _used; }

--- a/src/hotspot/share/gc/shenandoah/shenandoahGeneration.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahGeneration.cpp
@@ -256,10 +256,11 @@ void  ShenandoahGeneration::prepare_regions_and_collection_set(bool concurrent) 
     size_t old_evacuation_reserve = 0;
     size_t num_regions = heap->num_regions();
     size_t consumed_by_advance_promotion = 0;
-    bool preselected_regions[num_regions];
+    bool* preselected_regions = NEW_C_HEAP_ARRAY(bool, num_regions, mtGC);
     for (unsigned int i = 0; i < num_regions; i++) {
       preselected_regions[i] = false;
     }
+
     if (heap->mode()->is_generational()) {
       ShenandoahGeneration* old_generation = heap->old_generation();
       ShenandoahYoungGeneration* young_generation = heap->young_generation();
@@ -445,8 +446,9 @@ void  ShenandoahGeneration::prepare_regions_and_collection_set(bool concurrent) 
     // GC is evacuating and updating references.
 
     collection_set->establish_preselected(preselected_regions);
-    _heuristics->choose_collection_set(heap->collection_set(), heap->old_heuristics());
+    _heuristics->choose_collection_set(collection_set, heap->old_heuristics());
     collection_set->abandon_preselected();
+    FREE_C_HEAP_ARRAY(bool, preselected_regions);
 
     // At this point, young_generation->available() knows about recently discovered immediate garbage.  We also
     // know the composition of the chosen collection set.


### PR DESCRIPTION
<!--
Replace this text with a description of your pull request (also remove the surrounding HTML comment markers).
If in doubt, feel free to delete everything in this edit box first, the bot will restore the progress section as needed.
-->

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed (1 review required, with at least 1 [Committer](https://openjdk.org/bylaws#committer))

### Reviewers
 * [Y. Srinivas Ramakrishna](https://openjdk.org/census#ysr) (@ysramakrishna - no project role) ⚠️ Review applies to [e56738e7](https://git.openjdk.org/shenandoah/pull/151/files/e56738e73e4733ccb06ada162cd8cf0cd1ab36dc)
 * [Kelvin Nilsen](https://openjdk.org/census#kdnilsen) (@kdnilsen - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/shenandoah pull/151/head:pull/151` \
`$ git checkout pull/151`

Update a local copy of the PR: \
`$ git checkout pull/151` \
`$ git pull https://git.openjdk.org/shenandoah pull/151/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 151`

View PR using the GUI difftool: \
`$ git pr show -t 151`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/shenandoah/pull/151.diff">https://git.openjdk.org/shenandoah/pull/151.diff</a>

</details>
