### PR TITLE
Load balance remembered set scanning

### DIFF
--- a/src/hotspot/share/gc/shenandoah/shenandoahConcurrentGC.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahConcurrentGC.cpp
@@ -122,7 +122,7 @@ bool ShenandoahConcurrentGC::collect(GCCause::Cause cause) {
     // Concurrent remembered set scanning
     if (_generation->generation_mode() == YOUNG) {
       ShenandoahConcurrentPhase gc_phase("Concurrent remembered set scanning", ShenandoahPhaseTimings::init_scan_rset);
-      _generation->scan_remembered_set();
+      _generation->scan_remembered_set(true /* is_concurrent */);
     }
 
     // Concurrent mark roots

--- a/src/hotspot/share/gc/shenandoah/shenandoahGeneration.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahGeneration.cpp
@@ -781,7 +781,7 @@ ShenandoahObjToScanQueueSet* ShenandoahGeneration::old_gen_task_queues() const {
   return nullptr;
 }
 
-void ShenandoahGeneration::scan_remembered_set() {
+void ShenandoahGeneration::scan_remembered_set(bool is_concurrent) {
   assert(generation_mode() == YOUNG, "Should only scan remembered set for young generation.");
 
   ShenandoahHeap* const heap = ShenandoahHeap::heap();
@@ -789,8 +789,8 @@ void ShenandoahGeneration::scan_remembered_set() {
   reserve_task_queues(nworkers);
 
   ShenandoahReferenceProcessor* rp = ref_processor();
-  ShenandoahRegionIterator regions;
-  ShenandoahScanRememberedTask task(task_queues(), old_gen_task_queues(), rp, &regions);
+  ShenandoahRegionChunkIterator work_list(nworkers);
+  ShenandoahScanRememberedTask task(task_queues(), old_gen_task_queues(), rp, &work_list, is_concurrent);
   heap->workers()->run_task(&task);
 }
 

--- a/src/hotspot/share/gc/shenandoah/shenandoahGeneration.hpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahGeneration.hpp
@@ -160,7 +160,7 @@ private:
   virtual ShenandoahObjToScanQueueSet* old_gen_task_queues() const;
 
   // Scan remembered set at start of concurrent young-gen marking. */
-  void scan_remembered_set();
+  void scan_remembered_set(bool is_concurrent);
 
   void increment_affiliated_region_count();
   void decrement_affiliated_region_count();

--- a/src/hotspot/share/gc/shenandoah/shenandoahHeap.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahHeap.cpp
@@ -2470,12 +2470,15 @@ class ShenandoahUpdateHeapRefsTask : public WorkerTask {
 private:
   ShenandoahHeap* _heap;
   ShenandoahRegionIterator* _regions;
+  ShenandoahRegionChunkIterator* _work_chunks;
 
 public:
-  explicit ShenandoahUpdateHeapRefsTask(ShenandoahRegionIterator* regions) :
+  explicit ShenandoahUpdateHeapRefsTask(ShenandoahRegionIterator* regions,
+                                        ShenandoahRegionChunkIterator* work_chunks) :
     WorkerTask("Shenandoah Update References"),
     _heap(ShenandoahHeap::heap()),
-    _regions(regions)
+    _regions(regions),
+    _work_chunks(work_chunks)
   {
   }
 
@@ -2504,60 +2507,24 @@ private:
       assert (update_watermark >= r->bottom(), "sanity");
 
       log_debug(gc)("ShenandoahUpdateHeapRefsTask::do_work(%u) looking at region " SIZE_FORMAT, worker_id, r->index());
+      bool region_progress = false;
       if (r->is_active() && !r->is_cset()) {
         if (!_heap->mode()->is_generational() || (r->affiliation() == ShenandoahRegionAffiliation::YOUNG_GENERATION)) {
           _heap->marked_object_oop_iterate(r, &cl, update_watermark);
+          region_progress = true;
         } else if (r->affiliation() == ShenandoahRegionAffiliation::OLD_GENERATION) {
           if (_heap->active_generation()->generation_mode() == GLOBAL) {
-            _heap->marked_object_oop_iterate(r, &cl, update_watermark);
-          } else {
-            // Old region in a young cycle or mixed cycle.
-            if (!is_mixed) {
-              // This is a young evac..
-              _heap->card_scan()->process_region(r, &cl, true);
-            } else {
-              // This is a _mixed_evac.
-              //
-              // TODO: For _mixed_evac, consider building an old-gen remembered set that allows restricted updating
-              // within old-gen HeapRegions.  This remembered set can be constructed by old-gen concurrent marking
-              // and augmented by card marking.  For example, old-gen concurrent marking can remember for each old-gen
-              // card which other old-gen regions it refers to: none, one-other specifically, multiple-other non-specific.
-              // Update-references when _mixed_evac processess each old-gen memory range that has a traditional DIRTY
-              // card or if the "old-gen remembered set" indicates that this card holds pointers specifically to an
-              // old-gen region in the most recent collection set, or if this card holds pointers to other non-specific
-              // old-gen heap regions.
-              if (r->is_humongous()) {
-                // Need to examine both dirty and clean cards during mixed evac.
-                r->oop_iterate_humongous(&cl);
-              } else {
-                // This is a mixed evacuation.  Old regions that are candidates for collection have not been coalesced
-                // and filled.  Use mark bits to find objects that need to be updated.
-                //
-                // Future TODO: establish a second remembered set to identify which old-gen regions point to other old-gen
-                // regions which are in the collection set for a particular mixed evacuation.
-                HeapWord *p = r->bottom();
-                ShenandoahObjectToOopBoundedClosure<T> objs(&cl, p, update_watermark);
+            // Note that GLOBAL collection is not as effectively balanced as young and mixed cycles.  This is because
+            // concurrent GC threads are parceled out entire heap regions of work at a time and there
+            // is no "catchup phase" consisting of remembered set scanning, during which parcels of work are smaller
+            // and more easily distributed more fairly across threads.
 
-                // Anything beyond update_watermark was allocated during evacuation.  Thus, it is known to not hold
-                // references to collection set objects.
-                while (p < update_watermark) {
-                  oop obj = cast_to_oop(p);
-                  if (ctx->is_marked(obj)) {
-                    objs.do_object(obj);
-                    p += obj->size();
-                  } else {
-                    // This object is not marked so we don't scan it.
-                    HeapWord* tams = ctx->top_at_mark_start(r);
-                    if (p >= tams) {
-                      p += obj->size();
-                    } else {
-                      p = ctx->get_next_marked_addr(p, tams);
-                    }
-                  }
-                }
-              }
-            }
+            // TODO: Consider an improvement to load balance GLOBAL GC.
+            _heap->marked_object_oop_iterate(r, &cl, update_watermark);
+            region_progress = true;
           }
+          // Otherwise, this is an old region in a young or mixed cycle.  Process it during a second phase, below.
+          // Don't bother to report pacing progress in this case.
         } else {
           // Because updating of references runs concurrently, it is possible that a FREE inactive region transitions
           // to a non-free active region while this loop is executing.  Whenever this happens, the changing of a region's
@@ -2574,7 +2541,7 @@ private:
                  affiliation_name(r->affiliation()), r->index());
         }
       }
-      if (ShenandoahPacing) {
+      if (region_progress && ShenandoahPacing) {
         _heap->pacer()->report_updaterefs(pointer_delta(update_watermark, r->bottom()));
       }
       if (_heap->check_cancelled_gc_and_yield(CONCURRENT)) {
@@ -2582,21 +2549,140 @@ private:
       }
       r = _regions->next();
     }
+    if (_heap->mode()->is_generational() && (_heap->active_generation()->generation_mode() != GLOBAL)) {
+      // Since this is generational and not GLOBAL, we have to process the remembered set.  There's no remembered
+      // set processing if not in generational mode or if GLOBAL mode.
+
+      // After this thread has exhausted its traditional update-refs work, it continues with updating refs within remembered set.
+      // The remembered set workload is better balanced between threads, so threads that are "behind" can catch up with other
+      // threads during this phase, allowing all threads to work more effectively in parallel.
+      work_chunk assignment;
+      bool have_work = _work_chunks->next(&assignment);
+      RememberedScanner* scanner = _heap->card_scan();
+      while (have_work) {
+        ShenandoahHeapRegion* r = assignment._r;
+        if (r->is_active() && !r->is_cset() && (r->affiliation() == ShenandoahRegionAffiliation::OLD_GENERATION)) {
+          HeapWord* start_of_range = r->bottom() + assignment._chunk_offset;
+          HeapWord* end_of_range = r->get_update_watermark();
+          if (end_of_range > start_of_range + assignment._chunk_size) {
+            end_of_range = start_of_range + assignment._chunk_size;
+          }
+
+          // Old region in a young cycle or mixed cycle.
+          if (is_mixed) {
+            // TODO: For mixed evac, consider building an old-gen remembered set that allows restricted updating
+            // within old-gen HeapRegions.  This remembered set can be constructed by old-gen concurrent marking
+            // and augmented by card marking.  For example, old-gen concurrent marking can remember for each old-gen
+            // card which other old-gen regions it refers to: none, one-other specifically, multiple-other non-specific.
+            // Update-references when _mixed_evac processess each old-gen memory range that has a traditional DIRTY
+            // card or if the "old-gen remembered set" indicates that this card holds pointers specifically to an
+            // old-gen region in the most recent collection set, or if this card holds pointers to other non-specific
+            // old-gen heap regions.
+
+            if (r->is_humongous()) {
+              if (start_of_range < end_of_range) {
+                // Need to examine both dirty and clean cards during mixed evac.
+                r->oop_iterate_humongous_slice(&cl, false, start_of_range, assignment._chunk_size, true, CONCURRENT);
+              }
+            } else {
+              // Since this is mixed evacuation, old regions that are candidates for collection have not been coalesced
+              // and filled.  Use mark bits to find objects that need to be updated.
+              //
+              // Future TODO: establish a second remembered set to identify which old-gen regions point to other old-gen
+              // regions which are in the collection set for a particular mixed evacuation.
+              if (start_of_range < end_of_range) {
+                HeapWord* p = nullptr;
+                size_t card_index = scanner->card_index_for_addr(start_of_range);
+                // In case last object in my range spans boundary of my chunk, I may need to scan all the way to top()
+                ShenandoahObjectToOopBoundedClosure<T> objs(&cl, start_of_range, r->top());
+
+                // Any object that begins in a previous range is part of a different scanning assignment.  Any object that
+                // starts after end_of_range is also not my responsibility.  (Either allocated during evacuation, so does
+                // not hold pointers to from-space, or is beyond the range of my assigned work chunk.)
+
+                // Find the first object that begins in my range, if there is one.
+                p = start_of_range;
+                oop obj = cast_to_oop(p);
+                HeapWord* tams = ctx->top_at_mark_start(r);
+                if (p >= tams) {
+                  // We cannot use ctx->is_marked(obj) to test whether an object begins at this address.  Instead,
+                  // we need to use the remembered set crossing map to advance p to the first object that starts
+                  // within the enclosing card.
+
+                  while (true) {
+                    HeapWord* first_object = scanner->first_object_in_card(card_index);
+                    if (first_object != nullptr) {
+                      p = first_object;
+                      break;
+                    } else if (scanner->addr_for_card_index(card_index + 1) < end_of_range) {
+                      card_index++;
+                    } else {
+                      // Force the loop that follows to immediately terminate.
+                      p = end_of_range;
+                      break;
+                    }
+                  }
+                  obj = cast_to_oop(p);
+                  // Note: p may be >= end_of_range
+                } else if (!ctx->is_marked(obj)) {
+                  p = ctx->get_next_marked_addr(p, tams);
+                  obj = cast_to_oop(p);
+                  // If there are no more marked objects before tams, this returns tams.
+                  // Note that tams is either >= end_of_range, or tams is the start of an object that is marked.
+                }
+                while (p < end_of_range) {
+                  // p is known to point to the beginning of marked object obj
+                  objs.do_object(obj);
+                  HeapWord* prev_p = p;
+                  p += obj->size();
+                  if (p < tams) {
+                    p = ctx->get_next_marked_addr(p, tams);
+                    // If there are no more marked objects before tams, this returns tams.  Note that tams is
+                    // either >= end_of_range, or tams is the start of an object that is marked.
+                  }
+                  assert(p != prev_p, "Lack of forward progress");
+                  obj = cast_to_oop(p);
+                }
+              }
+            }
+          } else {
+            // This is a young evac..
+            if (start_of_range < end_of_range) {
+              size_t cluster_size =
+                CardTable::card_size_in_words() * ShenandoahCardCluster<ShenandoahDirectCardMarkRememberedSet>::CardsPerCluster;
+              size_t clusters = assignment._chunk_size / cluster_size;
+              assert(clusters * cluster_size == assignment._chunk_size, "Chunk assignment must align on cluster boundaries");
+              scanner->process_region_slice(r, assignment._chunk_offset, clusters, end_of_range, &cl, true, CONCURRENT);
+            }
+          }
+          if (ShenandoahPacing && (start_of_range < end_of_range)) {
+            _heap->pacer()->report_updaterefs(pointer_delta(end_of_range, start_of_range));
+          }
+        }
+        // Otherwise, this work chunk had nothing for me to do, so do not report pacer progress.
+
+        // Before we take responsibility for another chunk of work, see if cancellation is requested.
+        if (_heap->check_cancelled_gc_and_yield(CONCURRENT)) {
+          return;
+        }
+        have_work = _work_chunks->next(&assignment);
+      }
+    }
   }
 };
 
 void ShenandoahHeap::update_heap_references(bool concurrent) {
   assert(!is_full_gc_in_progress(), "Only for concurrent and degenerated GC");
+  ShenandoahRegionChunkIterator work_list(workers()->active_workers());
 
   if (concurrent) {
-    ShenandoahUpdateHeapRefsTask<true> task(&_update_refs_iterator);
+    ShenandoahUpdateHeapRefsTask<true> task(&_update_refs_iterator, &work_list);
     workers()->run_task(&task);
   } else {
-    ShenandoahUpdateHeapRefsTask<false> task(&_update_refs_iterator);
+    ShenandoahUpdateHeapRefsTask<false> task(&_update_refs_iterator, &work_list);
     workers()->run_task(&task);
   }
 }
-
 
 class ShenandoahFinalUpdateRefsUpdateRegionStateClosure : public ShenandoahHeapRegionClosure {
 private:

--- a/src/hotspot/share/gc/shenandoah/shenandoahHeap.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahHeap.cpp
@@ -2556,7 +2556,7 @@ private:
       // After this thread has exhausted its traditional update-refs work, it continues with updating refs within remembered set.
       // The remembered set workload is better balanced between threads, so threads that are "behind" can catch up with other
       // threads during this phase, allowing all threads to work more effectively in parallel.
-      work_chunk assignment;
+      struct ShenandoahRegionChunk assignment;
       bool have_work = _work_chunks->next(&assignment);
       RememberedScanner* scanner = _heap->card_scan();
       while (have_work) {

--- a/src/hotspot/share/gc/shenandoah/shenandoahSTWMark.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahSTWMark.cpp
@@ -116,7 +116,7 @@ void ShenandoahSTWMark::mark() {
     // Mark
     if (_generation->generation_mode() == YOUNG) {
       // But only scan the remembered set for young generation.
-      _generation->scan_remembered_set();
+      _generation->scan_remembered_set(false /* is_concurrent */);
     }
 
     StrongRootsScope scope(nworkers);

--- a/src/hotspot/share/gc/shenandoah/shenandoahScanRemembered.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahScanRemembered.cpp
@@ -148,9 +148,9 @@ void ShenandoahScanRememberedTask::do_work(uint worker_id) {
 
 
 size_t ShenandoahRegionChunkIterator::calc_group_size() {
-  // First group does roughly half of heap, one region at a time.  
+  // First group does roughly half of heap, one region at a time.
   // Second group does roughly one quarter of heap, half of a region at a time, and so on.
-  // Last group does the remnant of heap, one _smallest_chunk_size at a time.  
+  // Last group does the remnant of heap, one _smallest_chunk_size at a time.
   // Round down.
   return _heap->num_regions() / 2;
 }
@@ -237,7 +237,7 @@ size_t ShenandoahRegionChunkIterator::calc_total_chunks() {
       assert (last_group_size * chunk_span == unspanned_heap_size, "Chunks must precisely span regions");
       num_chunks += last_group_size;
       return num_chunks;
-    }      
+    }
   }
   return num_chunks;
 }
@@ -281,7 +281,7 @@ ShenandoahRegionChunkIterator::ShenandoahRegionChunkIterator(ShenandoahHeap* hea
 {
   size_t words_in_region = ShenandoahHeapRegion::region_size_words();
   size_t group_span = _first_group_chunk_size * _group_size;
-  
+
   _region_index[0] = 0;
   _group_offset[0] = 0;
   for (size_t i = 1; i < _num_groups; i++) {

--- a/src/hotspot/share/gc/shenandoah/shenandoahScanRemembered.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahScanRemembered.cpp
@@ -146,13 +146,12 @@ void ShenandoahScanRememberedTask::do_work(uint worker_id) {
   }
 }
 
-
 size_t ShenandoahRegionChunkIterator::calc_group_size() {
   // The group size s calculated from the number of regions.  Every group except the last processes the same number of chunks.
   // The last group processes however many chunks are required to finish the total scanning effort.  The chunk sizes are
   // different for each group.  The intention is that the first group processes roughly half of the heap, the second processes
   // a quarter of the remaining heap, the third processes an eight of what remains and so on.  The smallest chunk size
-  // is represented by _smallest_chunk_size.  We do not divide work any smaller than this.  
+  // is represented by _smallest_chunk_size.  We do not divide work any smaller than this.
   //
   // Note that N/2 + N/4 + N/8 + N/16 + ...  sums to N if expanded to infinite terms.
   return _heap->num_regions() / 2;

--- a/src/hotspot/share/gc/shenandoah/shenandoahScanRemembered.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahScanRemembered.cpp
@@ -87,29 +87,215 @@ void ShenandoahDirectCardMarkRememberedSet::merge_overreach(size_t first_cluster
 ShenandoahScanRememberedTask::ShenandoahScanRememberedTask(ShenandoahObjToScanQueueSet* queue_set,
                                                            ShenandoahObjToScanQueueSet* old_queue_set,
                                                            ShenandoahReferenceProcessor* rp,
-                                                           ShenandoahRegionIterator* regions) :
+                                                           ShenandoahRegionChunkIterator* work_list, bool is_concurrent) :
   WorkerTask("Scan Remembered Set"),
-  _queue_set(queue_set), _old_queue_set(old_queue_set), _rp(rp), _regions(regions) {}
+  _queue_set(queue_set), _old_queue_set(old_queue_set), _rp(rp), _work_list(work_list), _is_concurrent(is_concurrent) {}
 
 void ShenandoahScanRememberedTask::work(uint worker_id) {
-  // This sets up a thread local reference to the worker_id which is necessary
-  // the weak reference processor.
-  ShenandoahParallelWorkerSession worker_session(worker_id);
+  if (_is_concurrent) {
+    // This sets up a thread local reference to the worker_id which is needed by the weak reference processor.
+    ShenandoahConcurrentWorkerSession worker_session(worker_id);
+    ShenandoahSuspendibleThreadSetJoiner stsj(ShenandoahSuspendibleWorkers);
+    do_work(worker_id);
+  } else {
+    // This sets up a thread local reference to the worker_id which is needed by the weak reference processor.
+    ShenandoahParallelWorkerSession worker_session(worker_id);
+    do_work(worker_id);
+  }
+}
+
+void ShenandoahScanRememberedTask::do_work(uint worker_id) {
   ShenandoahWorkerTimingsTracker x(ShenandoahPhaseTimings::init_scan_rset, ShenandoahPhaseTimings::ScanClusters, worker_id);
 
   ShenandoahObjToScanQueue* q = _queue_set->queue(worker_id);
   ShenandoahObjToScanQueue* old = _old_queue_set == NULL ? NULL : _old_queue_set->queue(worker_id);
   ShenandoahMarkRefsClosure<YOUNG> cl(q, _rp, old);
-  RememberedScanner* scanner = ShenandoahHeap::heap()->card_scan();
+  ShenandoahHeap* heap = ShenandoahHeap::heap();
+  RememberedScanner* scanner = heap->card_scan();
 
   // set up thread local closure for shen ref processor
   _rp->set_mark_closure(worker_id, &cl);
-  ShenandoahHeapRegion* region = _regions->next();
-  while (region != NULL) {
-    log_debug(gc)("ShenandoahScanRememberedTask::work(%u), looking at region " SIZE_FORMAT, worker_id, region->index());
-    if (region->affiliation() == OLD_GENERATION) {
-      scanner->process_region(region, &cl);
+  work_chunk assignment;
+  bool has_work = _work_list->next(&assignment);
+  while (has_work) {
+#ifdef ENABLE_REMEMBERED_SET_CANCELLATION
+    // This check is currently disabled to avoid crashes that occur
+    // when we try to cancel remembered set scanning
+    if (heap->check_cancelled_gc_and_yield(_is_concurrent)) {
+      return;
     }
-    region = _regions->next();
+#endif
+    ShenandoahHeapRegion* region = assignment._r;
+    log_debug(gc)("ShenandoahScanRememberedTask::do_work(%u), processing slice of region "
+                  SIZE_FORMAT " at offset " SIZE_FORMAT ", size: " SIZE_FORMAT,
+                  worker_id, region->index(), assignment._chunk_offset, assignment._chunk_size);
+    if (region->affiliation() == OLD_GENERATION) {
+      size_t cluster_size =
+        CardTable::card_size_in_words() * ShenandoahCardCluster<ShenandoahDirectCardMarkRememberedSet>::CardsPerCluster;
+      size_t clusters = assignment._chunk_size / cluster_size;
+      assert(clusters * cluster_size == assignment._chunk_size, "Chunk assignments must align on cluster boundaries");
+      HeapWord* end_of_range = region->bottom() + assignment._chunk_offset + assignment._chunk_size;
+
+      // During concurrent mark, region->top() equals TAMS with respect to the current young-gen pass.  */
+      if (end_of_range > region->top()) {
+        end_of_range = region->top();
+      }
+      scanner->process_region_slice(region, assignment._chunk_offset, clusters, end_of_range, &cl, false, _is_concurrent);
+    }
+    has_work = _work_list->next(&assignment);
   }
+}
+
+
+size_t ShenandoahRegionChunkIterator::calc_group_size() {
+  // First group does roughly half of heap, one region at a time.  
+  // Second group does roughly one quarter of heap, half of a region at a time, and so on.
+  // Last group does the remnant of heap, one _smallest_chunk_size at a time.  
+  // Round down.
+  return _heap->num_regions() / 2;
+}
+
+size_t ShenandoahRegionChunkIterator::calc_first_group_chunk_size() {
+  size_t words_in_region = ShenandoahHeapRegion::region_size_words();
+  return words_in_region;
+}
+
+size_t ShenandoahRegionChunkIterator::calc_num_groups() {
+  size_t total_heap_size = _heap->num_regions() * ShenandoahHeapRegion::region_size_words();
+  size_t num_groups = 0;
+  size_t cumulative_group_span = 0;
+  size_t current_group_span = _first_group_chunk_size * _group_size;
+  size_t smallest_group_span = _smallest_chunk_size * _group_size;
+  while ((num_groups < _maximum_groups) && (cumulative_group_span + current_group_span <= total_heap_size)) {
+    num_groups++;
+    cumulative_group_span += current_group_span;
+    if (current_group_span <= smallest_group_span) {
+      break;
+    } else {
+      current_group_span /= 2;    // Each group spans half of what the preceding group spanned.
+    }
+  }
+  // Loop post condition:
+  //   num_groups <= _maximum_groups
+  //   cumulative_group_span is the memory spanned by num_groups
+  //   current_group_span is the span of the last fully populated group (assuming loop iterates at least once)
+  //   each of num_groups is fully populated with _group_size chunks in each
+  // Non post conditions:
+  //   cumulative_group_span may be less than total_heap size for one or more of the folowing reasons
+  //   a) The number of regions remaining to be spanned is smaller than a complete group, or
+  //   b) We have filled up all groups through _maximum_groups and still have not spanned all regions
+
+  if (cumulative_group_span < total_heap_size) {
+    // We've got more regions to span
+    if ((num_groups < _maximum_groups) && (current_group_span > smallest_group_span)) {
+      num_groups++;             // Place all remaining regions into a new not-full group (chunk_size half that of previous group)
+    }
+    // Else we are unable to create a new group because we've exceed the number of allowed groups or have reached the
+    // minimum chunk size.
+
+    // Any remaining regions will be treated as if they are part of the most recently created group.  This group will
+    // have more than _group_size chunks within it.
+  }
+  return num_groups;
+}
+
+size_t ShenandoahRegionChunkIterator::calc_total_chunks() {
+  size_t region_size_words = ShenandoahHeapRegion::region_size_words();
+  size_t unspanned_heap_size = _heap->num_regions() * region_size_words;
+  size_t num_chunks = 0;
+  size_t num_groups = 0;
+  size_t cumulative_group_span = 0;
+  size_t current_group_span = _first_group_chunk_size * _group_size;
+  size_t smallest_group_span = _smallest_chunk_size * _group_size;
+  while (unspanned_heap_size > 0) {
+    if (current_group_span <= unspanned_heap_size) {
+      unspanned_heap_size -= current_group_span;
+      num_chunks += _group_size;
+      num_groups++;
+
+      if (num_groups >= _num_groups) {
+        // The last group has more than _group_size entries.
+        size_t chunk_span = current_group_span / _group_size;
+        size_t extra_chunks = unspanned_heap_size / chunk_span;
+        assert (extra_chunks * chunk_span == unspanned_heap_size, "Chunks must precisely span regions");
+        num_chunks += extra_chunks;
+        return num_chunks;
+      } else if (current_group_span <= smallest_group_span) {
+        // We cannot introduce new groups because we've reached the lower bound on group size
+        size_t chunk_span = _smallest_chunk_size;
+        size_t extra_chunks = unspanned_heap_size / chunk_span;
+        assert (extra_chunks * chunk_span == unspanned_heap_size, "Chunks must precisely span regions");
+        num_chunks += extra_chunks;
+        return num_chunks;
+      } else {
+        current_group_span /= 2;
+      }
+    } else {
+      // The last group has fewer than _group_size entries.
+      size_t chunk_span = current_group_span / _group_size;
+      size_t last_group_size = unspanned_heap_size / chunk_span;
+      assert (last_group_size * chunk_span == unspanned_heap_size, "Chunks must precisely span regions");
+      num_chunks += last_group_size;
+      return num_chunks;
+    }      
+  }
+  return num_chunks;
+}
+
+ShenandoahRegionChunkIterator::ShenandoahRegionChunkIterator(size_t worker_count) :
+    _heap(ShenandoahHeap::heap()),
+    _group_size(calc_group_size()),
+    _first_group_chunk_size(calc_first_group_chunk_size()),
+    _num_groups(calc_num_groups()),
+    _total_chunks(calc_total_chunks()),
+    _index(0)
+{
+  assert(_smallest_chunk_size ==
+         CardTable::card_size_in_words() * ShenandoahCardCluster<ShenandoahDirectCardMarkRememberedSet>::CardsPerCluster,
+         "_smallest_chunk_size is not valid");
+
+  size_t words_in_region = ShenandoahHeapRegion::region_size_words();
+  size_t group_span = _first_group_chunk_size * _group_size;
+
+  _region_index[0] = 0;
+  _group_offset[0] = 0;
+  for (size_t i = 1; i < _num_groups; i++) {
+    _region_index[i] = _region_index[i-1] + (_group_offset[i-1] + group_span) / words_in_region;
+    _group_offset[i] = (_group_offset[i-1] + group_span) % words_in_region;
+    group_span /= 2;
+  }
+  // Not necessary, but keeps things tidy
+  for (size_t i = _num_groups; i < _maximum_groups; i++) {
+    _region_index[i] = 0;
+    _group_offset[i] = 0;
+  }
+}
+
+ShenandoahRegionChunkIterator::ShenandoahRegionChunkIterator(ShenandoahHeap* heap, size_t worker_count) :
+    _heap(heap),
+    _group_size(calc_group_size()),
+    _first_group_chunk_size(calc_first_group_chunk_size()),
+    _num_groups(calc_num_groups()),
+    _total_chunks(calc_total_chunks()),
+    _index(0)
+{
+  size_t words_in_region = ShenandoahHeapRegion::region_size_words();
+  size_t group_span = _first_group_chunk_size * _group_size;
+  
+  _region_index[0] = 0;
+  _group_offset[0] = 0;
+  for (size_t i = 1; i < _num_groups; i++) {
+    _region_index[i] = _region_index[i-1] + (_group_offset[i-1] + group_span) / words_in_region;
+    _group_offset[i] = (_group_offset[i-1] + group_span) % words_in_region;
+    group_span /= 2;
+  }
+  // Not necessary, but keeps things tidy
+  for (size_t i = _num_groups; i < _maximum_groups; i++) {
+    _region_index[i] = 0;
+    _group_offset[i] = 0;
+  }
+}
+
+void ShenandoahRegionChunkIterator::reset() {
+  _index = 0;
 }

--- a/src/hotspot/share/gc/shenandoah/shenandoahScanRemembered.hpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahScanRemembered.hpp
@@ -1047,7 +1047,6 @@ private:
   // than _smallest_chunk_size, which is 32 KB.
 
   // Under normal circumstances, no configuration needs more than _maximum_groups (default value of 16).
-  // 
 
   static const size_t _maximum_groups = 16;
 

--- a/src/hotspot/share/gc/shenandoah/shenandoahScanRemembered.hpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahScanRemembered.hpp
@@ -209,6 +209,7 @@
 #include "memory/iterator.hpp"
 #include "gc/shared/workerThread.hpp"
 #include "gc/shenandoah/shenandoahCardTable.hpp"
+#include "gc/shenandoah/shenandoahHeap.hpp"
 #include "gc/shenandoah/shenandoahHeapRegion.hpp"
 #include "gc/shenandoah/shenandoahTaskqueue.hpp"
 
@@ -923,11 +924,20 @@ public:
   void clear_old_remset() { _rs->clear_old_remset(); }
 
   size_t cluster_for_addr(HeapWord *addr);
+  HeapWord* addr_for_cluster(size_t cluster_no);
 
   void reset_object_range(HeapWord *from, HeapWord *to);
   void register_object(HeapWord *addr);
   void register_object_wo_lock(HeapWord *addr);
   void coalesce_objects(HeapWord *addr, size_t length_in_words);
+
+  HeapWord* first_object_in_card(size_t card_index) {
+    if (_scc->has_object(card_index)) {
+      return addr_for_card_index(card_index) + _scc->get_first_start(card_index);
+    } else {
+      return nullptr;
+    }
+  }
 
   // Return true iff this object is "properly" registered.
   bool verify_registration(HeapWord* address, ShenandoahMarkingContext* ctx);
@@ -967,16 +977,26 @@ public:
   // the template expansions were making it difficult for the link/loader to resolve references to the template-
   // parameterized implementations of this service.
   template <typename ClosureType>
-  inline void process_clusters(size_t first_cluster, size_t count, HeapWord *end_of_range, ClosureType *oops);
+  inline void process_clusters(size_t first_cluster, size_t count, HeapWord *end_of_range, ClosureType *oops, bool is_concurrent);
 
   template <typename ClosureType>
-  inline void process_clusters(size_t first_cluster, size_t count, HeapWord *end_of_range, ClosureType *oops, bool use_write_table);
+  inline void process_clusters(size_t first_cluster, size_t count, HeapWord *end_of_range, ClosureType *oops,
+                               bool use_write_table, bool is_concurrent);
 
   template <typename ClosureType>
-  inline void process_region(ShenandoahHeapRegion* region, ClosureType *cl);
+  inline void process_humongous_clusters(ShenandoahHeapRegion* r, size_t first_cluster, size_t count,
+                                         HeapWord *end_of_range, ClosureType *oops, bool use_write_table, bool is_concurrent);
+
 
   template <typename ClosureType>
-  inline void process_region(ShenandoahHeapRegion* region, ClosureType *cl, bool use_write_table);
+  inline void process_region(ShenandoahHeapRegion* region, ClosureType *cl, bool is_concurrent);
+
+  template <typename ClosureType>
+  inline void process_region(ShenandoahHeapRegion* region, ClosureType *cl, bool use_write_table, bool is_concurrent);
+
+  template <typename ClosureType>
+  inline void process_region_slice(ShenandoahHeapRegion* region, size_t offset, size_t clusters, HeapWord* end_of_range,
+                                   ClosureType *cl, bool use_write_table, bool is_concurrent);
 
   // To Do:
   //  Create subclasses of ShenandoahInitMarkRootsClosure and
@@ -1002,6 +1022,81 @@ public:
   void roots_do(OopIterateClosure* cl);
 };
 
+typedef struct ChunkOfRegion {
+  ShenandoahHeapRegion *_r;
+  size_t _chunk_offset;          // HeapWordSize offset
+  size_t _chunk_size;            // HeapWordSize qty
+} work_chunk;
+
+class ShenandoahRegionChunkIterator : public StackObj {
+private:
+  // smallest_chunk_size is 64 words per card *
+  // ShenandoahCardCluster<ShenandoahDirectCardMarkRememberedSet>::CardsPerCluster.
+  // This is computed from CardTable::card_size_in_words() *
+  //      ShenandoahCardCluster<ShenandoahDirectCardMarkRememberedSet>::CardsPerCluster;
+  // We can't perform this computation here, because of encapsulation and initialization constraints.  We paste
+  // the magic number here, and assert that this number matches the intended computation in constructor.
+  static const size_t _smallest_chunk_size = 64 * ShenandoahCardCluster<ShenandoahDirectCardMarkRememberedSet>::CardsPerCluster;
+
+  // The total remembered set scanning effort is divided into chunks of work that are assigned to individual worker tasks.
+  // The chunks of assigned work are divided into groups, where the size of each group (_group_size) is 4 * the number of
+  // worker tasks.  All of the assignments within a group represent the same amount of memory to be scanned.  Each of the
+  // assignments within the first group are of size _first_group_chunk_size (typically the ShenandoahHeapRegion size, but
+  // possibly smaller.  Each of the assignments within each subsequent group are half the size of the assignments in the
+  // preceding group.  The last group may be larger than the others.  Because no group is allowed to have smaller assignments
+  // than _smallest_chunk_size, which is 32 KB.
+
+  // Under normal circumstances, no configuration needs more than _maximum_groups (default value of 16).
+  // 
+
+  static const size_t _maximum_groups = 16;
+
+  const ShenandoahHeap* _heap;
+
+  const size_t _group_size;                        // Number of chunks in each group, equals worker_threads * 8
+  const size_t _first_group_chunk_size;
+  const size_t _num_groups;                        // Number of groups in this configuration
+  const size_t _total_chunks;
+
+  shenandoah_padding(0);
+  volatile size_t _index;
+  shenandoah_padding(1);
+
+  size_t _region_index[_maximum_groups];
+  size_t _group_offset[_maximum_groups];
+
+
+  // No implicit copying: iterators should be passed by reference to capture the state
+  NONCOPYABLE(ShenandoahRegionChunkIterator);
+
+  // Makes use of _heap.
+  size_t calc_group_size();
+
+  // Makes use of _group_size, which must be initialized before call.
+  size_t calc_first_group_chunk_size();
+
+  // Makes use of _group_size and _first_group_chunk_size, both of which must be initialized before call.
+  size_t calc_num_groups();
+
+  // Makes use of _group_size, _first_group_chunk_size, which must be initialized before call.
+  size_t calc_total_chunks();
+
+public:
+  ShenandoahRegionChunkIterator(size_t worker_count);
+  ShenandoahRegionChunkIterator(ShenandoahHeap* heap, size_t worker_count);
+
+  // Reset iterator to default state
+  void reset();
+
+  // Fills in assignment with next chunk of work and returns true iff there is more work.
+  // Otherwise, returns false.  This is multi-thread-safe.
+  inline bool next(work_chunk *assignment);
+
+  // This is *not* MT safe. However, in the absence of multithreaded access, it
+  // can be used to determine if there is more work to do.
+  inline bool has_next() const;
+};
+
 typedef ShenandoahScanRemembered<ShenandoahDirectCardMarkRememberedSet> RememberedScanner;
 
 class ShenandoahScanRememberedTask : public WorkerTask {
@@ -1009,13 +1104,16 @@ class ShenandoahScanRememberedTask : public WorkerTask {
   ShenandoahObjToScanQueueSet* _queue_set;
   ShenandoahObjToScanQueueSet* _old_queue_set;
   ShenandoahReferenceProcessor* _rp;
-  ShenandoahRegionIterator* _regions;
+  ShenandoahRegionChunkIterator* _work_list;
+  bool _is_concurrent;
  public:
   ShenandoahScanRememberedTask(ShenandoahObjToScanQueueSet* queue_set,
                                ShenandoahObjToScanQueueSet* old_queue_set,
                                ShenandoahReferenceProcessor* rp,
-                               ShenandoahRegionIterator* regions);
+                               ShenandoahRegionChunkIterator* work_list,
+                               bool is_concurrent);
 
   void work(uint worker_id);
+  void do_work(uint worker_id);
 };
 #endif // SHARE_GC_SHENANDOAH_SHENANDOAHSCANREMEMBERED_HPP

--- a/src/hotspot/share/gc/shenandoah/shenandoahScanRemembered.hpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahScanRemembered.hpp
@@ -1022,11 +1022,11 @@ public:
   void roots_do(OopIterateClosure* cl);
 };
 
-typedef struct ChunkOfRegion {
+struct ShenandoahRegionChunk {
   ShenandoahHeapRegion *_r;
   size_t _chunk_offset;          // HeapWordSize offset
   size_t _chunk_size;            // HeapWordSize qty
-} work_chunk;
+};
 
 class ShenandoahRegionChunkIterator : public StackObj {
 private:
@@ -1089,7 +1089,7 @@ public:
 
   // Fills in assignment with next chunk of work and returns true iff there is more work.
   // Otherwise, returns false.  This is multi-thread-safe.
-  inline bool next(work_chunk *assignment);
+  inline bool next(struct ShenandoahRegionChunk *assignment);
 
   // This is *not* MT safe. However, in the absence of multithreaded access, it
   // can be used to determine if there is more work to do.

--- a/src/hotspot/share/gc/shenandoah/shenandoahScanRemembered.inline.hpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahScanRemembered.inline.hpp
@@ -821,7 +821,7 @@ inline bool ShenandoahRegionChunkIterator::has_next() const {
   return _index < _total_chunks;
 }
 
-inline bool ShenandoahRegionChunkIterator::next(work_chunk *assignment) {
+inline bool ShenandoahRegionChunkIterator::next(struct ShenandoahRegionChunk *assignment) {
   if (_index > _total_chunks) {
     return false;
   }

--- a/src/hotspot/share/gc/shenandoah/shenandoahScanRemembered.inline.hpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahScanRemembered.inline.hpp
@@ -848,7 +848,7 @@ inline bool ShenandoahRegionChunkIterator::next(work_chunk *assignment) {
   size_t regions_spanned_by_chunk_offset = offset_of_this_chunk / region_size_words;
   size_t region_index = group_region_index + regions_spanned_by_chunk_offset;
   size_t offset_within_region = offset_of_this_chunk % region_size_words;
-  
+
   assignment->_r = _heap->get_region(region_index);
   assignment->_chunk_offset = offset_within_region;
   assignment->_chunk_size = group_chunk_size;

--- a/src/hotspot/share/gc/shenandoah/shenandoahScanRemembered.inline.hpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahScanRemembered.inline.hpp
@@ -449,9 +449,12 @@ ShenandoahScanRemembered<RememberedSet>::verify_registration(HeapWord* address, 
         last_obj = obj;
       } else {
         offset = ctx->get_next_marked_addr(base_addr + offset, tams) - base_addr;
-        // offset will be zero if no objects are marked in this card.
+        // If there are no marked objects remaining in this region, offset equals tams - base_addr.  If this offset is
+        // greater than max_offset, we will immediately exit this loop.  Otherwise, the next iteration of the loop will
+        // treat the object at offset as marked and live (because address >= tams) and we will continue iterating object
+        // by consulting the size() fields of each.
       }
-    } while (offset > 0 && offset < max_offset);
+    } while (offset < max_offset);
     if (last_obj != nullptr && prev_offset + last_obj->size() >= max_offset) {
       // last marked object extends beyond end of card
       if (_scc->get_last_start(index) != prev_offset) {
@@ -481,18 +484,21 @@ template<typename RememberedSet>
 template <typename ClosureType>
 inline void
 ShenandoahScanRemembered<RememberedSet>::process_clusters(size_t first_cluster, size_t count, HeapWord *end_of_range,
-                                                          ClosureType *cl) {
-  process_clusters(first_cluster, count, end_of_range, cl, false);
+                                                          ClosureType *cl, bool is_concurrent) {
+  process_clusters(first_cluster, count, end_of_range, cl, false, is_concurrent);
 }
 
 // Process all objects starting within count clusters beginning with first_cluster for which the start address is
-// less than end_of_range.  For any such object, process the complete object, even if its end reaches beyond
-// end_of_range.
+// less than end_of_range.  For any such object, process the complete object, even if its end reaches beyond end_of_range.
+
+// Do not CANCEL within process_clusters.  It is assumed that if a worker thread accepts responsbility for processing
+// a chunk of work, it will finish the work it starts.  Otherwise, the chunk of work will be lost in the transition to
+// degenerated execution.
 template<typename RememberedSet>
 template <typename ClosureType>
 inline void
 ShenandoahScanRemembered<RememberedSet>::process_clusters(size_t first_cluster, size_t count, HeapWord *end_of_range,
-                                                          ClosureType *cl, bool write_table) {
+                                                          ClosureType *cl, bool write_table, bool is_concurrent) {
 
   // Unlike traditional Shenandoah marking, the old-gen resident objects that are examined as part of the remembered set are not
   // themselves marked.  Each such object will be scanned only once.  Any young-gen objects referenced from the remembered set will
@@ -514,14 +520,24 @@ ShenandoahScanRemembered<RememberedSet>::process_clusters(size_t first_cluster, 
     ctx = nullptr;
   }
 
-  HeapWord* end_of_clusters = _rs->addr_for_card_index(first_cluster)
-    + count * ShenandoahCardCluster<RememberedSet>::CardsPerCluster * CardTable::card_size_in_words();
+  size_t card_index = first_cluster * ShenandoahCardCluster<RememberedSet>::CardsPerCluster;
+  HeapWord *start_of_range = _rs->addr_for_card_index(card_index);
+  ShenandoahHeapRegion* r = heap->heap_region_containing(start_of_range);
+  assert(end_of_range <= r->top(), "process_clusters() examines one region at a time");
+
   while (count-- > 0) {
-    size_t card_index = first_cluster * ShenandoahCardCluster<RememberedSet>::CardsPerCluster;
+    // TODO: do we want to check cancellation in inner loop, on every card processed?  That would be more responsive,
+    // but require more overhead for checking.
+    card_index = first_cluster * ShenandoahCardCluster<RememberedSet>::CardsPerCluster;
     size_t end_card_index = card_index + ShenandoahCardCluster<RememberedSet>::CardsPerCluster;
     first_cluster++;
     size_t next_card_index = 0;
     while (card_index < end_card_index) {
+      if (_rs->addr_for_card_index(card_index) > end_of_range) {
+        count = 0;
+        card_index = end_card_index;
+        break;
+      }
       bool is_dirty = (write_table)? is_write_card_dirty(card_index): is_card_dirty(card_index);
       bool has_object = _scc->has_object(card_index);
       if (is_dirty) {
@@ -532,6 +548,8 @@ ShenandoahScanRemembered<RememberedSet>::process_clusters(size_t first_cluster, 
           HeapWord *p = _rs->addr_for_card_index(card_index);
           HeapWord *card_start = p;
           HeapWord *endp = p + CardTable::card_size_in_words();
+          assert(!r->is_humongous(), "Process humongous regions elsewhere");
+
           if (endp > end_of_range) {
             endp = end_of_range;
             next_card_index = end_card_index;
@@ -569,8 +587,7 @@ ShenandoahScanRemembered<RememberedSet>::process_clusters(size_t first_cluster, 
               }
               p += obj->size();
             } else {
-              // This object is not marked so we don't scan it.
-              ShenandoahHeapRegion* r = heap->heap_region_containing(p);
+              // This object is not marked so we don't scan it.  Containing region r is initialized above.
               HeapWord* tams = ctx->top_at_mark_start(r);
               if (p >= tams) {
                 p += obj->size();
@@ -618,6 +635,11 @@ ShenandoahScanRemembered<RememberedSet>::process_clusters(size_t first_cluster, 
               }
           }
 
+          // TODO: only iterate over this object if it spans dirty within this cluster or within following clusters.
+          // Code as written is known not to examine a zombie object because either the object is marked, or we are
+          // not using the mark-context to differentiate objects, so the object is known to have been coalesced and
+          // filled if it is not "live".
+
           if (reaches_next_cluster || spans_dirty_within_this_cluster) {
             if (obj->is_objArray()) {
               objArrayOop array = objArrayOop(obj);
@@ -635,8 +657,7 @@ ShenandoahScanRemembered<RememberedSet>::process_clusters(size_t first_cluster, 
           }
         } else {
           // The object that spans end of this clean card is not marked, so no need to scan it or its
-          // unmarked neighbors.
-          ShenandoahHeapRegion* r = heap->heap_region_containing(p);
+          // unmarked neighbors.  Containing region r is initialized above.
           HeapWord* tams = ctx->top_at_mark_start(r);
           HeapWord* nextp;
           if (p >= tams) {
@@ -656,19 +677,58 @@ ShenandoahScanRemembered<RememberedSet>::process_clusters(size_t first_cluster, 
   }
 }
 
+// Given that this range of clusters is known to span a humongous object spanned by region r, scan the
+// portion of the humongous object that corresponds to the specified range.
 template<typename RememberedSet>
 template <typename ClosureType>
 inline void
-ShenandoahScanRemembered<RememberedSet>::process_region(ShenandoahHeapRegion *region, ClosureType *cl) {
-  process_region(region, cl, false);
+ShenandoahScanRemembered<RememberedSet>::process_humongous_clusters(ShenandoahHeapRegion* r, size_t first_cluster, size_t count,
+                                                                    HeapWord *end_of_range, ClosureType *cl, bool write_table,
+                                                                    bool is_concurrent) {
+  ShenandoahHeapRegion* start_region = r->humongous_start_region();
+  HeapWord* p = start_region->bottom();
+  oop obj = cast_to_oop(p);
+  assert(r->is_humongous(), "Only process humongous regions here");
+  assert(start_region->is_humongous_start(), "Should be start of humongous region");
+  assert(p + obj->size() >= end_of_range, "Humongous object ends before range ends");
+
+  size_t first_card_index = first_cluster * ShenandoahCardCluster<RememberedSet>::CardsPerCluster;
+  HeapWord* first_cluster_addr = _rs->addr_for_card_index(first_card_index);
+  size_t spanned_words = count * ShenandoahCardCluster<RememberedSet>::CardsPerCluster * CardTable::card_size_in_words();
+
+  start_region->oop_iterate_humongous_slice(cl, true, first_cluster_addr, spanned_words, write_table, is_concurrent);
 }
 
 template<typename RememberedSet>
 template <typename ClosureType>
 inline void
-ShenandoahScanRemembered<RememberedSet>::process_region(ShenandoahHeapRegion *region, ClosureType *cl, bool use_write_table) {
-  HeapWord *start_of_range = region->bottom();
+ShenandoahScanRemembered<RememberedSet>::process_region(ShenandoahHeapRegion *region, ClosureType *cl, bool is_concurrent) {
+  process_region(region, cl, false, is_concurrent);
+}
+
+template<typename RememberedSet>
+template <typename ClosureType>
+inline void
+ShenandoahScanRemembered<RememberedSet>::process_region(ShenandoahHeapRegion *region, ClosureType *cl,
+                                                        bool use_write_table, bool is_concurrent) {
+  size_t cluster_size =
+    CardTable::card_size_in_words() * ShenandoahCardCluster<ShenandoahDirectCardMarkRememberedSet>::CardsPerCluster;
+  size_t clusters = ShenandoahHeapRegion::region_size_words() / cluster_size;
+  process_region_slice(region, 0, clusters, region->end(), cl, use_write_table, is_concurrent);
+}
+
+template<typename RememberedSet>
+template <typename ClosureType>
+inline void
+ShenandoahScanRemembered<RememberedSet>::process_region_slice(ShenandoahHeapRegion *region, size_t start_offset, size_t clusters,
+                                                              HeapWord *end_of_range, ClosureType *cl, bool use_write_table,
+                                                              bool is_concurrent) {
+  HeapWord *start_of_range = region->bottom() + start_offset;
+  size_t cluster_size =
+    CardTable::card_size_in_words() * ShenandoahCardCluster<ShenandoahDirectCardMarkRememberedSet>::CardsPerCluster;
+  size_t words = clusters * cluster_size;
   size_t start_cluster_no = cluster_for_addr(start_of_range);
+  assert(addr_for_cluster(start_cluster_no) == start_of_range, "process_region_slice range must align on cluster boundary");
 
   // region->end() represents the end of memory spanned by this region, but not all of this
   //   memory is eligible to be scanned because some of this memory has not yet been allocated.
@@ -676,34 +736,43 @@ ShenandoahScanRemembered<RememberedSet>::process_region(ShenandoahHeapRegion *re
   // region->top() represents the end of allocated memory within this region.  Any addresses
   //   beyond region->top() should not be scanned as that memory does not hold valid objects.
 
-  HeapWord *end_of_range;
   if (use_write_table) {
     // This is update-refs servicing.
-    end_of_range = region->get_update_watermark();
+    if (end_of_range > region->get_update_watermark()) {
+      end_of_range = region->get_update_watermark();
+    }
   } else {
     // This is concurrent mark servicing.  Note that TAMS for this region is TAMS at start of old-gen
     // collection.  Here, we need to scan up to TAMS for most recently initiated young-gen collection.
     // Since all LABs are retired at init mark, and since replacement LABs are allocated lazily, and since no
     // promotions occur until evacuation phase, TAMS for most recent young-gen is same as top().
-    end_of_range = region->top();
+    if (end_of_range > region->top()) {
+      end_of_range = region->top();
+    }
   }
 
   log_debug(gc)("Remembered set scan processing Region " SIZE_FORMAT ", from " PTR_FORMAT " to " PTR_FORMAT ", using %s table",
-                region->index(), p2i(region->bottom()), p2i(end_of_range),
+                region->index(), p2i(start_of_range), p2i(end_of_range),
                 use_write_table? "read/write (updating)": "read (marking)");
-  // end_of_range may point to the middle of a cluster because region->top() may be different than region->end().
+
+  // Note that end_of_range may point to the middle of a cluster because region->top() or region->get_update_watermark() may
+  // be less than start_of_range + words.
+
   // We want to assure that our process_clusters() request spans all relevant clusters.  Note that each cluster
   // processed will avoid processing beyond end_of_range.
 
   // Note that any object that starts between start_of_range and end_of_range, including humongous objects, will
   // be fully processed by process_clusters, even though the object may reach beyond end_of_range.
-  size_t num_heapwords = end_of_range - start_of_range;
-  unsigned int cluster_size = CardTable::card_size_in_words() * ShenandoahCardCluster<ShenandoahDirectCardMarkRememberedSet>::CardsPerCluster;
-  size_t num_clusters = (size_t) ((num_heapwords - 1 + cluster_size) / cluster_size);
 
-  if (!region->is_humongous_continuation()) {
-    // Remembered set scanner
-    process_clusters(start_cluster_no, num_clusters, end_of_range, cl, use_write_table);
+  // If I am assigned to process a range that starts beyond end_of_range (top or update-watermark), we have no work to do.
+
+  if (start_of_range < end_of_range) {
+    if (region->is_humongous()) {
+      ShenandoahHeapRegion* start_region = region->humongous_start_region();
+      process_humongous_clusters(start_region, start_cluster_no, clusters, end_of_range, cl, use_write_table, is_concurrent);
+    } else {
+      process_clusters(start_cluster_no, clusters, end_of_range, cl, use_write_table, is_concurrent);
+    }
   }
 }
 
@@ -713,6 +782,13 @@ ShenandoahScanRemembered<RememberedSet>::cluster_for_addr(HeapWordImpl **addr) {
   size_t card_index = _rs->card_index_for_addr(addr);
   size_t result = card_index / ShenandoahCardCluster<RememberedSet>::CardsPerCluster;
   return result;
+}
+
+template<typename RememberedSet>
+inline HeapWord*
+ShenandoahScanRemembered<RememberedSet>::addr_for_cluster(size_t cluster_no) {
+  size_t card_index = cluster_no * ShenandoahCardCluster<RememberedSet>::CardsPerCluster;
+  return addr_for_card_index(card_index);
 }
 
 // This is used only for debug verification so don't worry about making the scan parallel.
@@ -731,9 +807,53 @@ inline void ShenandoahScanRemembered<RememberedSet>::roots_do(OopIterateClosure*
       size_t num_clusters = (size_t) ((num_heapwords - 1 + cluster_size) / cluster_size);
 
       // Remembered set scanner
-      process_clusters(start_cluster_no, num_clusters, end_of_range, cl);
+      if (region->is_humongous()) {
+        process_humongous_clusters(region->humongous_start_region(), start_cluster_no, num_clusters, end_of_range, cl,
+                                   false /* is_write_table */, false /* is_concurrent */);
+      } else {
+        process_clusters(start_cluster_no, num_clusters, end_of_range, cl, false /* is_concurrent */);
+      }
     }
   }
+}
+
+inline bool ShenandoahRegionChunkIterator::has_next() const {
+  return _index < _total_chunks;
+}
+
+inline bool ShenandoahRegionChunkIterator::next(work_chunk *assignment) {
+  if (_index > _total_chunks) {
+    return false;
+  }
+  size_t new_index = Atomic::add(&_index, (size_t) 1, memory_order_relaxed);
+  if (new_index > _total_chunks) {
+    return false;
+  }
+  // convert to zero-based indexing
+  new_index--;
+
+  size_t group_no = new_index / _group_size;
+  if (group_no + 1 > _num_groups) {
+    group_no = _num_groups - 1;
+  }
+
+  // All size computations measured in HeapWord
+  size_t region_size_words = ShenandoahHeapRegion::region_size_words();
+  size_t group_region_index = _region_index[group_no];
+  size_t group_region_offset = _group_offset[group_no];
+
+  size_t index_within_group = new_index - (group_no * _group_size);
+  size_t group_chunk_size = _first_group_chunk_size >> group_no;
+  size_t offset_of_this_chunk = group_region_offset + index_within_group * group_chunk_size;
+  size_t regions_spanned_by_chunk_offset = offset_of_this_chunk / region_size_words;
+  size_t region_index = group_region_index + regions_spanned_by_chunk_offset;
+  size_t offset_within_region = offset_of_this_chunk % region_size_words;
+  
+  assignment->_r = _heap->get_region(region_index);
+  assignment->_chunk_offset = offset_within_region;
+  assignment->_chunk_size = group_chunk_size;
+
+  return true;
 }
 
 #endif   // SHARE_GC_SHENANDOAH_SHENANDOAHSCANREMEMBEREDINLINE_HPP


### PR DESCRIPTION
This branch divides remembered set scanning into smaller units of work so that multiple cores can more effectively share the workload between them.  The benefit is to reduce concurrent scan remembered set times and to increase the parallelism of this phase.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed (1 review required, with at least 1 [Committer](https://openjdk.org/bylaws#committer))

### Reviewers
 * [William Kemper](https://openjdk.org/census#wkemper) (@earthling-amzn - Committer) ⚠️ Review applies to [a806698e](https://git.openjdk.org/shenandoah/pull/153/files/a806698e736230ccf9866ff055d72df65b87ecae)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/shenandoah pull/153/head:pull/153` \
`$ git checkout pull/153`

Update a local copy of the PR: \
`$ git checkout pull/153` \
`$ git pull https://git.openjdk.org/shenandoah pull/153/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 153`

View PR using the GUI difftool: \
`$ git pr show -t 153`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/shenandoah/pull/153.diff">https://git.openjdk.org/shenandoah/pull/153.diff</a>

</details>
