### PR TITLE
Include a version identifier in region sampling protocol for visualizer

### DIFF
--- a/src/hotspot/share/gc/shenandoah/shenandoahHeapRegionCounters.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahHeapRegionCounters.cpp
@@ -53,6 +53,9 @@ ShenandoahHeapRegionCounters::ShenandoahHeapRegionCounters() :
     cname = PerfDataManager::counter_name(_name_space, "max_regions");
     PerfDataManager::create_constant(SUN_GC, cname, PerfData::U_None, num_regions, CHECK);
 
+    cname = PerfDataManager::counter_name(_name_space, "protocol_version"); //creating new protocol_version
+    PerfDataManager::create_constant(SUN_GC, cname, PerfData::U_None, VERSION_NUMBER, CHECK);
+
     cname = PerfDataManager::counter_name(_name_space, "region_size");
     PerfDataManager::create_constant(SUN_GC, cname, PerfData::U_None, ShenandoahHeapRegion::region_size_bytes() >> 10, CHECK);
 
@@ -116,7 +119,7 @@ void ShenandoahHeapRegionCounters::update() {
 
         // If logging enabled, dump current region snapshot to log file
         if (ShenandoahLogRegionSampling && _log_file != NULL) {
-          _log_file->write_snapshot(_regions_data, _timestamp, _status, num_regions, rs >> 10);
+          _log_file->write_snapshot(_regions_data, _timestamp, _status, num_regions, rs >> 10, VERSION_NUMBER);
         }
       }
     }

--- a/src/hotspot/share/gc/shenandoah/shenandoahHeapRegionCounters.hpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahHeapRegionCounters.hpp
@@ -81,7 +81,8 @@ private:
   static const jlong AGE_SHIFT         = 51;
   static const jlong AFFILIATION_SHIFT = 56;
   static const jlong STATUS_SHIFT      = 58;
-  static const jlong VERSION_NUMBER    = 2; //Newly add version number
+
+  static const jlong VERSION_NUMBER    = 2;
 
   char* _name_space;
   PerfLongVariable** _regions_data;

--- a/src/hotspot/share/gc/shenandoah/shenandoahHeapRegionCounters.hpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahHeapRegionCounters.hpp
@@ -81,6 +81,7 @@ private:
   static const jlong AGE_SHIFT         = 51;
   static const jlong AFFILIATION_SHIFT = 56;
   static const jlong STATUS_SHIFT      = 58;
+  static const jlong VERSION_NUMBER    = 2; //Newly add version number
 
   char* _name_space;
   PerfLongVariable** _regions_data;

--- a/src/hotspot/share/gc/shenandoah/shenandoahLogFileOutput.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahLogFileOutput.cpp
@@ -103,14 +103,15 @@ int ShenandoahLogFileOutput::write_snapshot(PerfLongVariable** regions,
                                             PerfLongVariable* ts,
                                             PerfLongVariable* status,
                                             size_t num_regions,
-                                            size_t rs) {
+                                            size_t region_size, size_t protocol_version) {
   int written = 0;
+
   FileLocker flocker(_stream);
-  WRITE_LOG_WITH_RESULT_CHECK(jio_fprintf(_stream, "%lli %lli %u %u\n",
+  WRITE_LOG_WITH_RESULT_CHECK(jio_fprintf(_stream, "%lli %lli %u %u %u\n",
                                           ts->get_value(),
                                           status->get_value(),
                                           num_regions,
-                                          rs),written);
+                                          region_size, protocol_version), written);
   if (num_regions > 0) {
     WRITE_LOG_WITH_RESULT_CHECK(jio_fprintf(_stream, "%lli", regions[0]->get_value()), written);
   }

--- a/src/hotspot/share/gc/shenandoah/shenandoahLogFileOutput.hpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahLogFileOutput.hpp
@@ -65,7 +65,7 @@ public:
                        PerfLongVariable* ts,
                        PerfLongVariable* status,
                        size_t num_regions,
-                       size_t rs);
+                       size_t rs, size_t protocolVersion);
 
     const char* name() const {
       return _name;

--- a/src/hotspot/share/gc/shenandoah/shenandoahLogFileOutput.hpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahLogFileOutput.hpp
@@ -65,7 +65,7 @@ public:
                        PerfLongVariable* ts,
                        PerfLongVariable* status,
                        size_t num_regions,
-                       size_t rs, size_t protocolVersion);
+                       size_t region_size, size_t protocolVersion);
 
     const char* name() const {
       return _name;


### PR DESCRIPTION
This change adds a new variable to the PerfData for region sampling. With this change, the visualizer is able to identify the version of the encoding used in the communication protocol with Shenandoah. This allows the same visualizer to operate with the original unmodified Shenandoah and the generational mode Shenandoah.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed (1 review required, with at least 1 [Committer](https://openjdk.org/bylaws#committer))

### Reviewers
 * [Kelvin Nilsen](https://openjdk.org/census#kdnilsen) (@kdnilsen - Committer)


### Contributors
 * Celine Wu `<cfumiwu@amazon.com>`

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/shenandoah pull/152/head:pull/152` \
`$ git checkout pull/152`

Update a local copy of the PR: \
`$ git checkout pull/152` \
`$ git pull https://git.openjdk.org/shenandoah pull/152/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 152`

View PR using the GUI difftool: \
`$ git pr show -t 152`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/shenandoah/pull/152.diff">https://git.openjdk.org/shenandoah/pull/152.diff</a>

</details>
