### PR TITLE
Use only up to ConcGCThreads for concurrent RS scanning.

### DIFF
--- a/src/hotspot/share/gc/shenandoah/shenandoahConcurrentGC.hpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahConcurrentGC.hpp
@@ -86,6 +86,7 @@ private:
   // for concurrent operation.
   void entry_reset();
   void entry_mark_roots();
+  void entry_scan_remembered_set();
 
 protected:
   void entry_mark();

--- a/src/hotspot/share/gc/shenandoah/shenandoahGeneration.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahGeneration.cpp
@@ -800,6 +800,7 @@ void ShenandoahGeneration::scan_remembered_set(bool is_concurrent) {
   ShenandoahReferenceProcessor* rp = ref_processor();
   ShenandoahRegionChunkIterator work_list(nworkers);
   ShenandoahScanRememberedTask task(task_queues(), old_gen_task_queues(), rp, &work_list, is_concurrent);
+  heap->assert_gc_workers(nworkers);
   heap->workers()->run_task(&task);
 }
 

--- a/src/hotspot/share/gc/shenandoah/shenandoahWorkerPolicy.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahWorkerPolicy.cpp
@@ -32,6 +32,7 @@
 
 uint ShenandoahWorkerPolicy::_prev_par_marking     = 0;
 uint ShenandoahWorkerPolicy::_prev_conc_marking    = 0;
+uint ShenandoahWorkerPolicy::_prev_conc_rs_scanning = 0;
 uint ShenandoahWorkerPolicy::_prev_conc_evac       = 0;
 uint ShenandoahWorkerPolicy::_prev_conc_root_proc  = 0;
 uint ShenandoahWorkerPolicy::_prev_conc_refs_proc  = 0;
@@ -59,6 +60,15 @@ uint ShenandoahWorkerPolicy::calc_workers_for_conc_marking() {
                                            active_workers,
                                            Threads::number_of_non_daemon_threads());
   return _prev_conc_marking;
+}
+
+uint ShenandoahWorkerPolicy::calc_workers_for_rs_scanning() {
+  uint active_workers = (_prev_conc_rs_scanning == 0) ? ConcGCThreads : _prev_conc_rs_scanning;
+  _prev_conc_rs_scanning =
+    WorkerPolicy::calc_active_conc_workers(ConcGCThreads,
+                                           active_workers,
+                                           Threads::number_of_non_daemon_threads());
+  return _prev_conc_rs_scanning;
 }
 
 // Reuse the calculation result from init marking

--- a/src/hotspot/share/gc/shenandoah/shenandoahWorkerPolicy.hpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahWorkerPolicy.hpp
@@ -31,6 +31,7 @@ class ShenandoahWorkerPolicy : AllStatic {
 private:
   static uint _prev_par_marking;
   static uint _prev_conc_marking;
+  static uint _prev_conc_rs_scanning;
   static uint _prev_conc_root_proc;
   static uint _prev_conc_refs_proc;
   static uint _prev_conc_evac;
@@ -47,6 +48,9 @@ public:
 
   // Calculate the number of workers for concurrent marking
   static uint calc_workers_for_conc_marking();
+
+  // Calculate the number of workers for remembered set scanning
+  static uint calc_workers_for_rs_scanning();
 
   // Calculate the number of workers for final marking
   static uint calc_workers_for_final_marking();


### PR DESCRIPTION
The concurrent RS scanning phase was using (up to) ParallelGCThreads, rather than ConcGCThreads as was the original intention for concurrent phases.
