### PR TITLE
Fix budgeting assertion

### DIFF
--- a/src/hotspot/share/gc/shenandoah/heuristics/shenandoahAdaptiveHeuristics.cpp
+++ b/src/hotspot/share/gc/shenandoah/heuristics/shenandoahAdaptiveHeuristics.cpp
@@ -123,7 +123,11 @@ void ShenandoahAdaptiveHeuristics::choose_collection_set_from_regiondata(Shenand
             add_region = true;
             old_cur_cset = new_cset;
           }
-        } else if (cset->is_preselected(idx)) {
+        } else if (cset->is_preselected(r->index())) {
+#undef KELVIN_VERBOSE
+#ifdef KELVIN_VERBOSE
+          printf("GLOBAL: Preselected region " SIZE_FORMAT " added to cset, age is: %d\n", r->index(), r->age());
+#endif
           assert(r->age() >= InitialTenuringThreshold, "Preselected regions must have tenure age");
           // Entire region will be promoted, This region does not impact young-gen or old-gen evacuation reserve.
           // This region has been pre-selected and its impact on promotion reserve is already accounted for.
@@ -170,8 +174,12 @@ void ShenandoahAdaptiveHeuristics::choose_collection_set_from_regiondata(Shenand
         size_t region_garbage = r->garbage();
         size_t new_garbage = cur_young_garbage + region_garbage;
         bool add_region = false;
+
         if (!r->is_old()) {
-          if (cset->is_preselected(idx)) {
+          if (cset->is_preselected(r->index())) {
+#ifdef KELVIN_VERBOSE
+            printf("YOUNG or MIXED: Preselected region " SIZE_FORMAT " added to cset, age is: %d\n", r->index(), r->age());
+#endif
             assert(r->age() >= InitialTenuringThreshold, "Preselected regions must have tenure age");
             // Entire region will be promoted, This region does not impact young-gen evacuation reserve.  Memory has already
             // been set aside to hold evacuation results as advance_promotion_reserve.

--- a/src/hotspot/share/gc/shenandoah/heuristics/shenandoahAdaptiveHeuristics.cpp
+++ b/src/hotspot/share/gc/shenandoah/heuristics/shenandoahAdaptiveHeuristics.cpp
@@ -123,12 +123,18 @@ void ShenandoahAdaptiveHeuristics::choose_collection_set_from_regiondata(Shenand
             add_region = true;
             old_cur_cset = new_cset;
           }
-        } else if (r->age() >= InitialTenuringThreshold) {
+        } else if (cset->is_preselected(idx)) {
+          assert(r->age() >= InitialTenuringThreshold, "Preselected regions must have tenure age");
           // Entire region will be promoted, This region does not impact young-gen or old-gen evacuation reserve.
           // This region has been pre-selected and its impact on promotion reserve is already accounted for.
           add_region = true;
           cur_young_garbage += r->garbage();
-        } else {
+          // Since all live data in this region is being evacuated from young-gen, it is as if this memory
+          // is garbage insofar as young-gen is concerned.  Counting this as garbage reduces the need to
+          // reclaim highly utilized young-gen regions just for the sake of finding min_garbage to reclaim
+          // within youn-gen memory
+          cur_young_garbage += r->get_live_data_bytes();
+        } else if (r->age() < InitialTenuringThreshold) {
           size_t new_cset = young_cur_cset + r->get_live_data_bytes();
           size_t region_garbage = r->garbage();
           size_t new_garbage = cur_young_garbage + region_garbage;
@@ -139,13 +145,16 @@ void ShenandoahAdaptiveHeuristics::choose_collection_set_from_regiondata(Shenand
             cur_young_garbage = new_garbage;
           }
         }
+        // Note that we do not add aged regions if they were not pre-selected.  The reason they were not preselected
+        // is because there is not sufficient room in old-gen to hold their to-be-promoted live objects.
 
         if (add_region) {
           cset->add_region(r);
         }
       }
     } else {
-      // This is young-gen collection.
+      // This is young-gen collection or a mixed evacuation.  If this is mixed evacuation, the old-gen candidate regions
+      // have already been added.
       size_t max_cset    = (size_t) (heap->get_young_evac_reserve() / ShenandoahEvacWaste);
       size_t cur_cset = 0;
       size_t free_target = (capacity * ShenandoahMinFreeThreshold) / 100 + max_cset;
@@ -160,19 +169,36 @@ void ShenandoahAdaptiveHeuristics::choose_collection_set_from_regiondata(Shenand
         size_t new_cset;
         size_t region_garbage = r->garbage();
         size_t new_garbage = cur_young_garbage + region_garbage;
-        if (r->age() >= InitialTenuringThreshold) {
-          // Entire region will be promoted, This region does not impact young-gen evacuation reserve.  Memory has already
-          // been set aside to hold evacuation results as advance_promotion_reserve.
-          new_cset = cur_cset;
-        } else {
-          new_cset = cur_cset + r->get_live_data_bytes();
-        }
-        bool add_regardless = (region_garbage > ignore_threshold) && (new_garbage < min_garbage);
-        if ((new_cset <= max_cset) &&
-            (add_regardless || (region_garbage > garbage_threshold) || (r->age() >= InitialTenuringThreshold))) {
-          cset->add_region(r);
-          cur_cset = new_cset;
-          cur_young_garbage = new_garbage;
+        bool add_region = false;
+        if (!r->is_old()) {
+          if (cset->is_preselected(idx)) {
+            assert(r->age() >= InitialTenuringThreshold, "Preselected regions must have tenure age");
+            // Entire region will be promoted, This region does not impact young-gen evacuation reserve.  Memory has already
+            // been set aside to hold evacuation results as advance_promotion_reserve.
+            add_region = true;
+            new_cset = cur_cset;
+            // Since all live data in this region is being evacuated from young-gen, it is as if this memory
+            // is garbage insofar as young-gen is concerned.  Counting this as garbage reduces the need to
+            // reclaim highly utilized young-gen regions just for the sake of finding min_garbage to reclaim
+            // within youn-gen memory
+            cur_young_garbage += r->get_live_data_bytes();
+          } else if  (r->age() < InitialTenuringThreshold) {
+            new_cset = cur_cset + r->get_live_data_bytes();
+            size_t region_garbage = r->garbage();
+            size_t new_garbage = cur_young_garbage + region_garbage;
+            bool add_regardless = (region_garbage > ignore_threshold) && (new_garbage < min_garbage);
+            if ((new_cset <= max_cset) && (add_regardless || (region_garbage > garbage_threshold))) {
+              add_region = true;
+              cur_cset = new_cset;
+              cur_young_garbage = new_garbage;
+            }
+          }
+          // Note that we do not add aged regions if they were not pre-selected.  The reason they were not preselected
+          // is because there is not sufficient room in old-gen to hold their to-be-promoted live objects.
+
+          if (add_region) {
+            cset->add_region(r);
+          }
         }
       }
     }

--- a/src/hotspot/share/gc/shenandoah/heuristics/shenandoahAdaptiveHeuristics.cpp
+++ b/src/hotspot/share/gc/shenandoah/heuristics/shenandoahAdaptiveHeuristics.cpp
@@ -124,10 +124,6 @@ void ShenandoahAdaptiveHeuristics::choose_collection_set_from_regiondata(Shenand
             old_cur_cset = new_cset;
           }
         } else if (cset->is_preselected(r->index())) {
-#undef KELVIN_VERBOSE
-#ifdef KELVIN_VERBOSE
-          printf("GLOBAL: Preselected region " SIZE_FORMAT " added to cset, age is: %d\n", r->index(), r->age());
-#endif
           assert(r->age() >= InitialTenuringThreshold, "Preselected regions must have tenure age");
           // Entire region will be promoted, This region does not impact young-gen or old-gen evacuation reserve.
           // This region has been pre-selected and its impact on promotion reserve is already accounted for.
@@ -177,9 +173,6 @@ void ShenandoahAdaptiveHeuristics::choose_collection_set_from_regiondata(Shenand
 
         if (!r->is_old()) {
           if (cset->is_preselected(r->index())) {
-#ifdef KELVIN_VERBOSE
-            printf("YOUNG or MIXED: Preselected region " SIZE_FORMAT " added to cset, age is: %d\n", r->index(), r->age());
-#endif
             assert(r->age() >= InitialTenuringThreshold, "Preselected regions must have tenure age");
             // Entire region will be promoted, This region does not impact young-gen evacuation reserve.  Memory has already
             // been set aside to hold evacuation results as advance_promotion_reserve.

--- a/src/hotspot/share/gc/shenandoah/heuristics/shenandoahHeuristics.cpp
+++ b/src/hotspot/share/gc/shenandoah/heuristics/shenandoahHeuristics.cpp
@@ -84,17 +84,8 @@ size_t ShenandoahHeuristics::select_aged_regions(size_t old_available, size_t nu
     for (size_t i = 0; i < num_regions; i++) {
       ShenandoahHeapRegion* region = heap->get_region(i);
       if (in_generation(region) && !region->is_empty() && region->is_regular() && (region->age() >= InitialTenuringThreshold)) {
-#undef KELVIN_VERBOSE
-#ifdef KELVIN_VERBOSE
-        printf("Considering preselection of [" SIZE_FORMAT "], age is: %d\n", region->index(), region->age());
-#endif
         size_t promotion_need = (size_t) (region->get_live_data_bytes() * ShenandoahEvacWaste);
         if (old_consumed + promotion_need < old_available) {
-#ifdef KELVIN_VERBOSE
-          printf("Preselecte region " SIZE_FORMAT " because old_consumed (" SIZE_FORMAT ") + promotion_need (" SIZE_FORMAT 
-                 ") < old_available (" SIZE_FORMAT ")\n",
-                 region->index(), old_consumed, promotion_need, old_available);
-#endif
           old_consumed += promotion_need;
           preselected_regions[i] = true;
         }
@@ -137,7 +128,6 @@ void ShenandoahHeuristics::choose_collection_set(ShenandoahCollectionSet* collec
 
   for (size_t i = 0; i < num_regions; i++) {
     ShenandoahHeapRegion* region = heap->get_region(i);
-    assert(i == region->index(), "Expecting region to match get_region() argument");
     if (!in_generation(region)) {
       continue;
     }
@@ -159,10 +149,6 @@ void ShenandoahHeuristics::choose_collection_set(ShenandoahCollectionSet* collec
         // This is our candidate for later consideration.
         candidates[cand_idx]._region = region;
         if (is_generational && collection_set->is_preselected(i)) {
-#ifdef KELVIN_VERBOSE
-          printf("Biasing preselected region [" SIZE_FORMAT "] from garbage: " SIZE_FORMAT " to " SIZE_FORMAT "\n",
-                 region->index(), garbage, ShenandoahHeapRegion::region_size_bytes());
-#endif
           // If region is preselected, we know mode()->is_generational() and region->age() >= InitialTenuringThreshold)
           garbage = ShenandoahHeapRegion::region_size_bytes();
         }

--- a/src/hotspot/share/gc/shenandoah/heuristics/shenandoahHeuristics.cpp
+++ b/src/hotspot/share/gc/shenandoah/heuristics/shenandoahHeuristics.cpp
@@ -84,8 +84,17 @@ size_t ShenandoahHeuristics::select_aged_regions(size_t old_available, size_t nu
     for (size_t i = 0; i < num_regions; i++) {
       ShenandoahHeapRegion* region = heap->get_region(i);
       if (in_generation(region) && !region->is_empty() && region->is_regular() && (region->age() >= InitialTenuringThreshold)) {
+#undef KELVIN_VERBOSE
+#ifdef KELVIN_VERBOSE
+        printf("Considering preselection of [" SIZE_FORMAT "], age is: %d\n", region->index(), region->age());
+#endif
         size_t promotion_need = (size_t) (region->get_live_data_bytes() * ShenandoahEvacWaste);
         if (old_consumed + promotion_need < old_available) {
+#ifdef KELVIN_VERBOSE
+          printf("Preselecte region " SIZE_FORMAT " because old_consumed (" SIZE_FORMAT ") + promotion_need (" SIZE_FORMAT 
+                 ") < old_available (" SIZE_FORMAT ")\n",
+                 region->index(), old_consumed, promotion_need, old_available);
+#endif
           old_consumed += promotion_need;
           preselected_regions[i] = true;
         }
@@ -128,6 +137,7 @@ void ShenandoahHeuristics::choose_collection_set(ShenandoahCollectionSet* collec
 
   for (size_t i = 0; i < num_regions; i++) {
     ShenandoahHeapRegion* region = heap->get_region(i);
+    assert(i == region->index(), "Expecting region to match get_region() argument");
     if (!in_generation(region)) {
       continue;
     }
@@ -149,6 +159,10 @@ void ShenandoahHeuristics::choose_collection_set(ShenandoahCollectionSet* collec
         // This is our candidate for later consideration.
         candidates[cand_idx]._region = region;
         if (is_generational && collection_set->is_preselected(i)) {
+#ifdef KELVIN_VERBOSE
+          printf("Biasing preselected region [" SIZE_FORMAT "] from garbage: " SIZE_FORMAT " to " SIZE_FORMAT "\n",
+                 region->index(), garbage, ShenandoahHeapRegion::region_size_bytes());
+#endif
           // If region is preselected, we know mode()->is_generational() and region->age() >= InitialTenuringThreshold)
           garbage = ShenandoahHeapRegion::region_size_bytes();
         }


### PR DESCRIPTION
An assertion failure revealed problems with evacuation budgeting computations.  Three changes are reflected in this pull request:

1. Memory set aside for the promotion reserve was not excluded from the allocation supplement
2. When the old evacuation reserve is larger than the memory consumed by old evacuation collection set, we loan the excess memory to allocation supplement to make sure this memory is not consumed by promotions.  The number of regions set aside from this reserve for the allocation supplement must be rounded down from the total excess memory.  (Before this patch, it was rounded up.)
3. The assertion test that was failing needed a <= comparison instead of a < comparison.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed (1 review required, with at least 1 [Committer](https://openjdk.org/bylaws#committer))

### Reviewers
 * [William Kemper](https://openjdk.org/census#wkemper) (@earthling-amzn - Committer) ⚠️ Review applies to [7d256dba](https://git.openjdk.org/shenandoah/pull/156/files/7d256dbafb6285684f3961ce538b3576ea25fede)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/shenandoah pull/156/head:pull/156` \
`$ git checkout pull/156`

Update a local copy of the PR: \
`$ git checkout pull/156` \
`$ git pull https://git.openjdk.org/shenandoah pull/156/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 156`

View PR using the GUI difftool: \
`$ git pr show -t 156`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/shenandoah/pull/156.diff">https://git.openjdk.org/shenandoah/pull/156.diff</a>

</details>
