### PR TITLE
Enforce max regions

### DIFF
--- a/src/hotspot/share/gc/shenandoah/shenandoahFreeSet.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahFreeSet.cpp
@@ -100,12 +100,14 @@ HeapWord* ShenandoahFreeSet::allocate_single(ShenandoahAllocRequest& req, bool& 
   bool allow_new_region = true;
   switch (req.affiliation()) {
     case ShenandoahRegionAffiliation::OLD_GENERATION:
+      // Note: unsigned result from adjusted_unaffiliated_regions() will never be less than zero, but it may equal zero.
       if (_heap->old_generation()->adjusted_unaffiliated_regions() <= 0) {
         allow_new_region = false;
       }
       break;
 
     case ShenandoahRegionAffiliation::YOUNG_GENERATION:
+      // Note: unsigned result from adjusted_unaffiliated_regions() will never be less than zero, but it may equal zero.
       if (_heap->young_generation()->adjusted_unaffiliated_regions() <= 0) {
         allow_new_region = false;
       }

--- a/src/hotspot/share/gc/shenandoah/shenandoahFreeSet.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahFreeSet.cpp
@@ -97,14 +97,35 @@ HeapWord* ShenandoahFreeSet::allocate_single(ShenandoahAllocRequest& req, bool& 
 
   // Overwrite with non-zero (non-NULL) values only if necessary for allocation bookkeeping.
 
+  bool allow_new_region = true;
+  switch (req.affiliation()) {
+    case ShenandoahRegionAffiliation::OLD_GENERATION:
+      if (_heap->old_generation()->used_regions_size() >= _heap->old_generation()->adjusted_capacity()) {
+        allow_new_region = false;
+      }
+      break;
+
+    case ShenandoahRegionAffiliation::YOUNG_GENERATION:
+      if (_heap->young_generation()->used_regions_size() >= _heap->young_generation()->adjusted_capacity()) {
+        allow_new_region = false;
+      }
+      break;
+
+    case ShenandoahRegionAffiliation::FREE:
+    default:
+      ShouldNotReachHere();
+      break;
+  }
+
   switch (req.type()) {
     case ShenandoahAllocRequest::_alloc_tlab:
     case ShenandoahAllocRequest::_alloc_shared: {
       // Try to allocate in the mutator view
       for (size_t idx = _mutator_leftmost; idx <= _mutator_rightmost; idx++) {
-        if (is_mutator_free(idx)) {
+        ShenandoahHeapRegion* r = _heap->get_region(idx);
+        if (is_mutator_free(idx) && (allow_new_region || r->affiliation() != ShenandoahRegionAffiliation::FREE)) {
           // try_allocate_in() increases used if the allocation is successful.
-          HeapWord* result = try_allocate_in(_heap->get_region(idx), req, in_new_region);
+          HeapWord* result = try_allocate_in(r, req, in_new_region);
           if (result != NULL) {
             return result;
           }
@@ -127,10 +148,12 @@ HeapWord* ShenandoahFreeSet::allocate_single(ShenandoahAllocRequest& req, bool& 
       if (result != NULL) {
         return result;
       }
-      // Then try a free region that is dedicated to GC allocations.
-      result = allocate_with_affiliation(FREE, req, in_new_region);
-      if (result != NULL) {
-        return result;
+      if (allow_new_region) {
+        // Then try a free region that is dedicated to GC allocations.
+        result = allocate_with_affiliation(FREE, req, in_new_region);
+        if (result != NULL) {
+          return result;
+        }
       }
 
       // No dice. Can we borrow space from mutator view?
@@ -138,16 +161,18 @@ HeapWord* ShenandoahFreeSet::allocate_single(ShenandoahAllocRequest& req, bool& 
         return NULL;
       }
 
-      // Try to steal an empty region from the mutator view.
-      for (size_t c = _mutator_rightmost + 1; c > _mutator_leftmost; c--) {
-        size_t idx = c - 1;
-        if (is_mutator_free(idx)) {
-          ShenandoahHeapRegion* r = _heap->get_region(idx);
-          if (can_allocate_from(r)) {
-            flip_to_gc(r);
-            HeapWord *result = try_allocate_in(r, req, in_new_region);
-            if (result != NULL) {
-              return result;
+      if (allow_new_region) {
+        // Try to steal an empty region from the mutator view.
+        for (size_t c = _mutator_rightmost + 1; c > _mutator_leftmost; c--) {
+          size_t idx = c - 1;
+          if (is_mutator_free(idx)) {
+            ShenandoahHeapRegion* r = _heap->get_region(idx);
+            if (can_allocate_from(r)) {
+              flip_to_gc(r);
+              HeapWord *result = try_allocate_in(r, req, in_new_region);
+              if (result != NULL) {
+                return result;
+              }
             }
           }
         }
@@ -176,9 +201,7 @@ HeapWord* ShenandoahFreeSet::try_allocate_in(ShenandoahHeapRegion* r, Shenandoah
 
   if (r->affiliation() == ShenandoahRegionAffiliation::FREE) {
     ShenandoahMarkingContext* const ctx = _heap->complete_marking_context();
-
     r->set_affiliation(req.affiliation());
-
     if (r->is_old()) {
       // Any OLD region allocated during concurrent coalesce-and-fill does not need to be coalesced and filled because
       // all objects allocated within this region are above TAMS (and thus are implicitly marked).  In case this is an
@@ -243,6 +266,9 @@ HeapWord* ShenandoahFreeSet::try_allocate_in(ShenandoahHeapRegion* r, Shenandoah
       if (size >= req.min_size()) {
         result = r->allocate(size, req);
         assert (result != NULL, "Allocation must succeed: free " SIZE_FORMAT ", actual " SIZE_FORMAT, free, size);
+      } else {
+        log_info(gc, ergo)("Failed to shrink TLAB or GCLAB request (" SIZE_FORMAT ") in region " SIZE_FORMAT " to " SIZE_FORMAT
+                           " because min_size() is " SIZE_FORMAT, req.size(), r->index(), size, req.min_size());
       }
     }
   } else if (req.is_lab_alloc() && req.type() == ShenandoahAllocRequest::_alloc_plab) {
@@ -372,8 +398,12 @@ HeapWord* ShenandoahFreeSet::allocate_contiguous(ShenandoahAllocRequest& req) {
   size_t words_size = req.size();
   size_t num = ShenandoahHeapRegion::required_regions(words_size * HeapWordSize);
 
+  assert(req.affiliation() == ShenandoahRegionAffiliation::YOUNG_GENERATION, "Humongous regions always allocated in YOUNG");
+  size_t avail_young_regions = ((_heap->young_generation()->adjusted_capacity() - _heap->young_generation()->used_regions_size())
+                                / ShenandoahHeapRegion::region_size_bytes());
+
   // No regions left to satisfy allocation, bye.
-  if (num > mutator_count()) {
+  if (num > mutator_count() || (num > avail_young_regions)) {
     return NULL;
   }
 

--- a/src/hotspot/share/gc/shenandoah/shenandoahFreeSet.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahFreeSet.cpp
@@ -100,13 +100,13 @@ HeapWord* ShenandoahFreeSet::allocate_single(ShenandoahAllocRequest& req, bool& 
   bool allow_new_region = true;
   switch (req.affiliation()) {
     case ShenandoahRegionAffiliation::OLD_GENERATION:
-      if (_heap->old_generation()->used_regions_size() >= _heap->old_generation()->adjusted_capacity()) {
+      if (_heap->old_generation()->adjusted_unaffiliated_regions() <= 0) {
         allow_new_region = false;
       }
       break;
 
     case ShenandoahRegionAffiliation::YOUNG_GENERATION:
-      if (_heap->young_generation()->used_regions_size() >= _heap->young_generation()->adjusted_capacity()) {
+      if (_heap->young_generation()->adjusted_unaffiliated_regions() <= 0) {
         allow_new_region = false;
       }
       break;
@@ -399,8 +399,7 @@ HeapWord* ShenandoahFreeSet::allocate_contiguous(ShenandoahAllocRequest& req) {
   size_t num = ShenandoahHeapRegion::required_regions(words_size * HeapWordSize);
 
   assert(req.affiliation() == ShenandoahRegionAffiliation::YOUNG_GENERATION, "Humongous regions always allocated in YOUNG");
-  size_t avail_young_regions = ((_heap->young_generation()->adjusted_capacity() - _heap->young_generation()->used_regions_size())
-                                / ShenandoahHeapRegion::region_size_bytes());
+  size_t avail_young_regions = _heap->young_generation()->adjusted_unaffiliated_regions();
 
   // No regions left to satisfy allocation, bye.
   if (num > mutator_count() || (num > avail_young_regions)) {

--- a/src/hotspot/share/gc/shenandoah/shenandoahFullGC.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahFullGC.cpp
@@ -195,9 +195,9 @@ void ShenandoahFullGC::do_it(GCCause::Cause gc_cause) {
   heap->set_gc_generation(heap->global_generation());
 
   if (heap->mode()->is_generational()) {
-    // There will be no concurrent allocations during full GC so reset these coordination variables.
-    heap->young_generation()->unadjust_available();
-    heap->old_generation()->unadjust_available();
+    // Since we probably have not yet reclaimed the most recently selected collection set, we have to defer
+    // unadjust_available() invocations until after Full GC finishes its efforts.
+
     // No need to old_gen->increase_used().  That was done when plabs were allocated, accounting for both old evacs and promotions.
 
     heap->set_alloc_supplement_reserve(0);
@@ -352,6 +352,10 @@ void ShenandoahFullGC::do_it(GCCause::Cause gc_cause) {
       heap->verifier()->verify_after_fullgc();
     }
   }
+
+  // Having reclaimed all dead memory, it is now safe to restore capacities to original values.
+  heap->young_generation()->unadjust_available();
+  heap->old_generation()->unadjust_available();
 
   if (VerifyAfterGC) {
     Universe::verify();

--- a/src/hotspot/share/gc/shenandoah/shenandoahFullGC.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahFullGC.cpp
@@ -195,8 +195,8 @@ void ShenandoahFullGC::do_it(GCCause::Cause gc_cause) {
   heap->set_gc_generation(heap->global_generation());
 
   if (heap->mode()->is_generational()) {
-    // Since we probably have not yet reclaimed the most recently selected collection set, we have to defer
-    // unadjust_available() invocations until after Full GC finishes its efforts.
+    // Defer unadjust_available() invocations until after Full GC finishes its efforts because Full GC makes use
+    // of young-gen memory that may have been loaned from old-gen.
 
     // No need to old_gen->increase_used().  That was done when plabs were allocated, accounting for both old evacs and promotions.
 

--- a/src/hotspot/share/gc/shenandoah/shenandoahGeneration.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahGeneration.cpp
@@ -983,6 +983,10 @@ size_t ShenandoahGeneration::adjusted_capacity() const {
   return _adjusted_capacity;
 }
 
+size_t ShenandoahGeneration::adjusted_unaffiliated_regions() {
+  return (adjusted_capacity() - used_regions_size()) / ShenandoahHeapRegion::region_size_bytes();
+}
+
 void ShenandoahGeneration::record_success_concurrent(bool abbreviated) {
   heuristics()->record_success_concurrent(abbreviated);
   ShenandoahHeap::heap()->shenandoah_policy()->record_success_concurrent();

--- a/src/hotspot/share/gc/shenandoah/shenandoahGeneration.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahGeneration.cpp
@@ -914,12 +914,14 @@ void ShenandoahGeneration::scan_remembered_set(bool is_concurrent) {
   heap->workers()->run_task(&task);
 }
 
-void ShenandoahGeneration::increment_affiliated_region_count() {
+size_t ShenandoahGeneration::increment_affiliated_region_count() {
   _affiliated_region_count++;
+  return _affiliated_region_count;
 }
 
-void ShenandoahGeneration::decrement_affiliated_region_count() {
+size_t ShenandoahGeneration::decrement_affiliated_region_count() {
   _affiliated_region_count--;
+  return _affiliated_region_count;
 }
 
 void ShenandoahGeneration::clear_used() {
@@ -975,6 +977,10 @@ size_t ShenandoahGeneration::adjusted_available() const {
   size_t in_use = used();
   size_t capacity = _adjusted_capacity;
   return in_use > capacity ? 0 : capacity - in_use;
+}
+
+size_t ShenandoahGeneration::adjusted_capacity() const {
+  return _adjusted_capacity;
 }
 
 void ShenandoahGeneration::record_success_concurrent(bool abbreviated) {

--- a/src/hotspot/share/gc/shenandoah/shenandoahGeneration.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahGeneration.cpp
@@ -984,6 +984,7 @@ size_t ShenandoahGeneration::adjusted_capacity() const {
 }
 
 size_t ShenandoahGeneration::adjusted_unaffiliated_regions() {
+  assert(adjusted_capacity() > used_regions_size(), "adjusted_unaffiliated_regions() cannot return negative");
   return (adjusted_capacity() - used_regions_size()) / ShenandoahHeapRegion::region_size_bytes();
 }
 

--- a/src/hotspot/share/gc/shenandoah/shenandoahGeneration.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahGeneration.cpp
@@ -983,7 +983,7 @@ size_t ShenandoahGeneration::adjusted_capacity() const {
   return _adjusted_capacity;
 }
 
-size_t ShenandoahGeneration::adjusted_unaffiliated_regions() {
+size_t ShenandoahGeneration::adjusted_unaffiliated_regions() const {
   assert(adjusted_capacity() > used_regions_size(), "adjusted_unaffiliated_regions() cannot return negative");
   return (adjusted_capacity() - used_regions_size()) / ShenandoahHeapRegion::region_size_bytes();
 }

--- a/src/hotspot/share/gc/shenandoah/shenandoahGeneration.hpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahGeneration.hpp
@@ -95,6 +95,7 @@ private:
   // set aside within each generation to hold the results of evacuation, but not promotion, into that region.  Promotions
   // into old-gen are bounded by adjusted_available() whereas evacuations into old-gen are pre-committed.
   virtual size_t adjusted_available() const;
+  virtual size_t adjusted_capacity() const;
 
   // Both of following return new value of available
   virtual size_t adjust_available(intptr_t adjustment);
@@ -160,9 +161,9 @@ private:
 
   // Scan remembered set at start of concurrent young-gen marking. */
   void scan_remembered_set(bool is_concurrent);
-
-  void increment_affiliated_region_count();
-  void decrement_affiliated_region_count();
+  
+  size_t increment_affiliated_region_count();
+  size_t decrement_affiliated_region_count();
 
   void clear_used();
   void increase_used(size_t bytes);

--- a/src/hotspot/share/gc/shenandoah/shenandoahGeneration.hpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahGeneration.hpp
@@ -161,7 +161,7 @@ private:
 
   // Scan remembered set at start of concurrent young-gen marking. */
   void scan_remembered_set(bool is_concurrent);
-  
+
   size_t increment_affiliated_region_count();
   size_t decrement_affiliated_region_count();
 

--- a/src/hotspot/share/gc/shenandoah/shenandoahGeneration.hpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahGeneration.hpp
@@ -97,6 +97,10 @@ private:
   virtual size_t adjusted_available() const;
   virtual size_t adjusted_capacity() const;
 
+  // This is the number of FREE regions that are eligible to be affiliated with this generation according to the current
+  // adjusted capacity.
+  virtual size_t adjusted_unaffiliated_regions();
+
   // Both of following return new value of available
   virtual size_t adjust_available(intptr_t adjustment);
   virtual size_t unadjust_available();

--- a/src/hotspot/share/gc/shenandoah/shenandoahGeneration.hpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahGeneration.hpp
@@ -99,7 +99,7 @@ private:
 
   // This is the number of FREE regions that are eligible to be affiliated with this generation according to the current
   // adjusted capacity.
-  virtual size_t adjusted_unaffiliated_regions();
+  virtual size_t adjusted_unaffiliated_regions() const;
 
   // Both of following return new value of available
   virtual size_t adjust_available(intptr_t adjustment);
@@ -166,7 +166,10 @@ private:
   // Scan remembered set at start of concurrent young-gen marking. */
   void scan_remembered_set(bool is_concurrent);
 
+  // Return the updated value of affiliated_region_count
   size_t increment_affiliated_region_count();
+
+  // Return the updated value of affiliated_region_count
   size_t decrement_affiliated_region_count();
 
   void clear_used();

--- a/src/hotspot/share/gc/shenandoah/shenandoahGlobalGeneration.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahGlobalGeneration.cpp
@@ -40,6 +40,11 @@ size_t ShenandoahGlobalGeneration::max_capacity() const {
   return ShenandoahHeap::heap()->max_capacity();
 }
 
+size_t ShenandoahGlobalGeneration::used_regions() const {
+  ShenandoahHeap* heap = ShenandoahHeap::heap();
+  return heap->old_generation()->used_regions() + heap->young_generation()->used_regions();
+}
+
 size_t ShenandoahGlobalGeneration::used_regions_size() const {
   return ShenandoahHeap::heap()->capacity();
 }

--- a/src/hotspot/share/gc/shenandoah/shenandoahGlobalGeneration.hpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahGlobalGeneration.hpp
@@ -26,18 +26,21 @@
 #define SHARE_VM_GC_SHENANDOAH_SHENANDOAHGLOBALGENERATION_HPP
 
 #include "gc/shenandoah/shenandoahGeneration.hpp"
+#include "gc/shenandoah/shenandoahYoungGeneration.hpp"
+#include "gc/shenandoah/shenandoahOldGeneration.hpp"
 
 // A "generation" that represents the whole heap.
 class ShenandoahGlobalGeneration : public ShenandoahGeneration {
 public:
-  ShenandoahGlobalGeneration(uint max_queues)
-  : ShenandoahGeneration(GLOBAL, max_queues, 0, 0) { }
+  ShenandoahGlobalGeneration(uint max_queues, size_t max_capacity, size_t soft_max_capacity)
+  : ShenandoahGeneration(GLOBAL, max_queues, max_capacity, soft_max_capacity) { }
 
 public:
   virtual const char* name() const override;
 
   virtual size_t max_capacity() const override;
   virtual size_t soft_max_capacity() const override;
+  virtual size_t used_regions() const override;
   virtual size_t used_regions_size() const override;
   virtual size_t used() const override;
   virtual size_t available() const override;

--- a/src/hotspot/share/gc/shenandoah/shenandoahHeap.hpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahHeap.hpp
@@ -776,9 +776,11 @@ private:
   inline oop try_evacuate_object(oop src, Thread* thread, ShenandoahHeapRegion* from_region, ShenandoahRegionAffiliation target_gen);
   void handle_old_evacuation(HeapWord* obj, size_t words, bool promotion);
   void handle_old_evacuation_failure();
-  void handle_promotion_failure();
 
 public:
+  void handle_promotion_failure();
+  void report_promotion_failure(Thread* thread, size_t size);
+
   static address in_cset_fast_test_addr();
 
   ShenandoahCollectionSet* collection_set() const { return _collection_set; }
@@ -854,7 +856,6 @@ private:
   void try_inject_alloc_failure();
   bool should_inject_alloc_failure();
 
-  void report_promotion_failure(Thread* thread, size_t size);
 };
 
 #endif // SHARE_GC_SHENANDOAH_SHENANDOAHHEAP_HPP

--- a/src/hotspot/share/gc/shenandoah/shenandoahHeapRegion.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahHeapRegion.cpp
@@ -974,16 +974,21 @@ void ShenandoahHeapRegion::set_affiliation(ShenandoahRegionAffiliation new_affil
     heap->old_generation()->decrement_affiliated_region_count();
   }
 
+  size_t regions;
   switch (new_affiliation) {
     case FREE:
       assert(!has_live(), "Free region should not have live data");
       break;
     case YOUNG_GENERATION:
       reset_age();
-      heap->young_generation()->increment_affiliated_region_count();
+      regions = heap->young_generation()->increment_affiliated_region_count();
+      assert(regions * ShenandoahHeapRegion::region_size_bytes() <= heap->young_generation()->adjusted_capacity(),
+             "Number of young regions cannot exceed adjusted capacity");
       break;
     case OLD_GENERATION:
-      heap->old_generation()->increment_affiliated_region_count();
+      regions = heap->old_generation()->increment_affiliated_region_count();
+      assert(regions * ShenandoahHeapRegion::region_size_bytes() <= heap->old_generation()->adjusted_capacity(),
+             "Number of old regions cannot exceed adjusted capacity");
       break;
     default:
       ShouldNotReachHere();
@@ -992,6 +997,7 @@ void ShenandoahHeapRegion::set_affiliation(ShenandoahRegionAffiliation new_affil
   heap->set_affiliation(this, new_affiliation);
 }
 
+// Returns number of regions promoted, or zero if we choose not to promote.
 size_t ShenandoahHeapRegion::promote_humongous() {
   ShenandoahHeap* heap = ShenandoahHeap::heap();
   ShenandoahMarkingContext* marking_context = heap->marking_context();
@@ -1008,36 +1014,42 @@ size_t ShenandoahHeapRegion::promote_humongous() {
 
   size_t spanned_regions = ShenandoahHeapRegion::required_regions(obj->size() * HeapWordSize);
   size_t index_limit = index() + spanned_regions;
+  size_t available_old_regions = ((old_generation->adjusted_capacity() - old_generation->used_regions_size()) /
+                                  ShenandoahHeapRegion::region_size_bytes());
 
-  log_debug(gc)("promoting humongous region " SIZE_FORMAT ", spanning " SIZE_FORMAT, index(), spanned_regions);
+  if (spanned_regions <= available_old_regions) {
+    log_debug(gc)("promoting humongous region " SIZE_FORMAT ", spanning " SIZE_FORMAT, index(), spanned_regions);
 
-  // Since this region may have served previously as OLD, it may hold obsolete object range info.
-  heap->card_scan()->reset_object_range(bottom(), bottom() + spanned_regions * ShenandoahHeapRegion::region_size_words());
-  // Since the humongous region holds only one object, no lock is necessary for this register_object() invocation.
-  heap->card_scan()->register_object_wo_lock(bottom());
+    // Since this region may have served previously as OLD, it may hold obsolete object range info.
+    heap->card_scan()->reset_object_range(bottom(), bottom() + spanned_regions * ShenandoahHeapRegion::region_size_words());
+    // Since the humongous region holds only one object, no lock is necessary for this register_object() invocation.
+    heap->card_scan()->register_object_wo_lock(bottom());
 
-  // For this region and each humongous continuation region spanned by this humongous object, change
-  // affiliation to OLD_GENERATION and adjust the generation-use tallies.  The remnant of memory
-  // in the last humongous region that is not spanned by obj is currently not used.
-  for (size_t i = index(); i < index_limit; i++) {
-    ShenandoahHeapRegion* r = heap->get_region(i);
-    log_debug(gc)("promoting humongous region " SIZE_FORMAT ", from " PTR_FORMAT " to " PTR_FORMAT,
-                  r->index(), p2i(r->bottom()), p2i(r->top()));
-    // We mark the entire humongous object's range as dirty after loop terminates, so no need to dirty the range here
-    r->set_affiliation(OLD_GENERATION);
-    old_generation->increase_used(r->used());
-    young_generation->decrease_used(r->used());
-  }
-  if (obj->is_typeArray()) {
-    // Primitive arrays don't need to be scanned.  See above TODO question about requiring
-    // region promotion at safepoint.
-    log_debug(gc)("Clean cards for promoted humongous object (Region " SIZE_FORMAT ") from " PTR_FORMAT " to " PTR_FORMAT,
-                  index(), p2i(bottom()), p2i(bottom() + obj->size()));
-    heap->card_scan()->mark_range_as_clean(bottom(), obj->size());
+    // For this region and each humongous continuation region spanned by this humongous object, change
+    // affiliation to OLD_GENERATION and adjust the generation-use tallies.  The remnant of memory
+    // in the last humongous region that is not spanned by obj is currently not used.
+    for (size_t i = index(); i < index_limit; i++) {
+      ShenandoahHeapRegion* r = heap->get_region(i);
+      log_debug(gc)("promoting humongous region " SIZE_FORMAT ", from " PTR_FORMAT " to " PTR_FORMAT,
+                    r->index(), p2i(r->bottom()), p2i(r->top()));
+      // We mark the entire humongous object's range as dirty after loop terminates, so no need to dirty the range here
+      r->set_affiliation(OLD_GENERATION);
+      old_generation->increase_used(r->used());
+      young_generation->decrease_used(r->used());
+    }
+    if (obj->is_typeArray()) {
+      // Primitive arrays don't need to be scanned.  See above TODO question about requiring
+      // region promotion at safepoint.
+      log_debug(gc)("Clean cards for promoted humongous object (Region " SIZE_FORMAT ") from " PTR_FORMAT " to " PTR_FORMAT,
+                    index(), p2i(bottom()), p2i(bottom() + obj->size()));
+      heap->card_scan()->mark_range_as_clean(bottom(), obj->size());
+    } else {
+      log_debug(gc)("Dirty cards for promoted humongous object (Region " SIZE_FORMAT ") from " PTR_FORMAT " to " PTR_FORMAT,
+                    index(), p2i(bottom()), p2i(bottom() + obj->size()));
+      heap->card_scan()->mark_range_as_dirty(bottom(), obj->size());
+    }
+    return index_limit - index();
   } else {
-    log_debug(gc)("Dirty cards for promoted humongous object (Region " SIZE_FORMAT ") from " PTR_FORMAT " to " PTR_FORMAT,
-                  index(), p2i(bottom()), p2i(bottom() + obj->size()));
-    heap->card_scan()->mark_range_as_dirty(bottom(), obj->size());
+    return 0;
   }
-  return index_limit - index();
 }

--- a/src/hotspot/share/gc/shenandoah/shenandoahHeapRegion.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahHeapRegion.cpp
@@ -1045,7 +1045,7 @@ size_t ShenandoahHeapRegion::promote_humongous() {
   heap->card_scan()->reset_object_range(bottom(), bottom() + spanned_regions * ShenandoahHeapRegion::region_size_words());
   // Since the humongous region holds only one object, no lock is necessary for this register_object() invocation.
   heap->card_scan()->register_object_wo_lock(bottom());
-      
+
   if (obj->is_typeArray()) {
     // Primitive arrays don't need to be scanned.
     log_debug(gc)("Clean cards for promoted humongous object (Region " SIZE_FORMAT ") from " PTR_FORMAT " to " PTR_FORMAT,

--- a/src/hotspot/share/gc/shenandoah/shenandoahHeapRegion.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahHeapRegion.cpp
@@ -1014,42 +1014,47 @@ size_t ShenandoahHeapRegion::promote_humongous() {
 
   size_t spanned_regions = ShenandoahHeapRegion::required_regions(obj->size() * HeapWordSize);
   size_t index_limit = index() + spanned_regions;
-  size_t available_old_regions = ((old_generation->adjusted_capacity() - old_generation->used_regions_size()) /
-                                  ShenandoahHeapRegion::region_size_bytes());
 
-  if (spanned_regions <= available_old_regions) {
-    log_debug(gc)("promoting humongous region " SIZE_FORMAT ", spanning " SIZE_FORMAT, index(), spanned_regions);
+  {
+    // We need to grab the heap lock in order to avoid a race when changing the affiliations of spanned_regions from
+    // young to old.
+    ShenandoahHeapLocker locker(heap->lock());
+    size_t available_old_regions = old_generation->adjusted_unaffiliated_regions();
+    if (spanned_regions <= available_old_regions) {
+      log_debug(gc)("promoting humongous region " SIZE_FORMAT ", spanning " SIZE_FORMAT, index(), spanned_regions);
 
-    // Since this region may have served previously as OLD, it may hold obsolete object range info.
-    heap->card_scan()->reset_object_range(bottom(), bottom() + spanned_regions * ShenandoahHeapRegion::region_size_words());
-    // Since the humongous region holds only one object, no lock is necessary for this register_object() invocation.
-    heap->card_scan()->register_object_wo_lock(bottom());
-
-    // For this region and each humongous continuation region spanned by this humongous object, change
-    // affiliation to OLD_GENERATION and adjust the generation-use tallies.  The remnant of memory
-    // in the last humongous region that is not spanned by obj is currently not used.
-    for (size_t i = index(); i < index_limit; i++) {
-      ShenandoahHeapRegion* r = heap->get_region(i);
-      log_debug(gc)("promoting humongous region " SIZE_FORMAT ", from " PTR_FORMAT " to " PTR_FORMAT,
-                    r->index(), p2i(r->bottom()), p2i(r->top()));
-      // We mark the entire humongous object's range as dirty after loop terminates, so no need to dirty the range here
-      r->set_affiliation(OLD_GENERATION);
-      old_generation->increase_used(r->used());
-      young_generation->decrease_used(r->used());
-    }
-    if (obj->is_typeArray()) {
-      // Primitive arrays don't need to be scanned.  See above TODO question about requiring
-      // region promotion at safepoint.
-      log_debug(gc)("Clean cards for promoted humongous object (Region " SIZE_FORMAT ") from " PTR_FORMAT " to " PTR_FORMAT,
-                    index(), p2i(bottom()), p2i(bottom() + obj->size()));
-      heap->card_scan()->mark_range_as_clean(bottom(), obj->size());
+      // For this region and each humongous continuation region spanned by this humongous object, change
+      // affiliation to OLD_GENERATION and adjust the generation-use tallies.  The remnant of memory
+      // in the last humongous region that is not spanned by obj is currently not used.
+      for (size_t i = index(); i < index_limit; i++) {
+        ShenandoahHeapRegion* r = heap->get_region(i);
+        log_debug(gc)("promoting humongous region " SIZE_FORMAT ", from " PTR_FORMAT " to " PTR_FORMAT,
+                      r->index(), p2i(r->bottom()), p2i(r->top()));
+        // We mark the entire humongous object's range as dirty after loop terminates, so no need to dirty the range here
+        r->set_affiliation(OLD_GENERATION);
+        old_generation->increase_used(r->used());
+        young_generation->decrease_used(r->used());
+      }
+      // Then fall through to finish the promotion after releasing the heap lock.
     } else {
-      log_debug(gc)("Dirty cards for promoted humongous object (Region " SIZE_FORMAT ") from " PTR_FORMAT " to " PTR_FORMAT,
-                    index(), p2i(bottom()), p2i(bottom() + obj->size()));
-      heap->card_scan()->mark_range_as_dirty(bottom(), obj->size());
+      return 0;
     }
-    return index_limit - index();
-  } else {
-    return 0;
   }
+
+  // Since this region may have served previously as OLD, it may hold obsolete object range info.
+  heap->card_scan()->reset_object_range(bottom(), bottom() + spanned_regions * ShenandoahHeapRegion::region_size_words());
+  // Since the humongous region holds only one object, no lock is necessary for this register_object() invocation.
+  heap->card_scan()->register_object_wo_lock(bottom());
+      
+  if (obj->is_typeArray()) {
+    // Primitive arrays don't need to be scanned.
+    log_debug(gc)("Clean cards for promoted humongous object (Region " SIZE_FORMAT ") from " PTR_FORMAT " to " PTR_FORMAT,
+                  index(), p2i(bottom()), p2i(bottom() + obj->size()));
+    heap->card_scan()->mark_range_as_clean(bottom(), obj->size());
+  } else {
+    log_debug(gc)("Dirty cards for promoted humongous object (Region " SIZE_FORMAT ") from " PTR_FORMAT " to " PTR_FORMAT,
+                  index(), p2i(bottom()), p2i(bottom() + obj->size()));
+    heap->card_scan()->mark_range_as_dirty(bottom(), obj->size());
+  }
+  return index_limit - index();
 }

--- a/src/hotspot/share/gc/shenandoah/shenandoahVerifier.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahVerifier.cpp
@@ -342,21 +342,26 @@ public:
 
 class ShenandoahCalculateRegionStatsClosure : public ShenandoahHeapRegionClosure {
 private:
-  size_t _used, _committed, _garbage;
+  size_t _used, _committed, _garbage, _regions;
 public:
-  ShenandoahCalculateRegionStatsClosure() : _used(0), _committed(0), _garbage(0) {};
+  ShenandoahCalculateRegionStatsClosure() : _used(0), _committed(0), _garbage(0), _regions(0) {};
 
   void heap_region_do(ShenandoahHeapRegion* r) {
     _used += r->used();
-    log_debug(gc)("ShenandoahCalculatRegionStatsClosure added " SIZE_FORMAT " for %s Region " SIZE_FORMAT ", yielding: " SIZE_FORMAT,
+    log_debug(gc)("ShenandoahCalculateRegionStatsClosure added " SIZE_FORMAT " for %s Region " SIZE_FORMAT ", yielding: " SIZE_FORMAT,
                   r->used(), r->is_humongous()? "humongous": "regular", r->index(), _used);
     _garbage += r->garbage();
     _committed += r->is_committed() ? ShenandoahHeapRegion::region_size_bytes() : 0;
+    _regions++;
   }
 
   size_t used() { return _used; }
   size_t committed() { return _committed; }
   size_t garbage() { return _garbage; }
+  size_t regions() { return _regions; }
+
+  // span is the total memory affiliated with these stats (some of which is in use and other is available)
+  size_t span() { return _regions * ShenandoahHeapRegion::region_size_bytes(); }
 };
 
 class ShenandoahGenerationStatsClosure : public ShenandoahHeapRegionClosure {
@@ -395,6 +400,17 @@ class ShenandoahGenerationStatsClosure : public ShenandoahHeapRegionClosure {
               label, generation->name(),
               byte_size_in_proper_unit(generation_used), proper_unit_for_byte_size(generation_used),
               byte_size_in_proper_unit(stats.used()), proper_unit_for_byte_size(stats.used()));
+
+    guarantee(stats.regions() == generation->used_regions(),
+              "%s: generation (%s) used regions (" SIZE_FORMAT ") must equal regions that are in use (" SIZE_FORMAT ")",
+              label, generation->name(), generation->used_regions(), stats.regions());
+
+    size_t capacity = generation->adjusted_capacity();
+    guarantee(stats.span() <= capacity,
+              "%s: generation (%s) size spanned by regions (" SIZE_FORMAT ") must not exceed current capacity (" SIZE_FORMAT "%s)",
+              label, generation->name(), stats.regions(),
+              byte_size_in_proper_unit(capacity), proper_unit_for_byte_size(capacity));
+
   }
 };
 

--- a/src/hotspot/share/gc/shenandoah/shenandoahVerifier.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahVerifier.cpp
@@ -340,6 +340,8 @@ public:
   virtual void do_oop(narrowOop* p) { do_oop_work(p); }
 };
 
+// This closure computes the amounts of used, committed, and garbage memory and the number of regions contained within
+// a subset (e.g. the young generation or old generation) of the total heap.
 class ShenandoahCalculateRegionStatsClosure : public ShenandoahHeapRegionClosure {
 private:
   size_t _used, _committed, _garbage, _regions;


### PR DESCRIPTION
This commit enforces upper bounds on the number of ShenandoahHeapRegions affiliated with each generation.  Prior to this change, enforcement of generation sizes was by usage alone.  This allowed situations in which so many sparsely populated regions were affiliated with old-gen that there were insufficient FREE regions available to satisfy legitimate young-gen allocation requests.  This was resulting in excessive TLAB allocation failures and degenerated collections.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed (1 review required, with at least 1 [Committer](https://openjdk.org/bylaws#committer))

### Reviewers
 * [William Kemper](https://openjdk.org/census#wkemper) (@earthling-amzn - Committer) ⚠️ Review applies to [4617913f](https://git.openjdk.org/shenandoah/pull/179/files/4617913f5eb913fee8caa04dede1993055637d6a)
 * [Y. Srinivas Ramakrishna](https://openjdk.org/census#ysr) (@ysramakrishna - Author) ⚠️ Review applies to [4617913f](https://git.openjdk.org/shenandoah/pull/179/files/4617913f5eb913fee8caa04dede1993055637d6a)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/shenandoah pull/179/head:pull/179` \
`$ git checkout pull/179`

Update a local copy of the PR: \
`$ git checkout pull/179` \
`$ git pull https://git.openjdk.org/shenandoah pull/179/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 179`

View PR using the GUI difftool: \
`$ git pr show -t 179`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/shenandoah/pull/179.diff">https://git.openjdk.org/shenandoah/pull/179.diff</a>

</details>
