### PR TITLE
Include old humongous start regions when counting immediate garbage

### DIFF
--- a/src/hotspot/share/gc/shenandoah/heuristics/shenandoahOldHeuristics.cpp
+++ b/src/hotspot/share/gc/shenandoah/heuristics/shenandoahOldHeuristics.cpp
@@ -145,7 +145,9 @@ void ShenandoahOldHeuristics::prepare_for_old_collections() {
         // The humongous object is dead, we can just return this region and the continuations
         // immediately to the freeset - no evacuations are necessary here. The continuations
         // will be made into trash by this method, so they'll be skipped by the 'is_regular'
-        // check above.
+        // check above, but we still need to count the start region.
+        immediate_regions++;
+        immediate_garbage += garbage;
         size_t region_count = heap->trash_humongous_region_at(region);
         log_debug(gc)("Trashed " SIZE_FORMAT " regions for humongous object.", region_count);
       }


### PR DESCRIPTION
We only log these values, but we expect to one day use them to possibly shortcut an old generation collection in the same fashion as the young generation.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed (1 review required, with at least 1 [Committer](https://openjdk.org/bylaws#committer))

### Reviewers
 * [Y. Srinivas Ramakrishna](https://openjdk.org/census#ysr) (@ysramakrishna - Author)
 * [Kelvin Nilsen](https://openjdk.org/census#kdnilsen) (@kdnilsen - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/shenandoah pull/157/head:pull/157` \
`$ git checkout pull/157`

Update a local copy of the PR: \
`$ git checkout pull/157` \
`$ git pull https://git.openjdk.org/shenandoah pull/157/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 157`

View PR using the GUI difftool: \
`$ git pr show -t 157`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/shenandoah/pull/157.diff">https://git.openjdk.org/shenandoah/pull/157.diff</a>

</details>
