### PR TITLE
Generation sizing fixes

### DIFF
--- a/src/hotspot/share/gc/shenandoah/shenandoahControlThread.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahControlThread.cpp
@@ -292,6 +292,7 @@ void ShenandoahControlThread::run_service() {
           }
           case servicing_old: {
             assert(generation == OLD, "Expected old generation here");
+            GCIdMark gc_id_mark;
             service_concurrent_old_cycle(heap, cause);
             break;
           }

--- a/src/hotspot/share/gc/shenandoah/shenandoahMmuTracker.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahMmuTracker.cpp
@@ -141,7 +141,7 @@ bool ShenandoahMmuTracker::transfer_capacity(ShenandoahGeneration* from, Shenand
     return false;
   }
 
-  size_t regions_to_transfer = MAX2(1UL, size_t(double(available_regions) * _resize_increment));
+  size_t regions_to_transfer = MAX2(1u, uint(double(available_regions) * _resize_increment));
   size_t bytes_to_transfer = regions_to_transfer * ShenandoahHeapRegion::region_size_bytes();
   if (from->generation_mode() == YOUNG) {
     size_t new_young_size = from->max_capacity() - bytes_to_transfer;


### PR DESCRIPTION
Two small fixes:
* Fix windows build
* Need gc id for resumed old generation marking

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed (1 review required, with at least 1 [Committer](https://openjdk.org/bylaws#committer))

### Reviewers
 * [Y. Srinivas Ramakrishna](https://openjdk.org/census#ysr) (@ysramakrishna - Author)
 * [Kelvin Nilsen](https://openjdk.org/census#kdnilsen) (@kdnilsen - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/shenandoah pull/182/head:pull/182` \
`$ git checkout pull/182`

Update a local copy of the PR: \
`$ git checkout pull/182` \
`$ git pull https://git.openjdk.org/shenandoah pull/182/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 182`

View PR using the GUI difftool: \
`$ git pr show -t 182`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/shenandoah/pull/182.diff">https://git.openjdk.org/shenandoah/pull/182.diff</a>

</details>
