### PR TITLE
Log rotation

### DIFF
--- a/src/hotspot/share/gc/shenandoah/shenandoahHeapRegionCounters.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahHeapRegionCounters.cpp
@@ -77,6 +77,7 @@ ShenandoahHeapRegionCounters::ShenandoahHeapRegionCounters() :
 
     if (ShenandoahLogRegionSampling) {
       _log_file = new ShenandoahLogFileOutput(ShenandoahRegionSamplingFile, _timestamp->get_value());
+      _log_file->set_option(ShenandoahLogFileCount, ShenandoahLogFileSize);
       _log_file->initialize(tty);
     }
   }

--- a/src/hotspot/share/gc/shenandoah/shenandoahLogFileOutput.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahLogFileOutput.cpp
@@ -58,8 +58,88 @@ char        ShenandoahLogFileOutput::_vm_start_time_str[StartTimeBufferSize];
   total += result;                                            \
 }
 
+static uint number_of_digits(uint number) {
+    return number < 10 ? 1 : (number < 100 ? 2 : 3);
+}
+
+static bool is_regular_file(const char* filename) {
+    struct stat st;
+    int ret = os::stat(filename, &st);
+    if (ret != 0) {
+        return false;
+    }
+    return (st.st_mode & S_IFMT) == S_IFREG;
+}
+
+static bool is_fifo_file(const char* filename) {
+    struct stat st;
+    int ret = os::stat(filename, &st);
+    if (ret != 0) {
+        return false;
+    }
+    return S_ISFIFO(st.st_mode);
+}
+
+// Try to find the next number that should be used for file rotation.
+// Return UINT_MAX on error.
+static uint next_file_number(const char* filename,
+                             uint number_of_digits,
+                             uint filecount,
+                             outputStream* errstream) {
+    bool found = false;
+    uint next_num = 0;
+
+    // len is filename + dot + digits + null char
+    size_t len = strlen(filename) + number_of_digits + 2;
+    char* archive_name = NEW_C_HEAP_ARRAY(char, len, mtLogging);
+    char* oldest_name = NEW_C_HEAP_ARRAY(char, len, mtLogging);
+
+    for (uint i = 0; i < filecount; i++) {
+        int ret = jio_snprintf(archive_name, len, "%s.%0*u",
+                               filename, number_of_digits, i);
+        assert(ret > 0 && static_cast<size_t>(ret) == len - 1,
+               "incorrect buffer length calculation");
+
+        if (os::file_exists(archive_name) && !is_regular_file(archive_name)) {
+            // We've encountered something that's not a regular file among the
+            // possible file rotation targets. Fail immediately to prevent
+            // problems later.
+            errstream->print_cr("Possible rotation target file '%s' already exists "
+                                "but is not a regular file.", archive_name);
+            next_num = UINT_MAX;
+            break;
+        }
+
+        // Stop looking if we find an unused file name
+        if (!os::file_exists(archive_name)) {
+            next_num = i;
+            found = true;
+            break;
+        }
+
+        // Keep track of oldest existing log file
+        if (!found
+            || os::compare_file_modified_times(oldest_name, archive_name) > 0) {
+            strcpy(oldest_name, archive_name);
+            next_num = i;
+            found = true;
+        }
+    }
+
+    FREE_C_HEAP_ARRAY(char, oldest_name);
+    FREE_C_HEAP_ARRAY(char, archive_name);
+    return next_num;
+}
+void ShenandoahLogFileOutput::set_option(uint file_count, size_t rotation_size) {
+    if (file_count < MaxRotationFileCount) {
+        _file_count = file_count;
+    }
+    _rotate_size = rotation_size;
+}
+
 ShenandoahLogFileOutput::ShenandoahLogFileOutput(const char* name, jlong vm_start_time)
-  : _name(os::strdup_check_oom(name, mtLogging)), _file_name(NULL), _stream(NULL) {
+  : _name(os::strdup_check_oom(name, mtLogging)), _file_name(NULL), _archive_name(NULL), _stream(NULL), _current_file(0), _file_count(DefaultFileCount), _is_default_file_count(true), _archive_name_len(0),
+     _rotate_size(DefaultFileSize),  _current_size(0), _rotation_semaphore(1) {
   set_file_name_parameters(vm_start_time);
   _file_name = make_file_name(name, _pid_str, _vm_start_time_str);
 }
@@ -71,6 +151,7 @@ ShenandoahLogFileOutput::~ShenandoahLogFileOutput() {
                   _file_name, os::strerror(errno));
     }
   }
+  os::free(_archive_name);
   os::free(_file_name);
   os::free(const_cast<char*>(_name));
 }
@@ -90,14 +171,63 @@ bool ShenandoahLogFileOutput::flush() {
 }
 
 void ShenandoahLogFileOutput::initialize(outputStream* errstream) {
-  _stream = os::fopen(_file_name, ShenandoahLogFileOutput::FileOpenMode);
-  if (_stream == NULL) {
-    errstream->print_cr("Error opening log file '%s': %s", _file_name, os::strerror(errno));
-    _file_name = make_file_name("./shenandoahSnapshots_pid%p.log", _pid_str, _vm_start_time_str);
+
+    bool file_exist = os::file_exists(_file_name);
+    if (file_exist && _is_default_file_count && is_fifo_file(_file_name)) {
+        _file_count = 0; // Prevent file rotation for fifo's such as named pipes.
+    }
+
+    if (_file_count > 0) {
+        // compute digits with filecount - 1 since numbers will start from 0
+        _file_count_max_digits = number_of_digits(_file_count - 1);
+        _archive_name_len = 2 + strlen(_file_name) + _file_count_max_digits;
+        _archive_name = NEW_C_HEAP_ARRAY(char, _archive_name_len, mtLogging);
+        _archive_name[0] = 0;
+    }
+
+    if (_file_count > 0 && file_exist) {
+        if (!is_regular_file(_file_name)) {
+            errstream->print_cr("Unable to log to file %s with log file rotation: "
+                                "%s is not a regular file",
+                                _file_name, _file_name);
+            return;
+        }
+        _current_file = next_file_number(_file_name,
+                                         _file_count_max_digits,
+                                         _file_count,
+                                         errstream);
+        if (_current_file == UINT_MAX) {
+            return;
+        }
+        archive();
+        increment_file_count();
+    }
     _stream = os::fopen(_file_name, ShenandoahLogFileOutput::FileOpenMode);
-    errstream->print_cr("Writing to default log file: %s", _file_name);
-  }
+    if (_stream == NULL) {
+        errstream->print_cr("Error opening log file '%s': %s", _file_name, os::strerror(errno));
+        _file_name = make_file_name("./shenandoahSnapshots_pid%p.log", _pid_str, _vm_start_time_str);
+        _stream = os::fopen(_file_name, ShenandoahLogFileOutput::FileOpenMode);
+        errstream->print_cr("Writing to default log file: %s", _file_name);
+        return;
+    }
+    if (_file_count == 0 && is_regular_file(_file_name)) {
+        os::ftruncate(os::get_fileno(_stream), 0);
+    }
+    return;
 }
+
+class RotationLocker : public StackObj {
+    Semaphore& _sem;
+
+public:
+    RotationLocker(Semaphore& sem) : _sem(sem) {
+        sem.wait();
+    }
+
+    ~RotationLocker() {
+        _sem.signal();
+    }
+};
 
 int ShenandoahLogFileOutput::write_snapshot(PerfLongVariable** regions,
                                             PerfLongVariable* ts,
@@ -112,14 +242,76 @@ int ShenandoahLogFileOutput::write_snapshot(PerfLongVariable** regions,
                                           status->get_value(),
                                           num_regions,
                                           region_size, protocol_version), written);
+  _current_size += written;
   if (num_regions > 0) {
     WRITE_LOG_WITH_RESULT_CHECK(jio_fprintf(_stream, "%lli", regions[0]->get_value()), written);
+    _current_size += written;
   }
   for (uint i = 1; i < num_regions; ++i) {
     WRITE_LOG_WITH_RESULT_CHECK(jio_fprintf(_stream, " %lli", regions[i]->get_value()), written);
+    _current_size += written;
   }
-  jio_fprintf(_stream, "\n");
-  return flush() ? written : -1;
+  jio_fprintf(_stream, "\n", written);
+  _current_size += written;
+  written = flush() ? written : -1;
+  if (written > 0) {
+      _current_size += written;
+
+      if (should_rotate()) {
+          rotate();
+      }
+  }
+
+  return written;
+}
+
+void ShenandoahLogFileOutput::archive() {
+    assert(_archive_name != NULL && _archive_name_len > 0, "Rotation must be configured before using this function.");
+    int ret = jio_snprintf(_archive_name, _archive_name_len, "%s.%0*u",
+                           _file_name, _file_count_max_digits, _current_file);
+    assert(ret >= 0, "Buffer should always be large enough");
+
+    // Attempt to remove possibly existing archived log file before we rename.
+    // Don't care if it fails, we really only care about the rename that follows.
+    remove(_archive_name);
+
+    // Rename the file from ex hotspot.log to hotspot.log.2
+    if (rename(_file_name, _archive_name) == -1) {
+        jio_fprintf(defaultStream::error_stream(), "Could not rename log file '%s' to '%s' (%s).\n",
+                    _file_name, _archive_name, os::strerror(errno));
+    }
+}
+
+void ShenandoahLogFileOutput::force_rotate() {
+    if (_file_count == 0) {
+        // Rotation not possible
+        return;
+    }
+
+    RotationLocker lock(_rotation_semaphore);
+    rotate();
+}
+
+void ShenandoahLogFileOutput::rotate() {
+    if (fclose(_stream)) {
+        jio_fprintf(defaultStream::error_stream(), "Error closing file '%s' during log rotation (%s).\n",
+                    _file_name, os::strerror(errno));
+    }
+
+    // Archive the current log file
+    archive();
+
+    // Open the active log file using the same stream as before
+    _stream = os::fopen(_file_name, FileOpenMode);
+    if (_stream == NULL) {
+        jio_fprintf(defaultStream::error_stream(), "Could not reopen file '%s' during log rotation (%s).\n",
+                    _file_name, os::strerror(errno));
+        return;
+    }
+
+    // Reset accumulated size, increase current file counter, and check for file count wrap-around.
+    _current_size = 0;
+    increment_file_count();
 }
 
 void ShenandoahLogFileOutput::set_file_name_parameters(jlong vm_start_time) {

--- a/src/hotspot/share/gc/shenandoah/shenandoahLogFileOutput.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahLogFileOutput.cpp
@@ -210,7 +210,10 @@ void ShenandoahLogFileOutput::initialize(outputStream* errstream) {
         if (_stream != NULL) {
             errstream->print_cr("Writing to default log file: %s", _file_name);
             return;
-        } 
+        } else {
+            errstream->print_cr("Cannot open log file: %s", _file_name);
+            return;
+        }
     }
     if (_file_count == 0 && is_regular_file(_file_name)) {
         os::ftruncate(os::get_fileno(_stream), 0);

--- a/src/hotspot/share/gc/shenandoah/shenandoahLogFileOutput.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahLogFileOutput.cpp
@@ -205,14 +205,8 @@ void ShenandoahLogFileOutput::initialize(outputStream* errstream) {
     _stream = os::fopen(_file_name, ShenandoahLogFileOutput::FileOpenMode);
     if (_stream == NULL) {
         errstream->print_cr("Error opening log file '%s': %s", _file_name, os::strerror(errno));
-        _file_name = make_file_name("./shenandoahSnapshots_pid%p.log", _pid_str, _vm_start_time_str);
-        _stream = os::fopen(_file_name, ShenandoahLogFileOutput::FileOpenMode);
-        if (_stream != NULL) {
-            errstream->print_cr("Writing to default log file: %s", _file_name);
-            return;
-        } else {
-            vm_exit_during_initialization();
-        }
+        vm_exit_during_initialization();
+        assert(_stream != NULL, "JVM exits because log file cannot be written.");
     }
     if (_file_count == 0 && is_regular_file(_file_name)) {
         os::ftruncate(os::get_fileno(_stream), 0);

--- a/src/hotspot/share/gc/shenandoah/shenandoahLogFileOutput.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahLogFileOutput.cpp
@@ -211,8 +211,7 @@ void ShenandoahLogFileOutput::initialize(outputStream* errstream) {
             errstream->print_cr("Writing to default log file: %s", _file_name);
             return;
         } else {
-            errstream->print_cr("Cannot open log file: %s", _file_name);
-            return;
+            vm_exit_during_initialization();
         }
     }
     if (_file_count == 0 && is_regular_file(_file_name)) {
@@ -239,6 +238,10 @@ int ShenandoahLogFileOutput::write_snapshot(PerfLongVariable** regions,
                                             PerfLongVariable* status,
                                             size_t num_regions,
                                             size_t region_size, size_t protocol_version) {
+  if (_stream == NULL) {
+      // An error has occurred with this output, avoid writing to it.
+      return 0;
+  }
   int written = 0;
 
   FileLocker flocker(_stream);

--- a/src/hotspot/share/gc/shenandoah/shenandoahLogFileOutput.hpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahLogFileOutput.hpp
@@ -33,13 +33,10 @@
 #include "runtime/perfData.inline.hpp"
 
 // Log file output to capture Shenandoah GC data.
-class LogFileStreamOutput;
 
 class ShenandoahLogFileOutput : public CHeapObj<mtClass> {
 private:
     static const char* const FileOpenMode;
-    static const char* const FileCountOptionKey;
-    static const char* const FileSizeOptionKey;
     static const char* const PidFilenamePlaceholder;
     static const char* const TimestampFilenamePlaceholder;
     static const char* const TimestampFormat;

--- a/src/hotspot/share/gc/shenandoah/shenandoahLogFileOutput.hpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahLogFileOutput.hpp
@@ -28,30 +28,62 @@
 
 #include "logging/logFileStreamOutput.hpp"
 #include "logging/logFileOutput.hpp"
+#include "runtime/semaphore.hpp"
 #include "utilities/globalDefinitions.hpp"
 #include "runtime/perfData.inline.hpp"
 
 // Log file output to capture Shenandoah GC data.
+class LogFileStreamOutput;
 
 class ShenandoahLogFileOutput : public CHeapObj<mtClass> {
 private:
     static const char* const FileOpenMode;
+    static const char* const FileCountOptionKey;
+    static const char* const FileSizeOptionKey;
     static const char* const PidFilenamePlaceholder;
     static const char* const TimestampFilenamePlaceholder;
     static const char* const TimestampFormat;
+    static const size_t DefaultFileCount = 5;
+    static const size_t DefaultFileSize = 20 * M;
     static const size_t StartTimeBufferSize = 20;
     static const size_t PidBufferSize = 21;
+    static const uint   MaxRotationFileCount = 1000;
     static char         _pid_str[PidBufferSize];
     static char         _vm_start_time_str[StartTimeBufferSize];
 
     const char* _name;
     char* _file_name;
+    char* _archive_name;
     FILE* _stream;
+
+    uint  _current_file;
+    uint  _file_count;
+    uint  _file_count_max_digits;
+    bool  _is_default_file_count;
+
+    size_t  _archive_name_len;
+    size_t  _rotate_size;
+    size_t  _current_size;
 
     bool _write_error_is_shown;
 
+    Semaphore _rotation_semaphore;
+
     bool parse_options(const char* options, outputStream* errstream);
+    void archive();
+    void rotate();
     char *make_file_name(const char* file_name, const char* pid_string, const char* timestamp_string);
+
+    bool should_rotate() {
+        return _file_count > 0 && _rotate_size > 0 && _current_size >= _rotate_size;
+    }
+
+    void increment_file_count() {
+        _current_file++;
+        if (_current_file == _file_count) {
+            _current_file = 0;
+        }
+    }
 
     bool flush();
 
@@ -60,6 +92,8 @@ public:
     ~ShenandoahLogFileOutput();
 
     void initialize(outputStream* errstream);
+    void force_rotate();
+    void set_option(uint file_count, size_t rotation_size);
 
     int write_snapshot(PerfLongVariable** regions,
                        PerfLongVariable* ts,
@@ -71,6 +105,7 @@ public:
       return _name;
     }
 
+    const char* cur_log_file_name();
     static const char* const Prefix;
     static void set_file_name_parameters(jlong start_time);
 };

--- a/src/hotspot/share/gc/shenandoah/shenandoah_globals.hpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoah_globals.hpp
@@ -250,12 +250,14 @@
           "to this file [default: ./shenandoahSnapshots_pid%p.log] "        \
           "(%p replaced with pid)")                                         \
                                                                             \
-  product(uintx, ShenandoahLogFileCount, 5, "This setting defines the file "\
-          "count of for the log rotation. Defaulted to be 5 and maximum of 1000.")\
+  product(uintx, ShenandoahLogFileCount, 5, "Defines the maximum number of "\
+          "log files. Default is 5, maximum is 1000. Only includes rotated/"\
+          "archived files. Doesn't include active log file.")               \
           range(1, 1000)                                                    \
                                                                             \
-  product(size_t, ShenandoahLogFileSize, 20 * M, "This setting defines the "\
-          "file size of for the log rotation. Defaulted to be 20 * M.")     \
+  product(size_t, ShenandoahLogFileSize, 20 * M, "Defines the maximum size "\
+          "of the log file. Files over this size will be rotated. Default " \
+          "is 20MB.")                                                       \
                                                                             \
   product(uintx, ShenandoahControlIntervalMin, 1, EXPERIMENTAL,             \
           "The minimum sleep interval for the control loop that drives "    \

--- a/src/hotspot/share/gc/shenandoah/shenandoah_globals.hpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoah_globals.hpp
@@ -251,13 +251,14 @@
           "(%p replaced with pid)")                                         \
                                                                             \
   product(uintx, ShenandoahLogFileCount, 5, "Defines the maximum number of "\
-          "log files. Default is 5, maximum is 1000. Only includes rotated/"\
-          "archived files. Doesn't include active log file.")               \
-          range(1, 1000)                                                    \
+          "log files. Default is 5, maximum is 1000. Set to 0 to disable "  \
+          "rotation. Only includes rotated/archived files. Doesn't include "\
+          "active log file.")                                               \
+          range(0, 1000)                                                    \
                                                                             \
   product(size_t, ShenandoahLogFileSize, 20 * M, "Defines the maximum size "\
           "of the log file. Files over this size will be rotated. Default " \
-          "is 20MB.")                                                       \
+          "is 20MB. Set to 0 to disable rotation")                          \
                                                                             \
   product(uintx, ShenandoahControlIntervalMin, 1, EXPERIMENTAL,             \
           "The minimum sleep interval for the control loop that drives "    \

--- a/src/hotspot/share/gc/shenandoah/shenandoah_globals.hpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoah_globals.hpp
@@ -250,6 +250,13 @@
           "to this file [default: ./shenandoahSnapshots_pid%p.log] "        \
           "(%p replaced with pid)")                                         \
                                                                             \
+  product(uintx, ShenandoahLogFileCount, 5, "This setting defines the file "\
+          "count of for the log rotation. Defaulted to be 5 and maximum of 1000.")\
+          range(1, 1000)                                                    \
+                                                                            \
+  product(size_t, ShenandoahLogFileSize, 20 * M, "This setting defines the "\
+          "file size of for the log rotation. Defaulted to be 20 * M.")     \
+                                                                            \
   product(uintx, ShenandoahControlIntervalMin, 1, EXPERIMENTAL,             \
           "The minimum sleep interval for the control loop that drives "    \
           "the cycles. Lower values would increase GC responsiveness "      \

--- a/test/hotspot/jtreg/gc/shenandoah/TestRegionSamplingLogging.java
+++ b/test/hotspot/jtreg/gc/shenandoah/TestRegionSamplingLogging.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2018, Red Hat, Inc. All rights reserved.
+ * Copyright (c) 2022 Amazon.com, Inc. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -23,7 +23,7 @@
  */
 
 /*
- * @test id=adaptive
+ * @test id=rotation
  * @requires vm.gc.Shenandoah
  *
  * @run main/othervm -Xmx1g -Xms1g -XX:+UnlockDiagnosticVMOptions -XX:+UnlockExperimentalVMOptions

--- a/test/hotspot/jtreg/gc/shenandoah/TestShenandoahLogRotation.java
+++ b/test/hotspot/jtreg/gc/shenandoah/TestShenandoahLogRotation.java
@@ -42,7 +42,7 @@
 
    public class TestShenandoahLogRotation {
 
-       static final long TARGET_MB = Long.getLong("target", 1); // 2 Gb allocation
+       static final long TARGET_MB = Long.getLong("target", 1);
 
        static volatile Object sink;
 
@@ -62,7 +62,7 @@
                    smallFilesNumber++;
                }
            }
-           // Expect one more log file since the number-of-files doesn't include the active log file
+           // Expect one more log file since the ShenandoahLogFileCount doesn't include the active log file
            int expectedNumberOfFiles = 4;
            if (files.length != expectedNumberOfFiles) {
                throw new Error("There are " + files.length + " logs instead of the expected " + expectedNumberOfFiles + " " + files[0].getAbsolutePath());

--- a/test/hotspot/jtreg/gc/shenandoah/TestShenandoahLogRotation.java
+++ b/test/hotspot/jtreg/gc/shenandoah/TestShenandoahLogRotation.java
@@ -1,0 +1,75 @@
+   /*
+    * Copyright (c) 2017, 2018, Red Hat, Inc. All rights reserved.
+    * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+    *
+    * This code is free software; you can redistribute it and/or modify it
+    * under the terms of the GNU General Public License version 2 only, as
+    * published by the Free Software Foundation.
+    *
+    * This code is distributed in the hope that it will be useful, but WITHOUT
+    * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+    * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+    * version 2 for more details (a copy is included in the LICENSE file that
+    * accompanied this code).
+    *
+    * You should have received a copy of the GNU General Public License version
+    * 2 along with this work; if not, write to the Free Software Foundation,
+    * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+    *
+    * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+    * or visit www.oracle.com if you need additional information or have any
+    * questions.
+    *
+    */
+
+   /*
+    * @test id=adaptive
+    * @requires vm.gc.Shenandoah
+    *
+    * @run main/othervm -Xmx1g -Xms1g -XX:+UnlockDiagnosticVMOptions -XX:+UnlockExperimentalVMOptions
+    *      -XX:+ShenandoahRegionSampling -XX:+ShenandoahRegionSampling
+    *      -XX:+ShenandoahLogRegionSampling -XX:ShenandoahRegionSamplingFile=region-snapshots-%p.log
+    *      -XX:ShenandoahLogFileCount=3 -XX:ShenandoahLogFileSize=100
+    *      -XX:+UseShenandoahGC -XX:ShenandoahGCHeuristics=adaptive
+    *      TestShenandoahLogRotation
+    */
+
+   import java.io.File;
+   import java.util.Arrays;
+   import java.nio.file.Files;
+
+
+
+   public class TestShenandoahLogRotation {
+
+       static final long TARGET_MB = Long.getLong("target", 1); // 2 Gb allocation
+
+       static volatile Object sink;
+
+       public static void main(String[] args) throws Exception {
+           long count = TARGET_MB * 1024 * 1024 / 16;
+           for (long c = 0; c < count; c++) {
+               sink = new Object();
+               Thread.sleep(1);
+           }
+
+           File directory = new File(".");
+           File[] files = directory.listFiles((dir, name) -> name.startsWith("region-snapshots"));
+           System.out.println(Arrays.toString(files));
+           int smallFilesNumber = 0;
+           for (File file : files) {
+               if (file.length() < 100) {
+                   smallFilesNumber++;
+               }
+           }
+           // Expect one more log file since the number-of-files doesn't include the active log file
+           int expectedNumberOfFiles = 4;
+           if (files.length != expectedNumberOfFiles) {
+               throw new Error("There are " + files.length + " logs instead of the expected " + expectedNumberOfFiles + " " + files[0].getAbsolutePath());
+           }
+           if (smallFilesNumber > 1) {
+               throw new Error("There should maximum one log with size < " + 100 + "B");
+           }
+       }
+
+   }

--- a/test/hotspot/jtreg/gc/shenandoah/TestShenandoahLogRotation.java
+++ b/test/hotspot/jtreg/gc/shenandoah/TestShenandoahLogRotation.java
@@ -1,5 +1,5 @@
    /*
-    * Copyright (c) 2017, 2018, Red Hat, Inc. All rights reserved.
+    * Copyright (c) 2022 Amazon.com, Inc. All rights reserved.
     * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
     *
     * This code is free software; you can redistribute it and/or modify it
@@ -23,7 +23,7 @@
     */
 
    /*
-    * @test id=adaptive
+    * @test id=rotation
     * @requires vm.gc.Shenandoah
     *
     * @run main/othervm -Xmx1g -Xms1g -XX:+UnlockDiagnosticVMOptions -XX:+UnlockExperimentalVMOptions


### PR DESCRIPTION
Making the shenandoah log file be able to rotate with given log file count and log file size. Default log file count would be 5 and default log file size would be 20MB.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed (1 review required, with at least 1 [Committer](https://openjdk.org/bylaws#committer))

### Reviewers
 * [William Kemper](https://openjdk.org/census#wkemper) (@earthling-amzn - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/shenandoah pull/158/head:pull/158` \
`$ git checkout pull/158`

Update a local copy of the PR: \
`$ git checkout pull/158` \
`$ git pull https://git.openjdk.org/shenandoah pull/158/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 158`

View PR using the GUI difftool: \
`$ git pr show -t 158`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/shenandoah/pull/158.diff">https://git.openjdk.org/shenandoah/pull/158.diff</a>

</details>
