### PR TITLE
Allow adjusted capacity and used regions size to be equal

### DIFF
--- a/src/hotspot/share/gc/shenandoah/shenandoahGeneration.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahGeneration.cpp
@@ -984,7 +984,7 @@ size_t ShenandoahGeneration::adjusted_capacity() const {
 }
 
 size_t ShenandoahGeneration::adjusted_unaffiliated_regions() const {
-  assert(adjusted_capacity() > used_regions_size(), "adjusted_unaffiliated_regions() cannot return negative");
+  assert(adjusted_capacity() >= used_regions_size(), "adjusted_unaffiliated_regions() cannot return negative");
   return (adjusted_capacity() - used_regions_size()) / ShenandoahHeapRegion::region_size_bytes();
 }
 


### PR DESCRIPTION
Fix assertion which requires adjusted capacity to be larger than the used regions size (they may be equal).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed (1 review required, with at least 1 [Committer](https://openjdk.org/bylaws#committer))

### Reviewers
 * [Y. Srinivas Ramakrishna](https://openjdk.org/census#ysr) (@ysramakrishna - Author)
 * [Kelvin Nilsen](https://openjdk.org/census#kdnilsen) (@kdnilsen - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/shenandoah pull/181/head:pull/181` \
`$ git checkout pull/181`

Update a local copy of the PR: \
`$ git checkout pull/181` \
`$ git pull https://git.openjdk.org/shenandoah pull/181/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 181`

View PR using the GUI difftool: \
`$ git pr show -t 181`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/shenandoah/pull/181.diff">https://git.openjdk.org/shenandoah/pull/181.diff</a>

</details>
