### PR TITLE
Load balance remset scan

### DIFF
--- a/src/hotspot/share/gc/shenandoah/shenandoahHeap.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahHeap.cpp
@@ -1132,7 +1132,7 @@ HeapWord* ShenandoahHeap::allocate_new_plab(size_t min_size,
 }
 
 // is_promotion is true iff this allocation is known for sure to hold the result of young-gen evacuation
-// to old-gen.  plab allocates arre not known as such, since they may hold old-gen evacuations.
+// to old-gen.  plab allocates are not known as such, since they may hold old-gen evacuations.
 HeapWord* ShenandoahHeap::allocate_memory(ShenandoahAllocRequest& req, bool is_promotion) {
   intptr_t pacer_epoch = 0;
   bool in_new_region = false;

--- a/src/hotspot/share/gc/shenandoah/shenandoahScanRemembered.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahScanRemembered.cpp
@@ -109,28 +109,37 @@ void ShenandoahScanRememberedTask::do_work(uint worker_id) {
   }
 }
 
-size_t ShenandoahRegionChunkIterator::calc_group_size() {
-  // The group size s calculated from the number of regions.  Every group except the last processes the same number of chunks.
-  // The last group processes however many chunks are required to finish the total scanning effort.  The chunk sizes are
+size_t ShenandoahRegionChunkIterator::calc_regular_group_size() {
+  // The group size is calculated from the number of regions.  Suppose the entire heap size is N.  The first group processes
+  // N/2 of total heap size.  The second group processes N/4 of total heap size.  The third group processes N/2 of total heap
+  // size, and so on.  Note that N/2 + N/4 + N/8 + N/16 + ...  sums to N if expanded to infinite terms.
+  //
+  // The normal group size is the number of regions / 2, with the normal 
+
+  // In the case that the region_size_words is greater than _maximum_chunk_size_words, the first group_size is 
+  // larger than the normal group size because each chunk in the group will be smaller than the region size.
+  //
+  // The last group also has more than the normal entries because it finishes the total scanning effort.  The chunk sizes are
   // different for each group.  The intention is that the first group processes roughly half of the heap, the second processes
   // a quarter of the remaining heap, the third processes an eight of what remains and so on.  The smallest chunk size
-  // is represented by _smallest_chunk_size.  We do not divide work any smaller than this.
+  // is represented by _smallest_chunk_size_words.  We do not divide work any smaller than this.
   //
-  // Note that N/2 + N/4 + N/8 + N/16 + ...  sums to N if expanded to infinite terms.
-  return _heap->num_regions() / 2;
+
+  size_t group_size = _heap->num_regions() / 2;
+  return group_size;
 }
 
-size_t ShenandoahRegionChunkIterator::calc_first_group_chunk_size() {
-  size_t words_in_region = ShenandoahHeapRegion::region_size_words();
-  return words_in_region;
+size_t ShenandoahRegionChunkIterator::calc_first_group_chunk_size_b4_rebalance() {
+  size_t words_in_first_chunk = ShenandoahHeapRegion::region_size_words();
+  return words_in_first_chunk;
 }
 
 size_t ShenandoahRegionChunkIterator::calc_num_groups() {
   size_t total_heap_size = _heap->num_regions() * ShenandoahHeapRegion::region_size_words();
   size_t num_groups = 0;
   size_t cumulative_group_span = 0;
-  size_t current_group_span = _first_group_chunk_size * _group_size;
-  size_t smallest_group_span = _smallest_chunk_size * _group_size;
+  size_t current_group_span = _first_group_chunk_size_b4_rebalance * _regular_group_size;
+  size_t smallest_group_span = _smallest_chunk_size_words * _regular_group_size;
   while ((num_groups < _maximum_groups) && (cumulative_group_span + current_group_span <= total_heap_size)) {
     num_groups++;
     cumulative_group_span += current_group_span;
@@ -144,7 +153,7 @@ size_t ShenandoahRegionChunkIterator::calc_num_groups() {
   //   num_groups <= _maximum_groups
   //   cumulative_group_span is the memory spanned by num_groups
   //   current_group_span is the span of the last fully populated group (assuming loop iterates at least once)
-  //   each of num_groups is fully populated with _group_size chunks in each
+  //   each of num_groups is fully populated with _regular_group_size chunks in each
   // Non post conditions:
   //   cumulative_group_span may be less than total_heap size for one or more of the folowing reasons
   //   a) The number of regions remaining to be spanned is smaller than a complete group, or
@@ -159,7 +168,7 @@ size_t ShenandoahRegionChunkIterator::calc_num_groups() {
     // minimum chunk size.
 
     // Any remaining regions will be treated as if they are part of the most recently created group.  This group will
-    // have more than _group_size chunks within it.
+    // have more than _regular_group_size chunks within it.
   }
   return num_groups;
 }
@@ -168,29 +177,46 @@ size_t ShenandoahRegionChunkIterator::calc_total_chunks() {
   size_t region_size_words = ShenandoahHeapRegion::region_size_words();
   size_t unspanned_heap_size = _heap->num_regions() * region_size_words;
   size_t num_chunks = 0;
-  size_t spanned_groups = 0;
   size_t cumulative_group_span = 0;
-  size_t current_group_span = _first_group_chunk_size * _group_size;
-  size_t smallest_group_span = _smallest_chunk_size * _group_size;
+  size_t current_group_span = _first_group_chunk_size_b4_rebalance * _regular_group_size;
+  size_t smallest_group_span = _smallest_chunk_size_words * _regular_group_size;
+
+  // Tyhe first group gets special handling because the first chunk size can be no larger than _largets_chunk_size_words
+  if (region_size_words > _maximum_chunk_size_words) {
+    // In the case that we shrink the first group's chunk size, certain other groups will also be subsumed within the first group
+    size_t effective_chunk_size = _first_group_chunk_size_b4_rebalance;
+    while (effective_chunk_size >= _maximum_chunk_size_words) {
+      num_chunks += current_group_span / _maximum_chunk_size_words;
+      unspanned_heap_size -= current_group_span;
+      effective_chunk_size /= 2;
+      current_group_span /= 2;
+    }
+  } else {
+    num_chunks = _regular_group_size;
+    unspanned_heap_size -= current_group_span;
+    current_group_span /= 2;
+  }
+  size_t spanned_groups = 1;
   while (unspanned_heap_size > 0) {
     if (current_group_span <= unspanned_heap_size) {
       unspanned_heap_size -= current_group_span;
-      num_chunks += _group_size;
+      num_chunks += _regular_group_size;
       spanned_groups++;
 
       // _num_groups is the number of groups required to span the configured heap size.  We are not allowed
       // to change the number of groups.  The last group is responsible for spanning all chunks not spanned
       // by previously processed groups.
       if (spanned_groups >= _num_groups) {
-        // The last group has more than _group_size entries.
-        size_t chunk_span = current_group_span / _group_size;
+        // The last group has more than _regular_group_size entries.
+        size_t chunk_span = current_group_span / _regular_group_size;
         size_t extra_chunks = unspanned_heap_size / chunk_span;
         assert (extra_chunks * chunk_span == unspanned_heap_size, "Chunks must precisely span regions");
         num_chunks += extra_chunks;
         return num_chunks;
       } else if (current_group_span <= smallest_group_span) {
-        // We cannot introduce new groups because we've reached the lower bound on group size
-        size_t chunk_span = _smallest_chunk_size;
+        // We cannot introduce new groups because we've reached the lower bound on group size.  So this last
+        // group may hold extra chunks.
+        size_t chunk_span = _smallest_chunk_size_words;
         size_t extra_chunks = unspanned_heap_size / chunk_span;
         assert (extra_chunks * chunk_span == unspanned_heap_size, "Chunks must precisely span regions");
         num_chunks += extra_chunks;
@@ -199,8 +225,8 @@ size_t ShenandoahRegionChunkIterator::calc_total_chunks() {
         current_group_span /= 2;
       }
     } else {
-      // The last group has fewer than _group_size entries.
-      size_t chunk_span = current_group_span / _group_size;
+      // This last group has fewer than _regular_group_size entries.
+      size_t chunk_span = current_group_span / _regular_group_size;
       size_t last_group_size = unspanned_heap_size / chunk_span;
       assert (last_group_size * chunk_span == unspanned_heap_size, "Chunks must precisely span regions");
       num_chunks += last_group_size;
@@ -217,30 +243,68 @@ ShenandoahRegionChunkIterator::ShenandoahRegionChunkIterator(size_t worker_count
 
 ShenandoahRegionChunkIterator::ShenandoahRegionChunkIterator(ShenandoahHeap* heap, size_t worker_count) :
     _heap(heap),
-    _group_size(calc_group_size()),
-    _first_group_chunk_size(calc_first_group_chunk_size()),
+    _regular_group_size(calc_regular_group_size()),
+    _first_group_chunk_size_b4_rebalance(calc_first_group_chunk_size_b4_rebalance()),
     _num_groups(calc_num_groups()),
     _total_chunks(calc_total_chunks()),
     _index(0)
 {
-  assert(_smallest_chunk_size ==
-         CardTable::card_size_in_words() * ShenandoahCardCluster<ShenandoahDirectCardMarkRememberedSet>::CardsPerCluster,
-         "_smallest_chunk_size is not valid");
+  assert(_smallest_chunk_size_words == _clusters_in_smallest_chunk * CardTable::card_size_in_words()
+         * ShenandoahCardCluster<ShenandoahDirectCardMarkRememberedSet>::CardsPerCluster, "_smallest_chunk_size is not valid");
+  assert(_num_groups <= _maximum_groups,
+         "The number of remembered set scanning groups must be less than or equal to maximum groups");
+  assert(_smallest_chunk_size_words << (_maximum_groups - 1) == _maximum_chunk_size_words,
+         "Maximum number of groups needs to span maximum chunk size to smallest chunk size");
 
   size_t words_in_region = ShenandoahHeapRegion::region_size_words();
-  size_t group_span = _first_group_chunk_size * _group_size;
-
   _region_index[0] = 0;
   _group_offset[0] = 0;
-  for (size_t i = 1; i < _num_groups; i++) {
-    _region_index[i] = _region_index[i-1] + (_group_offset[i-1] + group_span) / words_in_region;
-    _group_offset[i] = (_group_offset[i-1] + group_span) % words_in_region;
-    group_span /= 2;
+  if (words_in_region > _maximum_chunk_size_words) {
+    // In the case that we shrink the first group's chunk size, certain other groups will also be subsumed within the first group
+    size_t num_chunks = 0;
+    size_t effective_chunk_size = _first_group_chunk_size_b4_rebalance;
+    size_t  current_group_span = effective_chunk_size * _regular_group_size;
+    while (effective_chunk_size >= _maximum_chunk_size_words) {
+      num_chunks += current_group_span / _maximum_chunk_size_words;
+      effective_chunk_size /= 2;
+      current_group_span /= 2;
+    }
+    _group_entries[0] = num_chunks;
+    _group_chunk_size[0] = _maximum_chunk_size_words;
+  } else {
+    _group_entries[0] = _regular_group_size;
+    _group_chunk_size[0] = _first_group_chunk_size_b4_rebalance;
   }
+
+  size_t previous_group_span = _group_entries[0] * _group_chunk_size[0];
+  for (size_t i = 1; i < _num_groups; i++) {
+    size_t previous_group_entries = (i == 1)? _group_entries[0]: (_group_entries[i-1] - _group_entries[i-2]);
+    _group_chunk_size[i] = _group_chunk_size[i-1] / 2;
+    size_t chunks_in_group = _regular_group_size;
+    size_t this_group_span = _group_chunk_size[i] * chunks_in_group;
+    size_t total_span_of_groups = previous_group_span + this_group_span;
+    _region_index[i] = previous_group_span / words_in_region;
+    _group_offset[i] = previous_group_span % words_in_region;
+    _group_entries[i] = _group_entries[i-1] + _regular_group_size;
+    previous_group_span = total_span_of_groups;
+  }
+  if (_group_entries[_num_groups-1] < _total_chunks) {
+    assert((_total_chunks - _group_entries[_num_groups-1]) * _group_chunk_size[_num_groups-1] + previous_group_span == 
+           heap->num_regions() * words_in_region, "Total region chunks (" SIZE_FORMAT
+           ") do not span total heap regions (" SIZE_FORMAT ")", _total_chunks, _heap->num_regions());
+    previous_group_span += (_total_chunks - _group_entries[_num_groups-1]) * _group_chunk_size[_num_groups-1];
+    _group_entries[_num_groups-1] = _total_chunks;
+  }
+  assert(previous_group_span == heap->num_regions() * words_in_region, "Total region chunks (" SIZE_FORMAT
+         ") do not span total heap regions (" SIZE_FORMAT "): " SIZE_FORMAT " does not equal " SIZE_FORMAT,
+	 _total_chunks, _heap->num_regions(), previous_group_span, heap->num_regions() * words_in_region);
+
   // Not necessary, but keeps things tidy
   for (size_t i = _num_groups; i < _maximum_groups; i++) {
     _region_index[i] = 0;
     _group_offset[i] = 0;
+    _group_entries[i] = _group_entries[i-1];
+    _group_chunk_size[i] = 0;
   }
 }
 

--- a/src/hotspot/share/gc/shenandoah/shenandoahScanRemembered.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahScanRemembered.cpp
@@ -114,9 +114,9 @@ size_t ShenandoahRegionChunkIterator::calc_regular_group_size() {
   // N/2 of total heap size.  The second group processes N/4 of total heap size.  The third group processes N/2 of total heap
   // size, and so on.  Note that N/2 + N/4 + N/8 + N/16 + ...  sums to N if expanded to infinite terms.
   //
-  // The normal group size is the number of regions / 2, with the normal 
-
-  // In the case that the region_size_words is greater than _maximum_chunk_size_words, the first group_size is 
+  // The normal group size is the number of regions / 2.
+  //
+  // In the case that the region_size_words is greater than _maximum_chunk_size_words, the first group_size is
   // larger than the normal group size because each chunk in the group will be smaller than the region size.
   //
   // The last group also has more than the normal entries because it finishes the total scanning effort.  The chunk sizes are
@@ -181,7 +181,7 @@ size_t ShenandoahRegionChunkIterator::calc_total_chunks() {
   size_t current_group_span = _first_group_chunk_size_b4_rebalance * _regular_group_size;
   size_t smallest_group_span = _smallest_chunk_size_words * _regular_group_size;
 
-  // Tyhe first group gets special handling because the first chunk size can be no larger than _largets_chunk_size_words
+  // The first group gets special handling because the first chunk size can be no larger than _largest_chunk_size_words
   if (region_size_words > _maximum_chunk_size_words) {
     // In the case that we shrink the first group's chunk size, certain other groups will also be subsumed within the first group
     size_t effective_chunk_size = _first_group_chunk_size_b4_rebalance;
@@ -289,7 +289,7 @@ ShenandoahRegionChunkIterator::ShenandoahRegionChunkIterator(ShenandoahHeap* hea
     previous_group_span = total_span_of_groups;
   }
   if (_group_entries[_num_groups-1] < _total_chunks) {
-    assert((_total_chunks - _group_entries[_num_groups-1]) * _group_chunk_size[_num_groups-1] + previous_group_span == 
+    assert((_total_chunks - _group_entries[_num_groups-1]) * _group_chunk_size[_num_groups-1] + previous_group_span ==
            heap->num_regions() * words_in_region, "Total region chunks (" SIZE_FORMAT
            ") do not span total heap regions (" SIZE_FORMAT ")", _total_chunks, _heap->num_regions());
     previous_group_span += (_total_chunks - _group_entries[_num_groups-1]) * _group_chunk_size[_num_groups-1];
@@ -297,7 +297,7 @@ ShenandoahRegionChunkIterator::ShenandoahRegionChunkIterator(ShenandoahHeap* hea
   }
   assert(previous_group_span == heap->num_regions() * words_in_region, "Total region chunks (" SIZE_FORMAT
          ") do not span total heap regions (" SIZE_FORMAT "): " SIZE_FORMAT " does not equal " SIZE_FORMAT,
-	 _total_chunks, _heap->num_regions(), previous_group_span, heap->num_regions() * words_in_region);
+         _total_chunks, _heap->num_regions(), previous_group_span, heap->num_regions() * words_in_region);
 
   // Not necessary, but keeps things tidy
   for (size_t i = _num_groups; i < _maximum_groups; i++) {

--- a/src/hotspot/share/gc/shenandoah/shenandoahScanRemembered.hpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahScanRemembered.hpp
@@ -1008,30 +1008,46 @@ struct ShenandoahRegionChunk {
 
 class ShenandoahRegionChunkIterator : public StackObj {
 private:
-  // smallest_chunk_size is 64 words per card *
-  // ShenandoahCardCluster<ShenandoahDirectCardMarkRememberedSet>::CardsPerCluster.
+  // The largest chunk size is 4 MiB, measured in words.  Otherwise, remembered set scanning may become too unbalanced.
+  // If the largest chunk size is too small, there is too much overhead sifting out assignments to individual worker threads.
+  static const size_t _maximum_chunk_size_words = (4 * 1024 * 1024) / HeapWordSize;
+
+  static const size_t _clusters_in_smallest_chunk = 4;
+  static const size_t _assumed_words_in_card = 64;
+
+  // smallest_chunk_size is 4 clusters (i.e. 128 KiB).  Note that there are 64 words per card and there are 64 cards per
+  // cluster.  Each cluster spans 128 KiB.
   // This is computed from CardTable::card_size_in_words() *
   //      ShenandoahCardCluster<ShenandoahDirectCardMarkRememberedSet>::CardsPerCluster;
   // We can't perform this computation here, because of encapsulation and initialization constraints.  We paste
   // the magic number here, and assert that this number matches the intended computation in constructor.
-  static const size_t _smallest_chunk_size = 64 * ShenandoahCardCluster<ShenandoahDirectCardMarkRememberedSet>::CardsPerCluster;
+  static const size_t _smallest_chunk_size_words = (_clusters_in_smallest_chunk * _assumed_words_in_card *
+                                                    ShenandoahCardCluster<ShenandoahDirectCardMarkRememberedSet>::CardsPerCluster);
 
   // The total remembered set scanning effort is divided into chunks of work that are assigned to individual worker tasks.
-  // The chunks of assigned work are divided into groups, where the size of each group (_group_size) is 4 * the number of
-  // worker tasks.  All of the assignments within a group represent the same amount of memory to be scanned.  Each of the
-  // assignments within the first group are of size _first_group_chunk_size (typically the ShenandoahHeapRegion size, but
-  // possibly smaller.  Each of the assignments within each subsequent group are half the size of the assignments in the
-  // preceding group.  The last group may be larger than the others.  Because no group is allowed to have smaller assignments
-  // than _smallest_chunk_size, which is 32 KB.
+  // The chunks of assigned work are divided into groups, where the size of the typical group (_regular_group_size) is half the
+  // total number of regions.  The first group may be larger than
+  // _regular_group_size in the case that the first group's chunk
+  // size is less than the region size.  The last group may be larger
+  // than _regular_group_size because no group is allowed to
+  // have smaller assignments than _smallest_chunk_size, which is 128 KB.
 
   // Under normal circumstances, no configuration needs more than _maximum_groups (default value of 16).
+  // The first group "effectively" processes chunks of size 1 MiB (or smaller for smaller region sizes).
+  // The last group processes chunks of size 128 KiB.  There are four groups total.
 
-  static const size_t _maximum_groups = 16;
+  // group[0] is 4 MiB chunk size (_maximum_chunk_size_words)
+  // group[1] is 2 MiB chunk size
+  // group[2] is 1 MiB chunk size
+  // group[3] is 512 KiB chunk size
+  // group[4] is 256 KiB chunk size
+  // group[5] is 128 Kib shunk size (_smallest_chunk_size_words = 4 * 64 * 64
+  static const size_t _maximum_groups = 6;
 
   const ShenandoahHeap* _heap;
 
-  const size_t _group_size;                        // Number of chunks in each group, equals worker_threads * 8
-  const size_t _first_group_chunk_size;
+  const size_t _regular_group_size;                        // Number of chunks in each group
+  const size_t _first_group_chunk_size_b4_rebalance;
   const size_t _num_groups;                        // Number of groups in this configuration
   const size_t _total_chunks;
 
@@ -1039,23 +1055,24 @@ private:
   volatile size_t _index;
   shenandoah_padding(1);
 
-  size_t _region_index[_maximum_groups];
-  size_t _group_offset[_maximum_groups];
-
+  size_t _region_index[_maximum_groups];           // The region index for the first region spanned by this group
+  size_t _group_offset[_maximum_groups];           // The offset at which group begins within first region spanned by this group
+  size_t _group_chunk_size[_maximum_groups];       // The size of each chunk within this group
+  size_t _group_entries[_maximum_groups];          // Total chunks spanned by this group and the ones before it.
 
   // No implicit copying: iterators should be passed by reference to capture the state
   NONCOPYABLE(ShenandoahRegionChunkIterator);
 
   // Makes use of _heap.
-  size_t calc_group_size();
+  size_t calc_regular_group_size();
 
-  // Makes use of _group_size, which must be initialized before call.
-  size_t calc_first_group_chunk_size();
+  // Makes use of _regular_group_size, which must be initialized before call.
+  size_t calc_first_group_chunk_size_b4_rebalance();
 
-  // Makes use of _group_size and _first_group_chunk_size, both of which must be initialized before call.
+  // Makes use of _regular_group_size and _first_group_chunk_size_b4_rebalance, both of which must be initialized before call.
   size_t calc_num_groups();
 
-  // Makes use of _group_size, _first_group_chunk_size, which must be initialized before call.
+  // Makes use of _regular_group_size, _first_group_chunk_size_b4_rebalance, which must be initialized before call.
   size_t calc_total_chunks();
 
 public:

--- a/src/hotspot/share/gc/shenandoah/shenandoahScanRemembered.inline.hpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahScanRemembered.inline.hpp
@@ -678,7 +678,6 @@ ShenandoahScanRemembered<RememberedSet>::process_humongous_clusters(ShenandoahHe
   size_t first_card_index = first_cluster * ShenandoahCardCluster<RememberedSet>::CardsPerCluster;
   HeapWord* first_cluster_addr = _rs->addr_for_card_index(first_card_index);
   size_t spanned_words = count * ShenandoahCardCluster<RememberedSet>::CardsPerCluster * CardTable::card_size_in_words();
-
   start_region->oop_iterate_humongous_slice(cl, true, first_cluster_addr, spanned_words, write_table, is_concurrent);
 }
 
@@ -815,27 +814,28 @@ inline bool ShenandoahRegionChunkIterator::next(struct ShenandoahRegionChunk *as
   // convert to zero-based indexing
   new_index--;
 
-  size_t group_no = new_index / _group_size;
-  if (group_no + 1 > _num_groups) {
-    group_no = _num_groups - 1;
-  }
+  size_t group_no;
+  for (group_no = 0; new_index >= _group_entries[group_no]; group_no++)
+    ;
+
+  assert(group_no < _num_groups, "Cannot have group no greater or equal to _num_groups");
 
   // All size computations measured in HeapWord
   size_t region_size_words = ShenandoahHeapRegion::region_size_words();
   size_t group_region_index = _region_index[group_no];
   size_t group_region_offset = _group_offset[group_no];
 
-  size_t index_within_group = new_index - (group_no * _group_size);
-  size_t group_chunk_size = _first_group_chunk_size >> group_no;
+  size_t index_within_group = (group_no == 0)? new_index: new_index - _group_entries[group_no - 1];
+  size_t group_chunk_size = _group_chunk_size[group_no];
   size_t offset_of_this_chunk = group_region_offset + index_within_group * group_chunk_size;
   size_t regions_spanned_by_chunk_offset = offset_of_this_chunk / region_size_words;
-  size_t region_index = group_region_index + regions_spanned_by_chunk_offset;
   size_t offset_within_region = offset_of_this_chunk % region_size_words;
+
+  size_t region_index = group_region_index + regions_spanned_by_chunk_offset;
 
   assignment->_r = _heap->get_region(region_index);
   assignment->_chunk_offset = offset_within_region;
   assignment->_chunk_size = group_chunk_size;
-
   return true;
 }
 


### PR DESCRIPTION
Prior to this change, the initial group of remembered set assignments was given to worker threads one entire region at a time.  We found that with large region sizes (e.g. 16 MiB and above), this resulted in too much imbalance in the work performed by individual threads.  A few threads assigned to scan 16 MiB regions with high density of "interesting pointers" were still scanning after all other worker threads finished their scanning efforts.

This change caps the maximum assignment size for worker threads at 4 MiB.  This results in better distribution of efforts between multiple concurrent threads.  With 13 worker threads and 16 MiB heap regions, we observe the following benefits on an Extremem workload (46_064 MiB heap size, 27_648 MiB new size):

Latency for customer preparation processing improved by 0.79% for P50, 2.26% for P95, 8.21% for p99, 28.17% for p99.9, 86.59% for p99.99, 86.77% for p99.999.  The p100 response improved only slightly, by 1.99%.

Average time for concurrent remembered set marking scan improved by 1.92%.  The average time for concurrent update refs time, which includes remembered set scanning, improved by 1.72%.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed (1 review required, with at least 1 [Committer](https://openjdk.org/bylaws#committer))

### Reviewers
 * [William Kemper](https://openjdk.org/census#wkemper) (@earthling-amzn - Committer) ⚠️ Review applies to [9704b348](https://git.openjdk.org/shenandoah/pull/173/files/9704b3487d2e4383fadcfead4cce2b3990ff1f5b)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/shenandoah pull/173/head:pull/173` \
`$ git checkout pull/173`

Update a local copy of the PR: \
`$ git checkout pull/173` \
`$ git pull https://git.openjdk.org/shenandoah pull/173/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 173`

View PR using the GUI difftool: \
`$ git pr show -t 173`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/shenandoah/pull/173.diff">https://git.openjdk.org/shenandoah/pull/173.diff</a>

</details>
