### PR TITLE
Fix assertion error with advance promotion budgeting

### DIFF
--- a/src/hotspot/share/gc/shenandoah/shenandoahGeneration.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahGeneration.cpp
@@ -440,8 +440,11 @@ void ShenandoahGeneration::adjust_evacuation_budgets(ShenandoahHeap* heap, Shena
     size_t loaned_regions = 0;
     size_t available_loan_remnant = 0; // loaned memory that is not yet dedicated to any particular budget
 
-    assert(consumed_by_advance_promotion >= collection_set->get_young_bytes_to_be_promoted() * ShenandoahEvacWaste,
-           "Advance promotion should be at least young_bytes_to_be_promoted * ShenandoahEvacWaste");
+    assert(((consumed_by_advance_promotion * 33) / 32) >= collection_set->get_young_bytes_to_be_promoted() * ShenandoahEvacWaste,
+           "Advance promotion (" SIZE_FORMAT ") should be at least young_bytes_to_be_promoted (" SIZE_FORMAT
+           ")* ShenandoahEvacWaste, totalling: " SIZE_FORMAT ", within round-off errors of up to 3.125%%",
+           consumed_by_advance_promotion, collection_set->get_young_bytes_to_be_promoted(),
+           (size_t) (collection_set->get_young_bytes_to_be_promoted() * ShenandoahEvacWaste));
 
     assert(consumed_by_advance_promotion <= (collection_set->get_young_bytes_to_be_promoted() * ShenandoahEvacWaste * 33) / 32,
            "Round-off errors should be less than 3.125%%, consumed by advance: " SIZE_FORMAT ", promoted: " SIZE_FORMAT,

--- a/src/hotspot/share/gc/shenandoah/shenandoahGeneration.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahGeneration.cpp
@@ -496,7 +496,7 @@ void ShenandoahGeneration::adjust_evacuation_budgets(ShenandoahHeap* heap, Shena
 
     // Recompute regions_available_to_loan based on possible changes to old_regions_loaned_for_young_evac and
     // old_evacuation_reserve.
-    
+
     // Any decrease in old_regions_loaned_for_young_evac are immediately available to be loaned
     // However, a change to old_evacuation_reserve() is not necessarily available to loan, because this memory may
     // reside within many fragments scattered throughout old-gen.

--- a/src/hotspot/share/gc/shenandoah/shenandoahGeneration.hpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahGeneration.hpp
@@ -61,12 +61,10 @@ protected:
 private:
   // Compute evacuation budgets prior to choosing collection set.
   void compute_evacuation_budgets(ShenandoahHeap* heap, bool* preselected_regions, ShenandoahCollectionSet* collection_set,
-                                  size_t &regions_available_to_loan,
                                   size_t &minimum_evacuation_reserve, size_t &consumed_by_advance_promotion);
 
   // Adjust evacuation budgets after choosing collection set.
   void adjust_evacuation_budgets(ShenandoahHeap* heap, ShenandoahCollectionSet* collection_set,
-                                 size_t regions_available_to_loan,
                                  size_t minimum_evacuation_reserve, size_t consumed_by_advance_promotion);
 
  public:

--- a/src/hotspot/share/gc/shenandoah/shenandoahGeneration.hpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahGeneration.hpp
@@ -61,12 +61,12 @@ protected:
 private:
   // Compute evacuation budgets prior to choosing collection set.
   void compute_evacuation_budgets(ShenandoahHeap* heap, bool* preselected_regions, ShenandoahCollectionSet* collection_set,
-                                  size_t &old_regions_loaned_for_young_evac, size_t &regions_available_to_loan,
+                                  size_t &regions_available_to_loan,
                                   size_t &minimum_evacuation_reserve, size_t &consumed_by_advance_promotion);
 
   // Adjust evacuation budgets after choosing collection set.
   void adjust_evacuation_budgets(ShenandoahHeap* heap, ShenandoahCollectionSet* collection_set,
-                                 size_t old_regions_loaned_for_young_evac, size_t regions_available_to_loan,
+                                 size_t regions_available_to_loan,
                                  size_t minimum_evacuation_reserve, size_t consumed_by_advance_promotion);
 
  public:

--- a/src/hotspot/share/gc/shenandoah/shenandoahGeneration.hpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahGeneration.hpp
@@ -61,11 +61,11 @@ protected:
 private:
   // Compute evacuation budgets prior to choosing collection set.
   void compute_evacuation_budgets(ShenandoahHeap* heap, bool* preselected_regions, ShenandoahCollectionSet* collection_set,
-                                  size_t &minimum_evacuation_reserve, size_t &consumed_by_advance_promotion);
+                                  size_t &consumed_by_advance_promotion);
 
   // Adjust evacuation budgets after choosing collection set.
   void adjust_evacuation_budgets(ShenandoahHeap* heap, ShenandoahCollectionSet* collection_set,
-                                 size_t minimum_evacuation_reserve, size_t consumed_by_advance_promotion);
+                                 size_t consumed_by_advance_promotion);
 
  public:
   ShenandoahGeneration(GenerationMode generation_mode, uint max_workers, size_t max_capacity, size_t soft_max_capacity);


### PR DESCRIPTION
Round-off errors were resulting in an assertion error.  Budgeting calculations are "complicated" because only regions that are fully empty may be loaned from old-gen to young-gen.  This change recalculates certain values during budgeting adjustments that follow collection set selection rather than endeavoring to make changes to the values computed before collection set selection.  The API is simpler as a result.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed (1 review required, with at least 1 [Committer](https://openjdk.org/bylaws#committer))

### Reviewers
 * [Roman Kennke](https://openjdk.org/census#rkennke) (@rkennke - **Reviewer**) ⚠️ Review applies to [55eb39a4](https://git.openjdk.org/shenandoah/pull/165/files/55eb39a4ab8a122cfe1ceb7e90e9b2244505acf9)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/shenandoah pull/165/head:pull/165` \
`$ git checkout pull/165`

Update a local copy of the PR: \
`$ git checkout pull/165` \
`$ git pull https://git.openjdk.org/shenandoah pull/165/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 165`

View PR using the GUI difftool: \
`$ git pr show -t 165`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/shenandoah/pull/165.diff">https://git.openjdk.org/shenandoah/pull/165.diff</a>

</details>
