### PR TITLE
Use CardTable::card_size_in_words rather than hard coded constant

### DIFF
--- a/src/hotspot/share/gc/shenandoah/shenandoahScanRemembered.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahScanRemembered.cpp
@@ -249,8 +249,11 @@ ShenandoahRegionChunkIterator::ShenandoahRegionChunkIterator(ShenandoahHeap* hea
     _total_chunks(calc_total_chunks()),
     _index(0)
 {
-  assert(_smallest_chunk_size_words == _clusters_in_smallest_chunk * CardTable::card_size_in_words()
-         * ShenandoahCardCluster<ShenandoahDirectCardMarkRememberedSet>::CardsPerCluster, "_smallest_chunk_size is not valid");
+#ifdef ASSERT
+  size_t expected_chunk_size_words = _clusters_in_smallest_chunk * CardTable::card_size_in_words() * ShenandoahCardCluster<ShenandoahDirectCardMarkRememberedSet>::CardsPerCluster;
+  assert(_smallest_chunk_size_words == expected_chunk_size_words, "_smallest_chunk_size (" SIZE_FORMAT") is not valid because it does not equal (" SIZE_FORMAT ")",
+      _smallest_chunk_size_words, expected_chunk_size_words);
+#endif
   assert(_num_groups <= _maximum_groups,
          "The number of remembered set scanning groups must be less than or equal to maximum groups");
   assert(_smallest_chunk_size_words << (_maximum_groups - 1) == _maximum_chunk_size_words,

--- a/src/hotspot/share/gc/shenandoah/shenandoahScanRemembered.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahScanRemembered.cpp
@@ -139,7 +139,7 @@ size_t ShenandoahRegionChunkIterator::calc_num_groups() {
   size_t num_groups = 0;
   size_t cumulative_group_span = 0;
   size_t current_group_span = _first_group_chunk_size_b4_rebalance * _regular_group_size;
-  size_t smallest_group_span = _smallest_chunk_size_words * _regular_group_size;
+  size_t smallest_group_span = smallest_chunk_size_words() * _regular_group_size;
   while ((num_groups < _maximum_groups) && (cumulative_group_span + current_group_span <= total_heap_size)) {
     num_groups++;
     cumulative_group_span += current_group_span;
@@ -179,7 +179,7 @@ size_t ShenandoahRegionChunkIterator::calc_total_chunks() {
   size_t num_chunks = 0;
   size_t cumulative_group_span = 0;
   size_t current_group_span = _first_group_chunk_size_b4_rebalance * _regular_group_size;
-  size_t smallest_group_span = _smallest_chunk_size_words * _regular_group_size;
+  size_t smallest_group_span = smallest_chunk_size_words() * _regular_group_size;
 
   // The first group gets special handling because the first chunk size can be no larger than _largest_chunk_size_words
   if (region_size_words > _maximum_chunk_size_words) {
@@ -216,7 +216,7 @@ size_t ShenandoahRegionChunkIterator::calc_total_chunks() {
       } else if (current_group_span <= smallest_group_span) {
         // We cannot introduce new groups because we've reached the lower bound on group size.  So this last
         // group may hold extra chunks.
-        size_t chunk_span = _smallest_chunk_size_words;
+        size_t chunk_span = smallest_chunk_size_words();
         size_t extra_chunks = unspanned_heap_size / chunk_span;
         assert (extra_chunks * chunk_span == unspanned_heap_size, "Chunks must precisely span regions");
         num_chunks += extra_chunks;
@@ -251,12 +251,12 @@ ShenandoahRegionChunkIterator::ShenandoahRegionChunkIterator(ShenandoahHeap* hea
 {
 #ifdef ASSERT
   size_t expected_chunk_size_words = _clusters_in_smallest_chunk * CardTable::card_size_in_words() * ShenandoahCardCluster<ShenandoahDirectCardMarkRememberedSet>::CardsPerCluster;
-  assert(_smallest_chunk_size_words == expected_chunk_size_words, "_smallest_chunk_size (" SIZE_FORMAT") is not valid because it does not equal (" SIZE_FORMAT ")",
-      _smallest_chunk_size_words, expected_chunk_size_words);
+  assert(smallest_chunk_size_words() == expected_chunk_size_words, "_smallest_chunk_size (" SIZE_FORMAT") is not valid because it does not equal (" SIZE_FORMAT ")",
+         smallest_chunk_size_words(), expected_chunk_size_words);
 #endif
   assert(_num_groups <= _maximum_groups,
          "The number of remembered set scanning groups must be less than or equal to maximum groups");
-  assert(_smallest_chunk_size_words << (_maximum_groups - 1) == _maximum_chunk_size_words,
+  assert(smallest_chunk_size_words() << (_maximum_groups - 1) == _maximum_chunk_size_words,
          "Maximum number of groups needs to span maximum chunk size to smallest chunk size");
 
   size_t words_in_region = ShenandoahHeapRegion::region_size_words();

--- a/src/hotspot/share/gc/shenandoah/shenandoahScanRemembered.hpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahScanRemembered.hpp
@@ -1024,7 +1024,6 @@ private:
   static const size_t _maximum_chunk_size_words = (4 * 1024 * 1024) / HeapWordSize;
 
   static const size_t _clusters_in_smallest_chunk = 4;
-  static const size_t _assumed_words_in_card = 64;
 
   // smallest_chunk_size is 4 clusters (i.e. 128 KiB).  Note that there are 64 words per card and there are 64 cards per
   // cluster.  Each cluster spans 128 KiB.
@@ -1032,8 +1031,10 @@ private:
   //      ShenandoahCardCluster<ShenandoahDirectCardMarkRememberedSet>::CardsPerCluster;
   // We can't perform this computation here, because of encapsulation and initialization constraints.  We paste
   // the magic number here, and assert that this number matches the intended computation in constructor.
-  static const size_t _smallest_chunk_size_words = (_clusters_in_smallest_chunk * _assumed_words_in_card *
-                                                    ShenandoahCardCluster<ShenandoahDirectCardMarkRememberedSet>::CardsPerCluster);
+  static size_t smallest_chunk_size_words() {
+      return _clusters_in_smallest_chunk * CardTable::card_size_in_words() *
+             ShenandoahCardCluster<ShenandoahDirectCardMarkRememberedSet>::CardsPerCluster;
+  }
 
   // The total remembered set scanning effort is divided into chunks of work that are assigned to individual worker tasks.
   // The chunks of assigned work are divided into groups, where the size of the typical group (_regular_group_size) is half the

--- a/src/hotspot/share/gc/shenandoah/shenandoahScanRemembered.hpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahScanRemembered.hpp
@@ -1025,12 +1025,9 @@ private:
 
   static const size_t _clusters_in_smallest_chunk = 4;
 
-  // smallest_chunk_size is 4 clusters (i.e. 128 KiB).  Note that there are 64 words per card and there are 64 cards per
-  // cluster.  Each cluster spans 128 KiB.
+  // smallest_chunk_size is 4 clusters.  Each cluster spans 128 KiB.
   // This is computed from CardTable::card_size_in_words() *
   //      ShenandoahCardCluster<ShenandoahDirectCardMarkRememberedSet>::CardsPerCluster;
-  // We can't perform this computation here, because of encapsulation and initialization constraints.  We paste
-  // the magic number here, and assert that this number matches the intended computation in constructor.
   static size_t smallest_chunk_size_words() {
       return _clusters_in_smallest_chunk * CardTable::card_size_in_words() *
              ShenandoahCardCluster<ShenandoahDirectCardMarkRememberedSet>::CardsPerCluster;


### PR DESCRIPTION
Calculation assumed 64 words per card, which does not hold on 32 bit word platforms. The number of words per card also depends on `GCCardSizeInBytes` command line parameter.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed (1 review required, with at least 1 [Committer](https://openjdk.org/bylaws#committer))

### Reviewers
 * [Y. Srinivas Ramakrishna](https://openjdk.org/census#ysr) (@ysramakrishna - Author) ⚠️ Review applies to [9ebacb5d](https://git.openjdk.org/shenandoah/pull/186/files/9ebacb5defdead91b4c62ec116a3952508e52249)
 * [Kelvin Nilsen](https://openjdk.org/census#kdnilsen) (@kdnilsen - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/shenandoah pull/186/head:pull/186` \
`$ git checkout pull/186`

Update a local copy of the PR: \
`$ git checkout pull/186` \
`$ git pull https://git.openjdk.org/shenandoah pull/186/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 186`

View PR using the GUI difftool: \
`$ git pr show -t 186`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/shenandoah/pull/186.diff">https://git.openjdk.org/shenandoah/pull/186.diff</a>

</details>
