### PR TITLE
Change affiliation representation

### DIFF
--- a/src/hotspot/share/gc/shenandoah/shenandoahAsserts.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahAsserts.cpp
@@ -428,3 +428,19 @@ void ShenandoahAsserts::assert_heaplocked_or_safepoint(const char* file, int lin
   ShenandoahMessageBuffer msg("Heap lock must be owned by current thread, or be at safepoint");
   report_vm_error(file, line, msg.buffer());
 }
+
+// unlike assert_heaplocked_or_safepoint(), this does not require current thread in safepoint to be a VM-thread
+void ShenandoahAsserts::assert_heaplocked_or_fullgc_safepoint(const char* file, int line) {
+  ShenandoahHeap* heap = ShenandoahHeap::heap();
+
+  if (heap->lock()->owned_by_self()) {
+    return;
+  }
+
+  if (ShenandoahSafepoint::is_at_shenandoah_safepoint()) {
+    return;
+  }
+
+  ShenandoahMessageBuffer msg("Heap lock must be owned by current thread, or be at safepoint");
+  report_vm_error(file, line, msg.buffer());
+}

--- a/src/hotspot/share/gc/shenandoah/shenandoahAsserts.hpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahAsserts.hpp
@@ -72,6 +72,7 @@ public:
   static void assert_heaplocked(const char* file, int line);
   static void assert_not_heaplocked(const char* file, int line);
   static void assert_heaplocked_or_safepoint(const char* file, int line);
+  static void assert_heaplocked_or_fullgc_safepoint(const char* file, int line);
 
 #ifdef ASSERT
 #define shenandoah_assert_in_heap(interior_loc, obj) \
@@ -163,6 +164,9 @@ public:
 
 #define shenandoah_assert_heaplocked_or_safepoint() \
                     ShenandoahAsserts::assert_heaplocked_or_safepoint(__FILE__, __LINE__)
+
+#define shenandoah_assert_heaplocked_or_fullgc_safepoint() \
+                    ShenandoahAsserts::assert_heaplocked_or_fullgc_safepoint(__FILE__, __LINE__)
 #else
 #define shenandoah_assert_in_heap(interior_loc, obj)
 #define shenandoah_assert_in_heap_or_null(interior_loc, obj)
@@ -213,6 +217,7 @@ public:
 #define shenandoah_assert_heaplocked()
 #define shenandoah_assert_not_heaplocked()
 #define shenandoah_assert_heaplocked_or_safepoint()
+#define shenandoah_assert_heaplocked_or_fullgc_safepoint()
 
 #endif
 

--- a/src/hotspot/share/gc/shenandoah/shenandoahHeap.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahHeap.cpp
@@ -358,7 +358,7 @@ jint ShenandoahHeap::initialize() {
   } else {
     _affiliations = NULL;
   }
-  _Free_set = new ShenandoahFreeSet(this, _num_regions);
+  _free_set = new ShenandoahFreeSet(this, _num_regions);
 
   {
     ShenandoahHeapLocker locker(lock());

--- a/src/hotspot/share/gc/shenandoah/shenandoahHeap.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahHeap.cpp
@@ -353,11 +353,7 @@ jint ShenandoahHeap::initialize() {
   }
 
   _regions = NEW_C_HEAP_ARRAY(ShenandoahHeapRegion*, _num_regions, mtGC);
-  if (mode()->is_generational()) {
-    _affiliations = NEW_C_HEAP_ARRAY(uint8_t, _num_regions, mtGC);
-  } else {
-    _affiliations = NULL;
-  }
+  _affiliations = NEW_C_HEAP_ARRAY(uint8_t, _num_regions, mtGC);
   _free_set = new ShenandoahFreeSet(this, _num_regions);
 
   {

--- a/src/hotspot/share/gc/shenandoah/shenandoahHeap.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahHeap.cpp
@@ -353,8 +353,12 @@ jint ShenandoahHeap::initialize() {
   }
 
   _regions = NEW_C_HEAP_ARRAY(ShenandoahHeapRegion*, _num_regions, mtGC);
-  _affiliations = NEW_C_HEAP_ARRAY(uint8_t, _num_regions, mtGC);
-  _free_set = new ShenandoahFreeSet(this, _num_regions);
+  if (mode()->is_generational()) {
+    _affiliations = NEW_C_HEAP_ARRAY(uint8_t, _num_regions, mtGC);
+  } else {
+    _affiliations = NULL;
+  }
+  _Free_set = new ShenandoahFreeSet(this, _num_regions);
 
   {
     ShenandoahHeapLocker locker(lock());

--- a/src/hotspot/share/gc/shenandoah/shenandoahHeap.hpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahHeap.hpp
@@ -269,6 +269,7 @@ private:
   bool      _heap_region_special;
   size_t    _num_regions;
   ShenandoahHeapRegion** _regions;
+  uint8_t* _affiliations;       // Holds array of enum ShenandoahRegionAffiliation
   ShenandoahRegionIterator _update_refs_iterator;
 
 public:
@@ -614,12 +615,18 @@ public:
   AdaptiveSizePolicy* size_policy() shenandoah_not_implemented_return(NULL);
   bool is_maximal_no_gc() const shenandoah_not_implemented_return(false);
 
-  bool is_in(const void* p) const;
+  inline bool is_in(const void* p) const;
 
-  bool is_in_active_generation(oop obj) const;
-  bool is_in_young(const void* p) const;
-  bool is_in_old(const void* p) const;
+  inline bool is_in_active_generation(oop obj) const;
+  inline bool is_in_young(const void* p) const;
+  inline bool is_in_old(const void* p) const;
   inline bool is_old(oop pobj) const;
+
+  inline ShenandoahRegionAffiliation region_affiliation(const ShenandoahHeapRegion* r);
+  inline void set_affiliation(ShenandoahHeapRegion* r, ShenandoahRegionAffiliation new_affiliation);
+
+  inline ShenandoahRegionAffiliation region_affiliation(size_t index);
+  inline void set_affiliation(size_t index, ShenandoahRegionAffiliation new_affiliation);
 
   bool requires_barriers(stackChunkOop obj) const;
 

--- a/src/hotspot/share/gc/shenandoah/shenandoahHeap.hpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahHeap.hpp
@@ -601,6 +601,9 @@ private:
   void stw_process_weak_roots(bool full_gc);
   void stw_weak_refs(bool full_gc);
 
+  inline void assert_lock_for_affiliation(ShenandoahRegionAffiliation orig_affiliation,
+                                          ShenandoahRegionAffiliation new_affiliation);
+
   // Heap iteration support
   void scan_roots_for_iteration(ShenandoahScanObjectStack* oop_stack, ObjectIterateScanRootClosure* oops);
   bool prepare_aux_bitmap_for_iteration();

--- a/src/hotspot/share/gc/shenandoah/shenandoahHeap.hpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahHeap.hpp
@@ -269,7 +269,7 @@ private:
   bool      _heap_region_special;
   size_t    _num_regions;
   ShenandoahHeapRegion** _regions;
-  uint8_t* _affiliations;       // Holds array of enum ShenandoahRegionAffiliation
+  uint8_t* _affiliations;       // Holds array of enum ShenandoahRegionAffiliation, including FREE status in non-generational mode
   ShenandoahRegionIterator _update_refs_iterator;
 
 public:

--- a/src/hotspot/share/gc/shenandoah/shenandoahHeap.inline.hpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahHeap.inline.hpp
@@ -607,6 +607,7 @@ inline ShenandoahRegionAffiliation ShenandoahHeap::region_affiliation(const Shen
 }
 
 inline void ShenandoahHeap::set_affiliation(ShenandoahHeapRegion* r, ShenandoahRegionAffiliation new_affiliation) {
+  shenandoah_assert_heaplocked_or_safepoint();
   _affiliations[r->index()] = (uint8_t) new_affiliation;
 }
 

--- a/src/hotspot/share/gc/shenandoah/shenandoahHeap.inline.hpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahHeap.inline.hpp
@@ -607,7 +607,11 @@ inline ShenandoahRegionAffiliation ShenandoahHeap::region_affiliation(const Shen
 }
 
 inline void ShenandoahHeap::set_affiliation(ShenandoahHeapRegion* r, ShenandoahRegionAffiliation new_affiliation) {
-  shenandoah_assert_heaplocked_or_safepoint();
+#ifdef ASSERT
+  if (new_affiliation != ShenandoahRegionAffiliation::FREE) {
+    shenandoah_assert_heaplocked_or_safepoint();
+  }
+#endif
   _affiliations[r->index()] = (uint8_t) new_affiliation;
 }
 
@@ -616,6 +620,11 @@ inline ShenandoahRegionAffiliation ShenandoahHeap::region_affiliation(size_t ind
 }
 
 inline void ShenandoahHeap::set_affiliation(size_t index, ShenandoahRegionAffiliation new_affiliation) {
+#ifdef ASSERT
+  if (new_affiliation != ShenandoahRegionAffiliation::FREE) {
+    shenandoah_assert_heaplocked_or_safepoint();
+  }
+#endif
   _affiliations[index] = (uint8_t) new_affiliation;
 }
 

--- a/src/hotspot/share/gc/shenandoah/shenandoahHeap.inline.hpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahHeap.inline.hpp
@@ -570,8 +570,8 @@ inline bool ShenandoahHeap::is_in_active_generation(oop obj) const {
 
   assert(is_in(obj), "only check if is in active generation for objects (" PTR_FORMAT ") in heap", p2i(obj));
   assert((active_generation() == (ShenandoahGeneration*) old_generation()) ||
-	 (active_generation() == (ShenandoahGeneration*) young_generation()) ||
-	 (active_generation() == global_generation()), "Active generation must be old, young, or global");
+         (active_generation() == (ShenandoahGeneration*) young_generation()) ||
+         (active_generation() == global_generation()), "Active generation must be old, young, or global");
 
   size_t index = heap_region_containing(obj)->index();
   switch (_affiliations[index]) {

--- a/src/hotspot/share/gc/shenandoah/shenandoahHeap.inline.hpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahHeap.inline.hpp
@@ -550,8 +550,72 @@ inline bool ShenandoahHeap::clear_old_evacuation_failure() {
   return _old_gen_oom_evac.try_unset();
 }
 
+bool ShenandoahHeap::is_in(const void* p) const {
+  HeapWord* heap_base = (HeapWord*) base();
+  HeapWord* last_region_end = heap_base + ShenandoahHeapRegion::region_size_words() * num_regions();
+  return p >= heap_base && p < last_region_end;
+}
+
+inline bool ShenandoahHeap::is_in_active_generation(oop obj) const {
+  if (!mode()->is_generational()) {
+    // everything is the same single generation
+    return true;
+  }
+
+  if (active_generation() == NULL) {
+    // no collection is happening, only expect this to be called
+    // when concurrent processing is active, but that could change
+    return false;
+  }
+
+  assert(is_in(obj), "only check if is in active generation for objects (" PTR_FORMAT ") in heap", p2i(obj));
+  assert((active_generation() == (ShenandoahGeneration*) old_generation()) ||
+	 (active_generation() == (ShenandoahGeneration*) young_generation()) ||
+	 (active_generation() == global_generation()), "Active generation must be old, young, or global");
+
+  size_t index = heap_region_containing(obj)->index();
+  switch (_affiliations[index]) {
+  case ShenandoahRegionAffiliation::FREE:
+    // Free regions are in Old, Young, Global
+    return true;
+  case ShenandoahRegionAffiliation::YOUNG_GENERATION:
+    // Young regions are in young_generation and global_generation, not in old_generation
+    return (active_generation() != (ShenandoahGeneration*) old_generation());
+  case ShenandoahRegionAffiliation::OLD_GENERATION:
+    // Old regions are in old_generation and global_generation, not in young_generation
+    return (active_generation() != (ShenandoahGeneration*) young_generation());
+  default:
+    assert(false, "Bad affiliation (%d) for region " SIZE_FORMAT, _affiliations[index], index);
+    return false;
+  }
+}
+
+inline bool ShenandoahHeap::is_in_young(const void* p) const {
+  return is_in(p) && (_affiliations[heap_region_index_containing(p)] == ShenandoahRegionAffiliation::YOUNG_GENERATION);
+}
+
+inline bool ShenandoahHeap::is_in_old(const void* p) const {
+  return is_in(p) && (_affiliations[heap_region_index_containing(p)] == ShenandoahRegionAffiliation::OLD_GENERATION);
+}
+
 inline bool ShenandoahHeap::is_old(oop obj) const {
   return is_gc_generation_young() && is_in_old(obj);
+}
+
+inline ShenandoahRegionAffiliation ShenandoahHeap::region_affiliation(const ShenandoahHeapRegion *r) {
+  return (ShenandoahRegionAffiliation) _affiliations[r->index()];
+}
+
+inline void ShenandoahHeap::set_affiliation(ShenandoahHeapRegion* r, ShenandoahRegionAffiliation new_affiliation) {
+  _affiliations[r->index()] = (uint8_t) new_affiliation;
+}
+
+inline ShenandoahRegionAffiliation ShenandoahHeap::region_affiliation(size_t index) {
+  return (ShenandoahRegionAffiliation) _affiliations[index];
+}
+
+inline void ShenandoahHeap::set_affiliation(size_t index, ShenandoahRegionAffiliation new_affiliation) {
+  _affiliations[index] = (uint8_t) new_affiliation;
 }
 
 inline bool ShenandoahHeap::requires_marking(const void* entry) const {

--- a/src/hotspot/share/gc/shenandoah/shenandoahHeapRegion.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahHeapRegion.cpp
@@ -112,7 +112,8 @@ void ShenandoahHeapRegion::make_regular_allocation(ShenandoahRegionAffiliation a
 // Change affiliation to YOUNG_GENERATION if _state is not _pinned_cset, _regular, or _pinned.  This implements
 // behavior previously performed as a side effect of make_regular_bypass().
 void ShenandoahHeapRegion::make_young_maybe() {
- switch (_state) {
+  shenandoah_assert_heaplocked();
+  switch (_state) {
    case _empty_uncommitted:
    case _empty_committed:
    case _cset:
@@ -661,6 +662,7 @@ ShenandoahHeapRegion* ShenandoahHeapRegion::humongous_start_region() const {
 
 void ShenandoahHeapRegion::recycle() {
   ShenandoahHeap* heap = ShenandoahHeap::heap();
+  shenandoah_assert_heaplocked();
 
   if (affiliation() == YOUNG_GENERATION) {
     heap->young_generation()->decrease_used(used());

--- a/src/hotspot/share/gc/shenandoah/shenandoahHeapRegion.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahHeapRegion.cpp
@@ -76,7 +76,6 @@ ShenandoahHeapRegion::ShenandoahHeapRegion(HeapWord* start, size_t index, bool c
   _live_data(0),
   _critical_pins(0),
   _update_watermark(start),
-  _affiliation(FREE),
   _age(0) {
 
   assert(Universe::on_page_boundary(_bottom) && Universe::on_page_boundary(_end),
@@ -407,7 +406,7 @@ void ShenandoahHeapRegion::print_on(outputStream* st) const {
       ShouldNotReachHere();
   }
 
-  switch (_affiliation) {
+  switch (ShenandoahHeap::heap()->region_affiliation(this)) {
     case ShenandoahRegionAffiliation::FREE:
       st->print("|F");
       break;
@@ -933,11 +932,12 @@ size_t ShenandoahHeapRegion::pin_count() const {
 void ShenandoahHeapRegion::set_affiliation(ShenandoahRegionAffiliation new_affiliation) {
   ShenandoahHeap* heap = ShenandoahHeap::heap();
 
+  ShenandoahRegionAffiliation region_affiliation = heap->region_affiliation(this);
   {
     ShenandoahMarkingContext* const ctx = heap->complete_marking_context();
     log_debug(gc)("Setting affiliation of Region " SIZE_FORMAT " from %s to %s, top: " PTR_FORMAT ", TAMS: " PTR_FORMAT
                   ", watermark: " PTR_FORMAT ", top_bitmap: " PTR_FORMAT,
-                  index(), affiliation_name(_affiliation), affiliation_name(new_affiliation),
+                  index(), affiliation_name(region_affiliation), affiliation_name(new_affiliation),
                   p2i(top()), p2i(ctx->top_at_mark_start(this)), p2i(_update_watermark), p2i(ctx->top_bitmap(this)));
   }
 
@@ -954,21 +954,21 @@ void ShenandoahHeapRegion::set_affiliation(ShenandoahRegionAffiliation new_affil
   }
 #endif
 
-  if (_affiliation == new_affiliation) {
+  if (region_affiliation == new_affiliation) {
     return;
   }
 
   if (!heap->mode()->is_generational()) {
-    _affiliation = new_affiliation;
+    heap->set_affiliation(this, new_affiliation);
     return;
   }
 
   log_trace(gc)("Changing affiliation of region %zu from %s to %s",
-    index(), affiliation_name(_affiliation), affiliation_name(new_affiliation));
+    index(), affiliation_name(region_affiliation), affiliation_name(new_affiliation));
 
-  if (_affiliation == ShenandoahRegionAffiliation::YOUNG_GENERATION) {
+  if (region_affiliation == ShenandoahRegionAffiliation::YOUNG_GENERATION) {
     heap->young_generation()->decrement_affiliated_region_count();
-  } else if (_affiliation == ShenandoahRegionAffiliation::OLD_GENERATION) {
+  } else if (region_affiliation == ShenandoahRegionAffiliation::OLD_GENERATION) {
     heap->old_generation()->decrement_affiliated_region_count();
   }
 
@@ -987,7 +987,7 @@ void ShenandoahHeapRegion::set_affiliation(ShenandoahRegionAffiliation new_affil
       ShouldNotReachHere();
       return;
   }
-  _affiliation = new_affiliation;
+  heap->set_affiliation(this, new_affiliation);
 }
 
 size_t ShenandoahHeapRegion::promote_humongous() {

--- a/src/hotspot/share/gc/shenandoah/shenandoahHeapRegion.hpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahHeapRegion.hpp
@@ -199,8 +199,8 @@ public:
   bool is_committed()              const { return !is_empty_uncommitted(); }
   bool is_cset()                   const { return _state == _cset   || _state == _pinned_cset; }
   bool is_pinned()                 const { return _state == _pinned || _state == _pinned_cset || _state == _pinned_humongous_start; }
-  bool is_young()                  const { return _affiliation == YOUNG_GENERATION; }
-  bool is_old()                    const { return _affiliation == OLD_GENERATION; }
+  inline bool is_young() const;
+  inline bool is_old() const;
 
   // Macro-properties:
   bool is_alloc_allowed()          const { return is_empty() || is_regular() || _state == _pinned; }
@@ -257,7 +257,6 @@ private:
 
   HeapWord* volatile _update_watermark;
 
-  ShenandoahRegionAffiliation _affiliation;
   uint _age;
 
 public:
@@ -441,9 +440,7 @@ public:
   inline void set_update_watermark(HeapWord* w);
   inline void set_update_watermark_at_safepoint(HeapWord* w);
 
-  ShenandoahRegionAffiliation affiliation() const {
-    return _affiliation;
-  }
+  inline ShenandoahRegionAffiliation affiliation() const;
 
   void set_affiliation(ShenandoahRegionAffiliation new_affiliation);
 

--- a/src/hotspot/share/gc/shenandoah/shenandoahHeapRegion.inline.hpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahHeapRegion.inline.hpp
@@ -176,6 +176,10 @@ inline void ShenandoahHeapRegion::set_update_watermark_at_safepoint(HeapWord* w)
   _update_watermark = w;
 }
 
+inline ShenandoahRegionAffiliation ShenandoahHeapRegion::affiliation() const {
+  return ShenandoahHeap::heap()->region_affiliation(this);
+}
+
 inline void ShenandoahHeapRegion::clear_young_lab_flags() {
   _has_young_lab = false;
 }
@@ -186,6 +190,14 @@ inline void ShenandoahHeapRegion::set_young_lab_flag() {
 
 inline bool ShenandoahHeapRegion::has_young_lab_flag() {
   return _has_young_lab;
+}
+
+inline bool ShenandoahHeapRegion::is_young() const {
+  return ShenandoahHeap::heap()->region_affiliation(this) == YOUNG_GENERATION;
+}
+
+inline bool ShenandoahHeapRegion::is_old() const {
+  return ShenandoahHeap::heap()->region_affiliation(this) == OLD_GENERATION;
 }
 
 #endif // SHARE_GC_SHENANDOAH_SHENANDOAHHEAPREGION_INLINE_HPP


### PR DESCRIPTION
With generational mode of Shenandoah, each region is associated with OLD, YOUNG, or FREE.  During certain marking and update-refs activities, the region affiliation is frequently consulted.  In the original implementation, the region affiliation was stored in a field of the ShenandoahHeapRegion object.  In this code, we maintain a separate array, indexed by region number, to represent the affiliation of each region.  This saves one level of indirection and improves cache locality for looking up the affiliation of each region.

Measurements show significant improvement in throughput.  One workload that was configured to perform back-to-back old-gen collections was able to increase the frequency of old-gen collections by almost 5 fold.  With a 20-minute Extremem workload using a 48G heap, 20G old-gen, the P95 latency improvement was 0.54% (2.395 ms) and the P99.999 latency improvement was 58.21% (29.195 ms) in comparison to the implementation before this patch.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed (1 review required, with at least 1 [Committer](https://openjdk.org/bylaws#committer))

### Reviewers
 * [Y. Srinivas Ramakrishna](https://openjdk.org/census#ysr) (@ysramakrishna - Author) ⚠️ Review applies to [1033b0cd](https://git.openjdk.org/shenandoah/pull/170/files/1033b0cdc5f00af5261f96d5e945c3b9b9ac4c13)
 * [William Kemper](https://openjdk.org/census#wkemper) (@earthling-amzn - Committer) ⚠️ Review applies to [1033b0cd](https://git.openjdk.org/shenandoah/pull/170/files/1033b0cdc5f00af5261f96d5e945c3b9b9ac4c13)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/shenandoah pull/170/head:pull/170` \
`$ git checkout pull/170`

Update a local copy of the PR: \
`$ git checkout pull/170` \
`$ git pull https://git.openjdk.org/shenandoah pull/170/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 170`

View PR using the GUI difftool: \
`$ git pr show -t 170`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/shenandoah/pull/170.diff">https://git.openjdk.org/shenandoah/pull/170.diff</a>

</details>
