### PR TITLE
Initial sizing refactor

### DIFF
--- a/src/hotspot/share/gc/shenandoah/heuristics/shenandoahAdaptiveHeuristics.cpp
+++ b/src/hotspot/share/gc/shenandoah/heuristics/shenandoahAdaptiveHeuristics.cpp
@@ -317,10 +317,6 @@ bool ShenandoahAdaptiveHeuristics::should_start_gc() {
                 ", max_capacity: " SIZE_FORMAT ", allocated: " SIZE_FORMAT,
                 _generation->name(), available, capacity, max_capacity, allocated);
 
-  // Make sure the code below treats available without the soft tail.
-  size_t soft_tail = max_capacity - capacity;
-  available = (available > soft_tail) ? (available - soft_tail) : 0;
-
   // The collector reserve may eat into what the mutator is allowed to use. Make sure we are looking
   // at what is available to the mutator when deciding whether to start a GC.
   size_t usable = ShenandoahHeap::heap()->free_set()->available();

--- a/src/hotspot/share/gc/shenandoah/mode/shenandoahGenerationalMode.cpp
+++ b/src/hotspot/share/gc/shenandoah/mode/shenandoahGenerationalMode.cpp
@@ -37,7 +37,6 @@ void ShenandoahGenerationalMode::initialize_flags() const {
   }
 
   SHENANDOAH_ERGO_OVERRIDE_DEFAULT(GCTimeRatio, 70);
-  SHENANDOAH_ERGO_OVERRIDE_DEFAULT(NewRatio, 1);
   SHENANDOAH_ERGO_OVERRIDE_DEFAULT(ShenandoahUnloadClassesFrequency, 0);
   SHENANDOAH_ERGO_ENABLE_FLAG(ExplicitGCInvokesConcurrent);
   SHENANDOAH_ERGO_ENABLE_FLAG(ShenandoahImplicitGCInvokesConcurrent);

--- a/src/hotspot/share/gc/shenandoah/shenandoahAsserts.hpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahAsserts.hpp
@@ -167,6 +167,8 @@ public:
 
 #define shenandoah_assert_heaplocked_or_fullgc_safepoint() \
                     ShenandoahAsserts::assert_heaplocked_or_fullgc_safepoint(__FILE__, __LINE__)
+#define shenandoah_assert_control_or_vm_thread() \
+                    assert(Thread::current()->is_VM_thread() || Thread::current() == ShenandoahHeap::heap()->control_thread(), "Expected control thread or vm thread")
 
 #define shenandoah_assert_generational() \
                     assert(ShenandoahHeap::heap()->mode()->is_generational(), "Must be in generational mode here.")
@@ -221,6 +223,7 @@ public:
 #define shenandoah_assert_not_heaplocked()
 #define shenandoah_assert_heaplocked_or_safepoint()
 #define shenandoah_assert_heaplocked_or_fullgc_safepoint()
+#define shenandoah_assert_control_or_vm_thread()
 #define shenandoah_assert_generational()
 
 #endif

--- a/src/hotspot/share/gc/shenandoah/shenandoahGeneration.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahGeneration.cpp
@@ -991,22 +991,14 @@ size_t ShenandoahGeneration::adjusted_unaffiliated_regions() const {
 
 void ShenandoahGeneration::increase_capacity(size_t increment) {
   shenandoah_assert_heaplocked_or_safepoint();
-  #ifdef ASSERT
-  if (generation_mode() == YOUNG) {
-    assert(_max_capacity + increment <= ShenandoahHeap::heap()->generation_sizer()->max_young_size(), "Cannot increase young generation capacity beyond maximum.");
-  }
-  #endif
+  assert(_max_capacity + increment <= ShenandoahHeap::heap()->max_size_for(this), "Cannot increase generation capacity beyond maximum.");
   _max_capacity += increment;
   _soft_max_capacity += increment;
 }
 
 void ShenandoahGeneration::decrease_capacity(size_t decrement) {
   shenandoah_assert_heaplocked_or_safepoint();
-  #ifdef ASSERT
-  if (generation_mode() == YOUNG) {
-    assert(_max_capacity - decrement >= ShenandoahHeap::heap()->generation_sizer()->min_young_size(), "Cannot decrease young generation capacity beyond minimum.");
-  }
-  #endif
+  assert(_max_capacity - decrement >= ShenandoahHeap::heap()->min_size_for(this), "Cannot decrease generation capacity beyond minimum.");
   _max_capacity -= decrement;
   _soft_max_capacity -= decrement;
 }

--- a/src/hotspot/share/gc/shenandoah/shenandoahGeneration.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahGeneration.cpp
@@ -991,14 +991,22 @@ size_t ShenandoahGeneration::adjusted_unaffiliated_regions() const {
 
 void ShenandoahGeneration::increase_capacity(size_t increment) {
   shenandoah_assert_heaplocked_or_safepoint();
-  assert(_max_capacity + increment <= ShenandoahHeap::heap()->generation_sizer()->max_young_size(), "Cannot increase generation capacity beyond maximum.");
+  #ifdef ASSERT
+  if (generation_mode() == YOUNG) {
+    assert(_max_capacity + increment <= ShenandoahHeap::heap()->generation_sizer()->max_young_size(), "Cannot increase young generation capacity beyond maximum.");
+  }
+  #endif
   _max_capacity += increment;
   _soft_max_capacity += increment;
 }
 
 void ShenandoahGeneration::decrease_capacity(size_t decrement) {
   shenandoah_assert_heaplocked_or_safepoint();
-  assert(_max_capacity - decrement >= ShenandoahHeap::heap()->generation_sizer()->min_young_size(), "Cannot decrease generation capacity beyond minimum.");
+  #ifdef ASSERT
+  if (generation_mode() == YOUNG) {
+    assert(_max_capacity - decrement >= ShenandoahHeap::heap()->generation_sizer()->min_young_size(), "Cannot decrease young generation capacity beyond minimum.");
+  }
+  #endif
   _max_capacity -= decrement;
   _soft_max_capacity -= decrement;
 }

--- a/src/hotspot/share/gc/shenandoah/shenandoahGeneration.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahGeneration.cpp
@@ -991,12 +991,14 @@ size_t ShenandoahGeneration::adjusted_unaffiliated_regions() const {
 
 void ShenandoahGeneration::increase_capacity(size_t increment) {
   shenandoah_assert_heaplocked_or_safepoint();
+  assert(_max_capacity + increment <= ShenandoahHeap::heap()->generation_sizer()->max_young_size(), "Cannot increase generation capacity beyond maximum.");
   _max_capacity += increment;
   _soft_max_capacity += increment;
 }
 
 void ShenandoahGeneration::decrease_capacity(size_t decrement) {
   shenandoah_assert_heaplocked_or_safepoint();
+  assert(_max_capacity - decrement >= ShenandoahHeap::heap()->generation_sizer()->min_young_size(), "Cannot decrease generation capacity beyond minimum.");
   _max_capacity -= decrement;
   _soft_max_capacity -= decrement;
 }

--- a/src/hotspot/share/gc/shenandoah/shenandoahGeneration.hpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahGeneration.hpp
@@ -168,7 +168,7 @@ private:
   virtual void reserve_task_queues(uint workers);
   virtual ShenandoahObjToScanQueueSet* old_gen_task_queues() const;
 
-  // Scan remembered set at start of concurrent young-gen marking. */
+  // Scan remembered set at start of concurrent young-gen marking.
   void scan_remembered_set(bool is_concurrent);
 
   // Return the updated value of affiliated_region_count
@@ -187,7 +187,14 @@ private:
   virtual void record_success_concurrent(bool abbreviated);
   virtual void record_success_degenerated();
 
+  // Record the total on-cpu time a thread has spent collecting this
+  // generation. This is only called by the control thread (at the start
+  // of a collection) and by the VM thread at the end of the collection,
+  // so there are no locking concerns.
   virtual void add_collection_time(double time_seconds);
+
+  // This returns the accumulated collection time and resets it to zero.
+  // This is used to decide which generation should be resized.
   double reset_collection_time();
 };
 

--- a/src/hotspot/share/gc/shenandoah/shenandoahHeap.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahHeap.cpp
@@ -449,14 +449,14 @@ jint ShenandoahHeap::initialize() {
 
 void ShenandoahHeap::initialize_generations() {
   _generation_sizer.heap_size_changed(soft_max_capacity());
-  size_t initial_capacity_young = _generation_sizer.min_young_size();
+  size_t initial_capacity_young = _generation_sizer.max_young_size();
   size_t max_capacity_young = _generation_sizer.max_young_size();
   size_t initial_capacity_old = max_capacity() - max_capacity_young;
   size_t max_capacity_old = max_capacity() - initial_capacity_young;
 
   _young_generation = new ShenandoahYoungGeneration(_max_workers, max_capacity_young, initial_capacity_young);
   _old_generation = new ShenandoahOldGeneration(_max_workers, max_capacity_old, initial_capacity_old);
-  _global_generation = new ShenandoahGlobalGeneration(_max_workers, max_capacity(), max_capacity());
+  _global_generation = new ShenandoahGlobalGeneration(_max_workers, soft_max_capacity(), soft_max_capacity());
 }
 
 void ShenandoahHeap::initialize_heuristics() {

--- a/src/hotspot/share/gc/shenandoah/shenandoahHeap.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahHeap.cpp
@@ -449,13 +449,14 @@ jint ShenandoahHeap::initialize() {
 
 void ShenandoahHeap::initialize_generations() {
   _generation_sizer.heap_size_changed(soft_max_capacity());
+  size_t initial_capacity_young = _generation_sizer.min_young_size();
   size_t max_capacity_young = _generation_sizer.max_young_size();
-  size_t max_capacity_old = max_capacity() - max_capacity_young;
-  size_t max_capacity_global = max_capacity_young + max_capacity_old;
+  size_t initial_capacity_old = max_capacity() - max_capacity_young;
+  size_t max_capacity_old = max_capacity() - initial_capacity_young;
 
-  _young_generation = new ShenandoahYoungGeneration(_max_workers, max_capacity_young, max_capacity_young);
-  _old_generation = new ShenandoahOldGeneration(_max_workers, max_capacity_old, max_capacity_old);
-  _global_generation = new ShenandoahGlobalGeneration(_max_workers, max_capacity_global, max_capacity_global);
+  _young_generation = new ShenandoahYoungGeneration(_max_workers, max_capacity_young, initial_capacity_young);
+  _old_generation = new ShenandoahOldGeneration(_max_workers, max_capacity_old, initial_capacity_old);
+  _global_generation = new ShenandoahGlobalGeneration(_max_workers, max_capacity(), max_capacity());
 }
 
 void ShenandoahHeap::initialize_heuristics() {

--- a/src/hotspot/share/gc/shenandoah/shenandoahHeap.hpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahHeap.hpp
@@ -538,15 +538,18 @@ private:
   ShenandoahMmuTracker          _mmu_tracker;
   ShenandoahGenerationSizer     _generation_sizer;
 
-  ShenandoahControlThread*   control_thread()          { return _control_thread;    }
   ShenandoahRegulatorThread* regulator_thread()        { return _regulator_thread;  }
 
 public:
+  ShenandoahControlThread*   control_thread()          { return _control_thread;    }
   ShenandoahYoungGeneration* young_generation()  const { return _young_generation;  }
   ShenandoahGeneration*      global_generation() const { return _global_generation; }
   ShenandoahOldGeneration*   old_generation()    const { return _old_generation;    }
   ShenandoahGeneration*      generation_for(ShenandoahRegionAffiliation affiliation) const;
   const ShenandoahGenerationSizer* generation_sizer()  const { return &_generation_sizer;  }
+
+  size_t max_size_for(ShenandoahGeneration* generation) const;
+  size_t min_size_for(ShenandoahGeneration* generation) const;
 
   ShenandoahCollectorPolicy* shenandoah_policy() const { return _shenandoah_policy; }
   ShenandoahMode*            mode()              const { return _gc_mode;           }

--- a/src/hotspot/share/gc/shenandoah/shenandoahHeap.hpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahHeap.hpp
@@ -223,7 +223,6 @@ private:
   volatile size_t _committed;
   shenandoah_padding(1);
 
-  static size_t young_generation_capacity(size_t total_capacity);
   void help_verify_region_rem_set(ShenandoahHeapRegion* r, ShenandoahMarkingContext* ctx,
                                   HeapWord* from, HeapWord* top, HeapWord* update_watermark, const char* message);
 
@@ -537,6 +536,7 @@ private:
   ShenandoahPhaseTimings*       _phase_timings;
   ShenandoahEvacuationTracker*  _evac_tracker;
   ShenandoahMmuTracker          _mmu_tracker;
+  ShenandoahGenerationSizer     _generation_sizer;
 
   ShenandoahControlThread*   control_thread()          { return _control_thread;    }
   ShenandoahRegulatorThread* regulator_thread()        { return _regulator_thread;  }
@@ -546,6 +546,7 @@ public:
   ShenandoahGeneration*      global_generation() const { return _global_generation; }
   ShenandoahOldGeneration*   old_generation()    const { return _old_generation;    }
   ShenandoahGeneration*      generation_for(ShenandoahRegionAffiliation affiliation) const;
+  const ShenandoahGenerationSizer* generation_sizer()  const { return &_generation_sizer;  }
 
   ShenandoahCollectorPolicy* shenandoah_policy() const { return _shenandoah_policy; }
   ShenandoahMode*            mode()              const { return _gc_mode;           }

--- a/src/hotspot/share/gc/shenandoah/shenandoahInitLogger.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahInitLogger.cpp
@@ -46,10 +46,19 @@ void ShenandoahInitLogger::print_heap() {
     log_info(gc, init)("Heuristics: %s", heap->global_generation()->heuristics()->name());
   } else {
     log_info(gc, init)("Young Heuristics: %s", heap->young_generation()->heuristics()->name());
-    log_info(gc, init)("Old Heuristics: %s", heap->old_generation()->heuristics()->name());
+    log_info(gc, init)("Young Generation Initial Size: " SIZE_FORMAT "%s",
+                       byte_size_in_proper_unit(heap->young_generation()->soft_max_capacity()),
+                       proper_unit_for_byte_size(heap->young_generation()->soft_max_capacity()));
     log_info(gc, init)("Young Generation Max: " SIZE_FORMAT "%s",
                        byte_size_in_proper_unit(heap->young_generation()->max_capacity()),
                        proper_unit_for_byte_size(heap->young_generation()->max_capacity()));
+    log_info(gc, init)("Old Heuristics: %s", heap->old_generation()->heuristics()->name());
+    log_info(gc, init)("Old Generation Initial Size: " SIZE_FORMAT "%s",
+                       byte_size_in_proper_unit(heap->old_generation()->soft_max_capacity()),
+                       proper_unit_for_byte_size(heap->old_generation()->soft_max_capacity()));
+    log_info(gc, init)("Old Generation Max: " SIZE_FORMAT "%s",
+                       byte_size_in_proper_unit(heap->old_generation()->max_capacity()),
+                       proper_unit_for_byte_size(heap->old_generation()->max_capacity()));
   }
 
 

--- a/src/hotspot/share/gc/shenandoah/shenandoahMmuTracker.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahMmuTracker.cpp
@@ -264,6 +264,10 @@ bool ShenandoahGenerationSizer::transfer_capacity(ShenandoahGeneration* from, Sh
   return true;
 }
 
+size_t round_down_to_multiple_of_region_size(size_t bytes) {
+  return (bytes / ShenandoahHeapRegion::region_size_bytes()) * ShenandoahHeapRegion::region_size_bytes();
+}
+
 size_t ShenandoahGenerationSizer::adjust_transfer_from_young(ShenandoahGeneration* from, size_t bytes_to_transfer) const {
   assert(from->generation_mode() == YOUNG, "Expect to transfer from young");
   size_t new_young_size = from->max_capacity() - bytes_to_transfer;
@@ -273,7 +277,7 @@ size_t ShenandoahGenerationSizer::adjust_transfer_from_young(ShenandoahGeneratio
     assert(minimum_size <= from->max_capacity(), "Young is under minimum capacity.");
     // If the transfer violates the minimum size and there is still some capacity to transfer,
     // adjust the transfer to take the size to the minimum. Note that this may be zero.
-    bytes_to_transfer = from->max_capacity() - minimum_size;
+    bytes_to_transfer = round_down_to_multiple_of_region_size(from->max_capacity() - minimum_size);
   }
   return bytes_to_transfer;
 }
@@ -287,7 +291,7 @@ size_t ShenandoahGenerationSizer::adjust_transfer_to_young(ShenandoahGeneration*
     assert(maximum_size >= to->max_capacity(), "Young is over maximum capacity");
     // If the transfer violates the maximum size and there is still some capacity to transfer,
     // adjust the transfer to take the size to the maximum. Note that this may be zero.
-    bytes_to_transfer = maximum_size - to->max_capacity();
+    bytes_to_transfer = round_down_to_multiple_of_region_size(maximum_size - to->max_capacity());
   }
   return bytes_to_transfer;
 }

--- a/src/hotspot/share/gc/shenandoah/shenandoahMmuTracker.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahMmuTracker.cpp
@@ -23,6 +23,7 @@
  */
 #include "precompiled.hpp"
 
+#include "gc/shenandoah/shenandoahAsserts.hpp"
 #include "gc/shenandoah/shenandoahMmuTracker.hpp"
 #include "gc/shenandoah/shenandoahHeap.inline.hpp"
 #include "gc/shenandoah/shenandoahOldGeneration.hpp"
@@ -82,7 +83,7 @@ ShenandoahMmuTracker::~ShenandoahMmuTracker() {
 }
 
 void ShenandoahMmuTracker::record(ShenandoahGeneration* generation) {
-  // This is only called by the control thread or the VM thread.
+  shenandoah_assert_control_or_vm_thread();
   double collector_time_s = gc_thread_time_seconds();
   double elapsed_gc_time_s = collector_time_s - _generational_reference_time_s;
   generation->add_collection_time(elapsed_gc_time_s);

--- a/src/hotspot/share/gc/shenandoah/shenandoahMmuTracker.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahMmuTracker.cpp
@@ -54,9 +54,9 @@ class ThreadTimeAccumulator : public ThreadClosure {
 
 double ShenandoahMmuTracker::gc_thread_time_seconds() {
   ThreadTimeAccumulator cl;
+  // We include only the gc threads because those are the only threads
+  // we are responsible for.
   ShenandoahHeap::heap()->gc_threads_do(&cl);
-  // Include VM thread? Compiler threads? or no - because there
-  // is nothing the collector can do about those threads.
   return double(cl.total_time) / NANOSECS_PER_SEC;
 }
 
@@ -70,11 +70,10 @@ double ShenandoahMmuTracker::process_time_seconds() {
 }
 
 ShenandoahMmuTracker::ShenandoahMmuTracker() :
-  _initial_collector_time_s(0.0),
-  _initial_process_time_s(0.0),
-  _resize_increment(YoungGenerationSizeIncrement / 100.0),
-  _mmu_periodic_task(new ShenandoahMmuTask(this)),
-  _mmu_average(10, ShenandoahAdaptiveDecayFactor) {
+    _generational_reference_time_s(0.0),
+    _process_reference_time_s(0.0),
+    _mmu_periodic_task(new ShenandoahMmuTask(this)),
+    _mmu_average(10, ShenandoahAdaptiveDecayFactor) {
 }
 
 ShenandoahMmuTracker::~ShenandoahMmuTracker() {
@@ -83,29 +82,126 @@ ShenandoahMmuTracker::~ShenandoahMmuTracker() {
 }
 
 void ShenandoahMmuTracker::record(ShenandoahGeneration* generation) {
-  // This is only called by the control thread.
+  // This is only called by the control thread or the VM thread.
   double collector_time_s = gc_thread_time_seconds();
-  double elapsed_gc_time_s = collector_time_s - _initial_collector_time_s;
+  double elapsed_gc_time_s = collector_time_s - _generational_reference_time_s;
   generation->add_collection_time(elapsed_gc_time_s);
-  _initial_collector_time_s = collector_time_s;
+  _generational_reference_time_s = collector_time_s;
 }
 
 void ShenandoahMmuTracker::report() {
   // This is only called by the periodic thread.
   double process_time_s = process_time_seconds();
-  double elapsed_process_time_s = process_time_s - _initial_process_time_s;
-  _initial_process_time_s = process_time_s;
+  double elapsed_process_time_s = process_time_s - _process_reference_time_s;
+  _process_reference_time_s = process_time_s;
   double verify_time_s = gc_thread_time_seconds();
-  double verify_elapsed = verify_time_s - _initial_verify_collector_time_s;
-  _initial_verify_collector_time_s = verify_time_s;
+  double verify_elapsed = verify_time_s - _collector_reference_time_s;
+  _collector_reference_time_s = verify_time_s;
   double verify_mmu = ((elapsed_process_time_s - verify_elapsed) / elapsed_process_time_s) * 100;
   _mmu_average.add(verify_mmu);
   log_info(gc)("Average MMU = %.3f", _mmu_average.davg());
 }
 
-bool ShenandoahMmuTracker::adjust_generation_sizes() {
+void ShenandoahMmuTracker::initialize() {
+  _process_reference_time_s = process_time_seconds();
+  _generational_reference_time_s = gc_thread_time_seconds();
+  _collector_reference_time_s = _generational_reference_time_s;
+  _mmu_periodic_task->enroll();
+}
+
+ShenandoahGenerationSizer::ShenandoahGenerationSizer(ShenandoahMmuTracker* mmu_tracker)
+  : _sizer_kind(SizerDefaults),
+    _use_adaptive_sizing(true),
+    _min_desired_young_size(0),
+    _max_desired_young_size(0),
+    _resize_increment(YoungGenerationSizeIncrement / 100.0),
+    _mmu_tracker(mmu_tracker) {
+
+  if (FLAG_IS_CMDLINE(NewRatio)) {
+    if (FLAG_IS_CMDLINE(NewSize) || FLAG_IS_CMDLINE(MaxNewSize)) {
+      log_warning(gc, ergo)("-XX:NewSize and -XX:MaxNewSize override -XX:NewRatio");
+    } else {
+      _sizer_kind = SizerNewRatio;
+      _use_adaptive_sizing = false;
+      return;
+    }
+  }
+
+  if (NewSize > MaxNewSize) {
+    if (FLAG_IS_CMDLINE(MaxNewSize)) {
+      log_warning(gc, ergo)("NewSize (" SIZE_FORMAT "k) is greater than the MaxNewSize (" SIZE_FORMAT "k). "
+                            "A new max generation size of " SIZE_FORMAT "k will be used.",
+                            NewSize/K, MaxNewSize/K, NewSize/K);
+    }
+    FLAG_SET_ERGO(MaxNewSize, NewSize);
+  }
+
+  if (FLAG_IS_CMDLINE(NewSize)) {
+    _min_desired_young_size = MAX2(NewSize, ShenandoahHeapRegion::region_size_bytes());
+    if (FLAG_IS_CMDLINE(MaxNewSize)) {
+      _max_desired_young_size = MAX2(MaxNewSize, ShenandoahHeapRegion::region_size_bytes());
+      _sizer_kind = SizerMaxAndNewSize;
+      _use_adaptive_sizing = _min_desired_young_size != _max_desired_young_size;
+    } else {
+      _sizer_kind = SizerNewSizeOnly;
+    }
+  } else if (FLAG_IS_CMDLINE(MaxNewSize)) {
+    _max_desired_young_size = MAX2(MaxNewSize, ShenandoahHeapRegion::region_size_bytes());
+    _sizer_kind = SizerMaxNewSizeOnly;
+  }
+}
+
+size_t ShenandoahGenerationSizer::calculate_min_size(size_t heap_size) {
+  size_t default_value = (heap_size * ShenandoahMinYoungPercentage) / 100;
+  return MAX2(ShenandoahHeapRegion::region_size_bytes(), default_value);
+}
+
+size_t ShenandoahGenerationSizer::calculate_max_size(size_t heap_size) {
+  size_t default_value = (heap_size * ShenandoahMaxYoungPercentage) / 100;
+  return MAX2(ShenandoahHeapRegion::region_size_bytes(), default_value);
+}
+
+void ShenandoahGenerationSizer::recalculate_min_max_young_length(size_t heap_size) {
+  assert(heap_size > 0, "Heap must be initialized");
+
+  switch (_sizer_kind) {
+    case SizerDefaults:
+      _min_desired_young_size = calculate_min_size(heap_size);
+      _max_desired_young_size = calculate_max_size(heap_size);
+      break;
+    case SizerNewSizeOnly:
+      _max_desired_young_size = calculate_max_size(heap_size);
+      _max_desired_young_size = MAX2(_min_desired_young_size, _max_desired_young_size);
+      break;
+    case SizerMaxNewSizeOnly:
+      _min_desired_young_size = calculate_min_size(heap_size);
+      _min_desired_young_size = MIN2(_min_desired_young_size, _max_desired_young_size);
+      break;
+    case SizerMaxAndNewSize:
+      // Do nothing. Values set on the command line, don't update them at runtime.
+      break;
+    case SizerNewRatio:
+      _min_desired_young_size = MAX2((heap_size / (NewRatio + 1)), ShenandoahHeapRegion::region_size_bytes());
+      _max_desired_young_size = _min_desired_young_size;
+      break;
+    default:
+      ShouldNotReachHere();
+  }
+
+  assert(_min_desired_young_size <= _max_desired_young_size, "Invalid min/max young gen size values");
+}
+
+void ShenandoahGenerationSizer::heap_size_changed(size_t heap_size) {
+  recalculate_min_max_young_length(heap_size);
+}
+
+bool ShenandoahGenerationSizer::adjust_generation_sizes() {
   shenandoah_assert_generational();
-  if (_mmu_average.davg() >= double(GCTimeRatio)) {
+  if (!use_adaptive_sizing()) {
+    return false;
+  }
+
+  if (_mmu_tracker->average() >= double(GCTimeRatio)) {
     return false;
   }
 
@@ -132,7 +228,7 @@ size_t percentage_of_heap(size_t bytes) {
   return size_t(100.0 * double(bytes) / double(heap_capacity));
 }
 
-bool ShenandoahMmuTracker::transfer_capacity(ShenandoahGeneration* from, ShenandoahGeneration* to) {
+bool ShenandoahGenerationSizer::transfer_capacity(ShenandoahGeneration* from, ShenandoahGeneration* to) {
   shenandoah_assert_heaplocked_or_safepoint();
 
   size_t available_regions = from->free_unaffiliated_regions();
@@ -145,15 +241,14 @@ bool ShenandoahMmuTracker::transfer_capacity(ShenandoahGeneration* from, Shenand
   size_t bytes_to_transfer = regions_to_transfer * ShenandoahHeapRegion::region_size_bytes();
   if (from->generation_mode() == YOUNG) {
     size_t new_young_size = from->max_capacity() - bytes_to_transfer;
-    if (percentage_of_heap(new_young_size) < ShenandoahMinYoungPercentage) {
-      ShenandoahHeap* heap = ShenandoahHeap::heap();
-      size_t minimum_size = size_t(ShenandoahMinYoungPercentage / 100.0 * heap->max_capacity());
+    size_t minimum_size = min_young_size();
+    if (new_young_size < minimum_size) {
       if (from->max_capacity() > minimum_size) {
         bytes_to_transfer = from->max_capacity() - minimum_size;
       } else {
         log_info(gc)("Cannot transfer from young: " SIZE_FORMAT "%s, at minimum capacity: " SIZE_FORMAT "%s",
-            byte_size_in_proper_unit(from->max_capacity()), proper_unit_for_byte_size(from->max_capacity()),
-            byte_size_in_proper_unit(minimum_size), proper_unit_for_byte_size(minimum_size));
+                     byte_size_in_proper_unit(from->max_capacity()), proper_unit_for_byte_size(from->max_capacity()),
+                     byte_size_in_proper_unit(minimum_size), proper_unit_for_byte_size(minimum_size));
         return false;
       }
     }
@@ -161,14 +256,13 @@ bool ShenandoahMmuTracker::transfer_capacity(ShenandoahGeneration* from, Shenand
     assert(to->generation_mode() == YOUNG, "Can only transfer between young and old.");
     size_t new_young_size = to->max_capacity() + bytes_to_transfer;
     if (percentage_of_heap(new_young_size) > ShenandoahMaxYoungPercentage) {
-      ShenandoahHeap* heap = ShenandoahHeap::heap();
-      size_t maximum_size = size_t(ShenandoahMaxYoungPercentage / 100.0 * heap->max_capacity());
+      size_t maximum_size = max_young_size();
       if (maximum_size > to->max_capacity()) {
         bytes_to_transfer = maximum_size - to->max_capacity();
       } else {
         log_info(gc)("Cannot transfer to young: " SIZE_FORMAT "%s, at maximum capacity: " SIZE_FORMAT "%s",
-            byte_size_in_proper_unit(to->max_capacity()), proper_unit_for_byte_size(to->max_capacity()),
-            byte_size_in_proper_unit(maximum_size), proper_unit_for_byte_size(maximum_size));
+                     byte_size_in_proper_unit(to->max_capacity()), proper_unit_for_byte_size(to->max_capacity()),
+                     byte_size_in_proper_unit(maximum_size), proper_unit_for_byte_size(maximum_size));
         return false;
       }
     }
@@ -180,11 +274,4 @@ bool ShenandoahMmuTracker::transfer_capacity(ShenandoahGeneration* from, Shenand
   from->decrease_capacity(bytes_to_transfer);
   to->increase_capacity(bytes_to_transfer);
   return true;
-}
-
-void ShenandoahMmuTracker::initialize() {
-  _initial_process_time_s = process_time_seconds();
-  _initial_collector_time_s = gc_thread_time_seconds();
-  _initial_verify_collector_time_s = _initial_collector_time_s;
-  _mmu_periodic_task->enroll();
 }

--- a/src/hotspot/share/gc/shenandoah/shenandoahMmuTracker.hpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahMmuTracker.hpp
@@ -114,7 +114,15 @@ private:
   // given the number of heap regions depending on the kind of sizing algorithm.
   void recalculate_min_max_young_length(size_t heap_size);
 
+  // This will attempt to transfer capacity from one generation to the other. It
+  // returns true if a transfer is made, false otherwise.
   bool transfer_capacity(ShenandoahGeneration* from, ShenandoahGeneration* to);
+
+  // These two methods are responsible for enforcing the minimum and maximum
+  // constraints for the size of the generations.
+  size_t adjust_transfer_from_young(ShenandoahGeneration* from, size_t bytes_to_transfer) const;
+  size_t adjust_transfer_to_young(ShenandoahGeneration* to, size_t bytes_to_transfer) const;
+
 public:
   ShenandoahGenerationSizer(ShenandoahMmuTracker* mmu_tracker);
 

--- a/src/hotspot/share/gc/shenandoah/shenandoahMmuTracker.hpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahMmuTracker.hpp
@@ -34,8 +34,10 @@ class ShenandoahMmuTask;
 /**
  * This class is responsible for tracking and adjusting the minimum mutator
  * utilization (MMU). MMU is defined as the percentage of CPU time available
- * to mutator threads over an arbitrary, fixed interval of time. MMU is measured
- * by summing all of the time given to the GC threads and comparing this too
+ * to mutator threads over an arbitrary, fixed interval of time. This interval
+ * defaults to 5 seconds and is configured by GCPauseIntervalMillis. The class
+ * maintains a decaying average of the last 10 values. The MMU is measured
+ * by summing all of the time given to the GC threads and comparing this to
  * the total CPU time for the process. There are OS APIs to support this on
  * all major platforms.
  *
@@ -49,16 +51,12 @@ class ShenandoahMmuTask;
  */
 class ShenandoahMmuTracker {
 
-  double _initial_collector_time_s;
-  double _initial_process_time_s;
-  double _initial_verify_collector_time_s;
-
-  double _resize_increment;
+  double _generational_reference_time_s;
+  double _process_reference_time_s;
+  double _collector_reference_time_s;
 
   ShenandoahMmuTask* _mmu_periodic_task;
   TruncatedSeq _mmu_average;
-
-  bool transfer_capacity(ShenandoahGeneration* from, ShenandoahGeneration* to);
 
   static double gc_thread_time_seconds();
   static double process_time_seconds();
@@ -83,17 +81,67 @@ public:
   // This method also logs the average MMU.
   void report();
 
+  double average() {
+    return _mmu_average.davg();
+  }
+};
+
+class ShenandoahGenerationSizer {
+private:
+  enum SizerKind {
+    SizerDefaults,
+    SizerNewSizeOnly,
+    SizerMaxNewSizeOnly,
+    SizerMaxAndNewSize,
+    SizerNewRatio
+  };
+  SizerKind _sizer_kind;
+
+  // False when using a fixed young generation size due to command-line options,
+  // true otherwise.
+  bool _use_adaptive_sizing;
+
+  size_t _min_desired_young_size;
+  size_t _max_desired_young_size;
+
+  double _resize_increment;
+  ShenandoahMmuTracker* _mmu_tracker;
+
+  static size_t calculate_min_size(size_t heap_size);
+  static size_t calculate_max_size(size_t heap_size);
+
+  // Update the given values for minimum and maximum young gen length in regions
+  // given the number of heap regions depending on the kind of sizing algorithm.
+  void recalculate_min_max_young_length(size_t heap_size);
+
+  bool transfer_capacity(ShenandoahGeneration* from, ShenandoahGeneration* to);
+public:
+  ShenandoahGenerationSizer(ShenandoahMmuTracker* mmu_tracker);
+
+  // Calculate the maximum length of the young gen given the number of regions
+  // depending on the sizing algorithm.
+  void heap_size_changed(size_t heap_size);
+
+  size_t min_young_size() const {
+    return _min_desired_young_size;
+  }
+  size_t max_young_size() const {
+    return _max_desired_young_size;
+  }
+
+  bool use_adaptive_sizing() const {
+    return _use_adaptive_sizing;
+  }
+
   // This is invoked at the end of a collection. This happens on a safepoint
   // to avoid any races with allocators (and to avoid interfering with
   // allocators by taking the heap lock). The amount of capacity to move
   // from one generation to another is controlled by YoungGenerationSizeIncrement
-  // and defaults to 20% of the heap. The minimum and maximum sizes of the
-  // young generation are controlled by ShenandoahMinYoungPercentage and
-  // ShenandoahMaxYoungPercentage, respectively. The method returns true
-  // when and adjustment is made, false otherwise.
+  // and defaults to 20% of the available capacity of the donor generation.
+  // The minimum and maximum sizes of the young generation are controlled by
+  // ShenandoahMinYoungPercentage and ShenandoahMaxYoungPercentage, respectively.
+  // The method returns true when an adjustment is made, false otherwise.
   bool adjust_generation_sizes();
 };
-
-
 
 #endif //SHARE_GC_SHENANDOAH_SHENANDOAHMMUTRACKER_HPP

--- a/src/hotspot/share/gc/shenandoah/shenandoahYoungGeneration.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahYoungGeneration.cpp
@@ -44,7 +44,7 @@ const char* ShenandoahYoungGeneration::name() const {
 void ShenandoahYoungGeneration::set_concurrent_mark_in_progress(bool in_progress) {
   ShenandoahHeap* heap = ShenandoahHeap::heap();
   heap->set_concurrent_young_mark_in_progress(in_progress);
-  if (_old_gen_task_queues != nullptr && in_progress && !heap->is_prepare_for_old_mark_in_progress()) {
+  if (is_bootstrap_cycle() && in_progress && !heap->is_prepare_for_old_mark_in_progress()) {
     // This is not a bug. When the bootstrapping marking phase is complete,
     // the old generation marking is still in progress, unless it's not.
     // In the case that old-gen preparation for mixed evacuation has been
@@ -75,7 +75,7 @@ bool ShenandoahYoungGeneration::is_concurrent_mark_in_progress() {
 
 void ShenandoahYoungGeneration::reserve_task_queues(uint workers) {
   ShenandoahGeneration::reserve_task_queues(workers);
-  if (_old_gen_task_queues != NULL) {
+  if (is_bootstrap_cycle()) {
     _old_gen_task_queues->reserve(workers);
   }
 }
@@ -92,7 +92,7 @@ ShenandoahHeuristics* ShenandoahYoungGeneration::initialize_heuristics(Shenandoa
 }
 
 void ShenandoahYoungGeneration::add_collection_time(double time_seconds) {
-  if (_old_gen_task_queues != NULL) {
+  if (is_bootstrap_cycle()) {
     // This is a bootstrap cycle, so attribute time to old gc
     ShenandoahHeap::heap()->old_generation()->add_collection_time(time_seconds);
   } else {

--- a/src/hotspot/share/gc/shenandoah/shenandoahYoungGeneration.hpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahYoungGeneration.hpp
@@ -52,6 +52,12 @@ public:
     return _old_gen_task_queues;
   }
 
+  // Returns true if the young generation is configured to enqueue old
+  // oops for the old generation mark queues.
+  bool is_bootstrap_cycle() {
+    return _old_gen_task_queues != nullptr;
+  }
+
   void reserve_task_queues(uint workers) override;
 
   virtual ShenandoahHeuristics* initialize_heuristics(ShenandoahMode* gc_mode) override;

--- a/test/hotspot/gtest/gc/shenandoah/test_shenandoahOldHeuristic.cpp
+++ b/test/hotspot/gtest/gc/shenandoah/test_shenandoahOldHeuristic.cpp
@@ -281,3 +281,5 @@ TEST_VM_F(ShenandoahOldHeuristicTest, unpinned_region_is_middle) {
   EXPECT_EQ(_collection_set->get_old_garbage(), g1 + g3);
   EXPECT_EQ(_heuristics->unprocessed_old_collection_candidates(), 0UL);
 }
+
+#undef SKIP_IF_NOT_SHENANDOAH


### PR DESCRIPTION
Some things to highlight here:
* This change borrows a bit of code from G1 to handle processing of command line arguments used to size the young generation.
* A (hard coded for now) threshold on the difference between young/old time has been added to reduce resizing churn.
* The adaptive heuristic doesn't consider the `soft_tail` anymore. `available` is already adjusted for the soft max capacity.
* `SoftMaxHeapSize` is used to compute the soft max size and max size for the young generation.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed (1 review required, with at least 1 [Committer](https://openjdk.org/bylaws#committer))

### Reviewers
 * [Kelvin Nilsen](https://openjdk.org/census#kdnilsen) (@kdnilsen - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/shenandoah pull/185/head:pull/185` \
`$ git checkout pull/185`

Update a local copy of the PR: \
`$ git checkout pull/185` \
`$ git pull https://git.openjdk.org/shenandoah pull/185/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 185`

View PR using the GUI difftool: \
`$ git pr show -t 185`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/shenandoah/pull/185.diff">https://git.openjdk.org/shenandoah/pull/185.diff</a>

</details>
