### PR TITLE
Improve some defaults and remove unused options for generational mode

### DIFF
--- a/src/hotspot/share/gc/shenandoah/mode/shenandoahGenerationalMode.cpp
+++ b/src/hotspot/share/gc/shenandoah/mode/shenandoahGenerationalMode.cpp
@@ -36,6 +36,7 @@ void ShenandoahGenerationalMode::initialize_flags() const {
     FLAG_SET_DEFAULT(VerifyBeforeExit, false);
   }
 
+  SHENANDOAH_ERGO_OVERRIDE_DEFAULT(NewRatio, 1);
   SHENANDOAH_ERGO_OVERRIDE_DEFAULT(ShenandoahUnloadClassesFrequency, 0);
   SHENANDOAH_ERGO_ENABLE_FLAG(ExplicitGCInvokesConcurrent);
   SHENANDOAH_ERGO_ENABLE_FLAG(ShenandoahImplicitGCInvokesConcurrent);

--- a/src/hotspot/share/gc/shenandoah/shenandoah_globals.hpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoah_globals.hpp
@@ -96,7 +96,7 @@
           "collector accepts. In percents of heap region size.")            \
           range(0,100)                                                      \
                                                                             \
-  product(uintx, ShenandoahOldGarbageThreshold, 25, EXPERIMENTAL,           \
+  product(uintx, ShenandoahOldGarbageThreshold, 10, EXPERIMENTAL,           \
           "How much garbage an old region has to contain before it would "  \
           "be taken for collection.")                                       \
           range(0,100)                                                      \
@@ -152,7 +152,7 @@
           "to learn application and GC performance.")                       \
           range(0,100)                                                      \
                                                                             \
-  product(uintx, ShenandoahImmediateThreshold, 90, EXPERIMENTAL,            \
+  product(uintx, ShenandoahImmediateThreshold, 70, EXPERIMENTAL,            \
           "The cycle may shortcut when enough garbage can be reclaimed "    \
           "from the immediate garbage (completely garbage regions). "       \
           "In percents of total garbage found. Setting this threshold "     \
@@ -525,10 +525,6 @@
           "for the purpose of supporting compaction of old-gen "            \
           "memory.  Otherwise, old-gen memory cannot be compacted.")        \
           range(0, 128)                                                     \
-                                                                            \
-  product(bool, ShenandoahPromoteTenuredObjects, true, DIAGNOSTIC,          \
-          "Turn on/off evacuating individual tenured young objects "        \
-          " to the old generation.")                                        \
                                                                             \
   product(bool, ShenandoahAllowOldMarkingPreemption, true, DIAGNOSTIC,      \
           "Allow young generation collections to suspend concurrent"        \

--- a/src/hotspot/share/gc/shenandoah/shenandoah_globals.hpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoah_globals.hpp
@@ -281,10 +281,6 @@
   product(bool, ShenandoahElasticTLAB, true, DIAGNOSTIC,                    \
           "Use Elastic TLABs with Shenandoah")                              \
                                                                             \
-  product(bool, ShenandoahUsePLAB, true, DIAGNOSTIC,                        \
-          "Use PLABs for object promotions with Shenandoah, "               \
-          "if in generational mode and UseTLAB is also set.")               \
-                                                                            \
   product(uintx, ShenandoahEvacReserve, 5, EXPERIMENTAL,                    \
           "How much of (young-generation) heap to reserve for "             \
           "(young-generation) evacuations.  Larger values allow GC to "     \


### PR DESCRIPTION
`ShenandoahPromoteTenuredObjects` and `ShenandoahUsePLABs` are removed.  The default `NewRatio` for generational mode is changed to 1. The default percentage of garbage for regions included in the old generation collection set is lowered to 10.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed (1 review required, with at least 1 [Committer](https://openjdk.org/bylaws#committer))

### Reviewers
 * [Roman Kennke](https://openjdk.org/census#rkennke) (@rkennke - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/shenandoah pull/169/head:pull/169` \
`$ git checkout pull/169`

Update a local copy of the PR: \
`$ git checkout pull/169` \
`$ git pull https://git.openjdk.org/shenandoah pull/169/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 169`

View PR using the GUI difftool: \
`$ git pr show -t 169`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/shenandoah/pull/169.diff">https://git.openjdk.org/shenandoah/pull/169.diff</a>

</details>
