### PR TITLE
Use os::malloc instead of malloc

### DIFF
--- a/src/hotspot/share/gc/shenandoah/shenandoahScanRemembered.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahScanRemembered.cpp
@@ -45,7 +45,7 @@ ShenandoahDirectCardMarkRememberedSet::ShenandoahDirectCardMarkRememberedSet(She
 
   _byte_map_base = _byte_map - (uintptr_t(_whole_heap_base) >> _card_shift);
 
-  _overreach_map = (uint8_t *) malloc(total_card_count);
+  _overreach_map = (uint8_t *) os::malloc(total_card_count, mtGC);
   _overreach_map_base = (_overreach_map -
                          (uintptr_t(_whole_heap_base) >> _card_shift));
 
@@ -55,7 +55,7 @@ ShenandoahDirectCardMarkRememberedSet::ShenandoahDirectCardMarkRememberedSet(She
 }
 
 ShenandoahDirectCardMarkRememberedSet::~ShenandoahDirectCardMarkRememberedSet() {
-  free(_overreach_map);
+  os::free(_overreach_map);
 }
 
 void ShenandoahDirectCardMarkRememberedSet::initialize_overreach(size_t first_cluster, size_t count) {

--- a/src/hotspot/share/gc/shenandoah/shenandoahScanRemembered.hpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahScanRemembered.hpp
@@ -206,12 +206,13 @@
 // existing implementation.
 
 #include <stdint.h>
-#include "memory/iterator.hpp"
 #include "gc/shared/workerThread.hpp"
 #include "gc/shenandoah/shenandoahCardTable.hpp"
 #include "gc/shenandoah/shenandoahHeap.hpp"
 #include "gc/shenandoah/shenandoahHeapRegion.hpp"
 #include "gc/shenandoah/shenandoahTaskqueue.hpp"
+#include "memory/iterator.hpp"
+#include "runtime/os.hpp"
 
 class ShenandoahReferenceProcessor;
 class ShenandoahConcurrentMark;
@@ -559,7 +560,7 @@ public:
     _rs = rs;
     // TODO: We don't really need object_starts entries for every card entry.  We only need these for
     // the card entries that correspond to old-gen memory.  But for now, let's be quick and dirty.
-    object_starts = (crossing_info *) malloc(rs->total_cards() * sizeof(crossing_info));
+    object_starts = (crossing_info *) os::malloc(rs->total_cards() * sizeof(crossing_info), mtGC);
     if (object_starts == nullptr)
       fatal("Insufficient memory for initializing heap");
     for (size_t i = 0; i < rs->total_cards(); i++)


### PR DESCRIPTION
This fixes a compiler error with gcc-10.3.0 used by github actions

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Committer](https://openjdk.org/bylaws#committer))

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/shenandoah pull/155/head:pull/155` \
`$ git checkout pull/155`

Update a local copy of the PR: \
`$ git checkout pull/155` \
`$ git pull https://git.openjdk.org/shenandoah pull/155/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 155`

View PR using the GUI difftool: \
`$ git pr show -t 155`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/shenandoah/pull/155.diff">https://git.openjdk.org/shenandoah/pull/155.diff</a>

</details>
