### PR TITLE
Allow heuristic trigger to increase capacity instead of running a collection

### DIFF
--- a/src/hotspot/share/gc/shenandoah/heuristics/shenandoahAdaptiveHeuristics.cpp
+++ b/src/hotspot/share/gc/shenandoah/heuristics/shenandoahAdaptiveHeuristics.cpp
@@ -360,7 +360,7 @@ bool ShenandoahAdaptiveHeuristics::should_start_gc() {
                  _generation->name(),
                  byte_size_in_proper_unit(allocation_headroom), proper_unit_for_byte_size(allocation_headroom),
                  byte_size_in_proper_unit(min_threshold),       proper_unit_for_byte_size(min_threshold));
-    return true;
+    return resize_and_evaluate();
   }
 
   // Check if we need to learn a bit about the application
@@ -458,7 +458,7 @@ bool ShenandoahAdaptiveHeuristics::should_start_gc() {
                        byte_size_in_proper_unit(allocation_headroom), proper_unit_for_byte_size(allocation_headroom));
 
     _last_trigger = RATE;
-    return true;
+    return resize_and_evaluate();
   }
 
   bool is_spiking = _allocation_rate.is_spiking(rate, _spike_threshold_sd);
@@ -470,10 +470,37 @@ bool ShenandoahAdaptiveHeuristics::should_start_gc() {
 
                  _spike_threshold_sd);
     _last_trigger = SPIKE;
-    return true;
+    return resize_and_evaluate();
   }
 
   return ShenandoahHeuristics::should_start_gc();
+}
+
+bool ShenandoahAdaptiveHeuristics::resize_and_evaluate() {
+  ShenandoahHeap* heap = ShenandoahHeap::heap();
+  if (!heap->mode()->is_generational()) {
+    // We only attempt to resize the generations in generational mode.
+    return true;
+  }
+
+  if (_gc_times_learned < ShenandoahLearningSteps) {
+    // We aren't going to attempt to resize our generation until we have 'learned'
+    // something about it. This provides a kind of cool down period after we've made
+    // a change, to help prevent thrashing.
+    return true;
+  }
+  
+  if (!heap->generation_sizer()->transfer_capacity(_generation)) {
+    // We could not enlarge our generation, so we must start a gc cycle.
+    return true;
+  }
+
+  // We successfully enlarged our generation. Reset times learned because the size
+  // of the generation has changed. The heuristic should relearn collection
+  // statistics. This also has the effect of not resizing the generations for at
+  // least ShenandoahLearningSteps.
+  _gc_times_learned = 0;
+  return should_start_gc();
 }
 
 void ShenandoahAdaptiveHeuristics::adjust_last_trigger_parameters(double amount) {

--- a/src/hotspot/share/gc/shenandoah/heuristics/shenandoahAdaptiveHeuristics.cpp
+++ b/src/hotspot/share/gc/shenandoah/heuristics/shenandoahAdaptiveHeuristics.cpp
@@ -489,7 +489,7 @@ bool ShenandoahAdaptiveHeuristics::resize_and_evaluate() {
     // a change, to help prevent thrashing.
     return true;
   }
-  
+
   if (!heap->generation_sizer()->transfer_capacity(_generation)) {
     // We could not enlarge our generation, so we must start a gc cycle.
     return true;

--- a/src/hotspot/share/gc/shenandoah/heuristics/shenandoahAdaptiveHeuristics.cpp
+++ b/src/hotspot/share/gc/shenandoah/heuristics/shenandoahAdaptiveHeuristics.cpp
@@ -495,11 +495,6 @@ bool ShenandoahAdaptiveHeuristics::resize_and_evaluate() {
     return true;
   }
 
-  // We successfully enlarged our generation. Reset times learned because the size
-  // of the generation has changed. The heuristic should relearn collection
-  // statistics. This also has the effect of not resizing the generations for at
-  // least ShenandoahLearningSteps.
-  _gc_times_learned = 0;
   return should_start_gc();
 }
 

--- a/src/hotspot/share/gc/shenandoah/heuristics/shenandoahAdaptiveHeuristics.hpp
+++ b/src/hotspot/share/gc/shenandoah/heuristics/shenandoahAdaptiveHeuristics.hpp
@@ -99,6 +99,8 @@ public:
   void adjust_margin_of_error(double amount);
   void adjust_spike_threshold(double amount);
 
+  bool resize_and_evaluate();
+
   ShenandoahAllocationRate _allocation_rate;
 
   // The margin of error expressed in standard deviations to add to our

--- a/src/hotspot/share/gc/shenandoah/heuristics/shenandoahHeuristics.cpp
+++ b/src/hotspot/share/gc/shenandoah/heuristics/shenandoahHeuristics.cpp
@@ -330,6 +330,10 @@ void ShenandoahHeuristics::record_allocation_failure_gc() {
 void ShenandoahHeuristics::record_requested_gc() {
   // Assume users call System.gc() when external state changes significantly,
   // which forces us to re-learn the GC timings and allocation rates.
+  reset_gc_learning();
+}
+
+void ShenandoahHeuristics::reset_gc_learning() {
   _gc_times_learned = 0;
 }
 

--- a/src/hotspot/share/gc/shenandoah/heuristics/shenandoahHeuristics.hpp
+++ b/src/hotspot/share/gc/shenandoah/heuristics/shenandoahHeuristics.hpp
@@ -155,6 +155,8 @@ public:
 
   virtual void record_requested_gc();
 
+  virtual void reset_gc_learning();
+
   virtual size_t select_aged_regions(size_t old_available, size_t num_regions, bool preselected_regions[]);
 
   virtual void choose_collection_set(ShenandoahCollectionSet* collection_set, ShenandoahOldHeuristics* old_heuristics);

--- a/src/hotspot/share/gc/shenandoah/heuristics/shenandoahOldHeuristics.cpp
+++ b/src/hotspot/share/gc/shenandoah/heuristics/shenandoahOldHeuristics.cpp
@@ -331,6 +331,12 @@ void ShenandoahOldHeuristics::abandon_collection_candidates() {
 }
 
 void ShenandoahOldHeuristics::handle_promotion_failure() {
+  if (!_promotion_failed) {
+    if (ShenandoahHeap::heap()->generation_sizer()->transfer_capacity(_old_generation)) {
+      log_info(gc)("Increased size of old generation due to promotion failure.");
+    }
+    // TODO: Increase tenuring threshold to push back on promotions.
+  }
   _promotion_failed = true;
 }
 
@@ -387,6 +393,10 @@ void ShenandoahOldHeuristics::record_requested_gc() {
   _trigger_heuristic->record_requested_gc();
 }
 
+void ShenandoahOldHeuristics::reset_gc_learning() {
+  _trigger_heuristic->reset_gc_learning();
+}
+
 bool ShenandoahOldHeuristics::can_unload_classes() {
   return _trigger_heuristic->can_unload_classes();
 }
@@ -418,4 +428,5 @@ void ShenandoahOldHeuristics::choose_collection_set_from_regiondata(ShenandoahCo
                                                                     size_t data_size, size_t free) {
   ShouldNotReachHere();
 }
+
 

--- a/src/hotspot/share/gc/shenandoah/heuristics/shenandoahOldHeuristics.hpp
+++ b/src/hotspot/share/gc/shenandoah/heuristics/shenandoahOldHeuristics.hpp
@@ -149,6 +149,8 @@ public:
 
   virtual void record_requested_gc() override;
 
+  virtual void reset_gc_learning() override;
+
   virtual bool can_unload_classes() override;
 
   virtual bool can_unload_classes_normal() override;

--- a/src/hotspot/share/gc/shenandoah/shenandoahGeneration.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahGeneration.cpp
@@ -994,17 +994,19 @@ size_t ShenandoahGeneration::adjusted_unaffiliated_regions() const {
 
 
 void ShenandoahGeneration::increase_capacity(size_t increment) {
-  shenandoah_assert_heaplocked_or_safepoint();
+  shenandoah_assert_heaplocked();
   assert(_max_capacity + increment <= ShenandoahHeap::heap()->max_size_for(this), "Cannot increase generation capacity beyond maximum.");
   _max_capacity += increment;
   _soft_max_capacity += increment;
+  _adjusted_capacity += increment;
 }
 
 void ShenandoahGeneration::decrease_capacity(size_t decrement) {
-  shenandoah_assert_heaplocked_or_safepoint();
+  shenandoah_assert_heaplocked();
   assert(_max_capacity - decrement >= ShenandoahHeap::heap()->min_size_for(this), "Cannot decrease generation capacity beyond minimum.");
   _max_capacity -= decrement;
   _soft_max_capacity -= decrement;
+  _adjusted_capacity -= decrement;
 }
 
 void ShenandoahGeneration::record_success_concurrent(bool abbreviated) {

--- a/src/hotspot/share/gc/shenandoah/shenandoahGeneration.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahGeneration.cpp
@@ -993,7 +993,7 @@ size_t ShenandoahGeneration::adjusted_unaffiliated_regions() const {
 }
 
 void ShenandoahGeneration::increase_capacity(size_t increment) {
-  shenandoah_assert_heaplocked();
+  shenandoah_assert_heaplocked_or_safepoint();
   assert(_max_capacity + increment <= ShenandoahHeap::heap()->max_size_for(this), "Cannot increase generation capacity beyond maximum.");
   _max_capacity += increment;
   _soft_max_capacity += increment;
@@ -1001,7 +1001,7 @@ void ShenandoahGeneration::increase_capacity(size_t increment) {
 }
 
 void ShenandoahGeneration::decrease_capacity(size_t decrement) {
-  shenandoah_assert_heaplocked();
+  shenandoah_assert_heaplocked_or_safepoint();
   assert(_max_capacity - decrement >= ShenandoahHeap::heap()->min_size_for(this), "Cannot decrease generation capacity beyond minimum.");
   _max_capacity -= decrement;
   _soft_max_capacity -= decrement;

--- a/src/hotspot/share/gc/shenandoah/shenandoahGeneration.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahGeneration.cpp
@@ -998,6 +998,7 @@ void ShenandoahGeneration::increase_capacity(size_t increment) {
   _max_capacity += increment;
   _soft_max_capacity += increment;
   _adjusted_capacity += increment;
+  heuristics()->reset_gc_learning();
 }
 
 void ShenandoahGeneration::decrease_capacity(size_t decrement) {
@@ -1006,6 +1007,7 @@ void ShenandoahGeneration::decrease_capacity(size_t decrement) {
   _max_capacity -= decrement;
   _soft_max_capacity -= decrement;
   _adjusted_capacity -= decrement;
+  heuristics()->reset_gc_learning();
 }
 
 void ShenandoahGeneration::record_success_concurrent(bool abbreviated) {

--- a/src/hotspot/share/gc/shenandoah/shenandoahGeneration.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahGeneration.cpp
@@ -273,7 +273,7 @@ void ShenandoahGeneration::compute_evacuation_budgets(ShenandoahHeap* heap, bool
   heap->set_old_evac_reserve(old_evacuation_reserve);
   heap->reset_old_evac_expended();
 
-  // Compute the young evauation reserve: This is how much memory is available for evacuating young-gen objects.
+  // Compute the young evacuation reserve: This is how much memory is available for evacuating young-gen objects.
   // We ignore the possible effect of promotions, which reduce demand for young-gen evacuation memory.
   //
   // TODO: We could give special treatment to the regions that have reached promotion age, because we know their
@@ -288,7 +288,7 @@ void ShenandoahGeneration::compute_evacuation_budgets(ShenandoahHeap* heap, bool
   //    1. (young_gen->capacity() * ShenandoahEvacReserve) / 100
   //    2. (young_gen->available() + old_gen_memory_available_to_be_loaned
   //
-  //  ShenandoahEvacReserve represents the configured taget size of the evacuation region.  We can only honor
+  //  ShenandoahEvacReserve represents the configured target size of the evacuation region.  We can only honor
   //  this target if there is memory available to hold the evacuations.  Memory is available if it is already
   //  free within young gen, or if it can be borrowed from old gen.  Since we have not yet chosen the collection
   //  sets, we do not yet know the exact accounting of how many regions will be freed by this collection pass.
@@ -992,7 +992,6 @@ size_t ShenandoahGeneration::adjusted_unaffiliated_regions() const {
   return (adjusted_capacity() - used_regions_size()) / ShenandoahHeapRegion::region_size_bytes();
 }
 
-
 void ShenandoahGeneration::increase_capacity(size_t increment) {
   shenandoah_assert_heaplocked();
   assert(_max_capacity + increment <= ShenandoahHeap::heap()->max_size_for(this), "Cannot increase generation capacity beyond maximum.");
@@ -1020,6 +1019,7 @@ void ShenandoahGeneration::record_success_degenerated() {
 }
 
 void ShenandoahGeneration::add_collection_time(double time_seconds) {
+  shenandoah_assert_control_or_vm_thread();
   _collection_thread_time_s += time_seconds;
 }
 

--- a/src/hotspot/share/gc/shenandoah/shenandoahGeneration.hpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahGeneration.hpp
@@ -73,6 +73,10 @@ private:
   ShenandoahGeneration(GenerationMode generation_mode, uint max_workers, size_t max_capacity, size_t soft_max_capacity);
   ~ShenandoahGeneration();
 
+  bool is_young() const  { return _generation_mode == YOUNG; }
+  bool is_old() const    { return _generation_mode == OLD; }
+  bool is_global() const { return _generation_mode == GLOBAL; }
+
   inline GenerationMode generation_mode() const { return _generation_mode; }
 
   inline ShenandoahHeuristics* heuristics() const { return _heuristics; }

--- a/src/hotspot/share/gc/shenandoah/shenandoahGeneration.hpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahGeneration.hpp
@@ -115,6 +115,9 @@ private:
   void reset_bytes_allocated_since_gc_start();
   void increase_allocated(size_t bytes);
 
+  // Changing the size of the generation will reset the times learned for the heuristic. The heuristic will need to
+  // relearn collection performance metrics. This also has the effect of preventing further capacity changes from the
+  // heuristics until at least ShenandoahLearningSteps(5) number of cycles has completed.
   void increase_capacity(size_t increment);
   void decrease_capacity(size_t decrement);
 

--- a/src/hotspot/share/gc/shenandoah/shenandoahMmuTracker.hpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahMmuTracker.hpp
@@ -114,17 +114,16 @@ private:
   // given the number of heap regions depending on the kind of sizing algorithm.
   void recalculate_min_max_young_length(size_t heap_size);
 
-  // This will attempt to transfer capacity from one generation to the other. It
-  // returns true if a transfer is made, false otherwise.
-  bool transfer_capacity(ShenandoahGeneration* from, ShenandoahGeneration* to);
-
   // These two methods are responsible for enforcing the minimum and maximum
   // constraints for the size of the generations.
   size_t adjust_transfer_from_young(ShenandoahGeneration* from, size_t bytes_to_transfer) const;
   size_t adjust_transfer_to_young(ShenandoahGeneration* to, size_t bytes_to_transfer) const;
 
+  // This will attempt to transfer capacity from one generation to the other. It
+  // returns true if a transfer is made, false otherwise.
+  bool transfer_capacity(ShenandoahGeneration* from, ShenandoahGeneration* to) const;
 public:
-  ShenandoahGenerationSizer(ShenandoahMmuTracker* mmu_tracker);
+  explicit ShenandoahGenerationSizer(ShenandoahMmuTracker* mmu_tracker);
 
   // Calculate the maximum length of the young gen given the number of regions
   // depending on the sizing algorithm.
@@ -149,7 +148,11 @@ public:
   // The minimum and maximum sizes of the young generation are controlled by
   // ShenandoahMinYoungPercentage and ShenandoahMaxYoungPercentage, respectively.
   // The method returns true when an adjustment is made, false otherwise.
-  bool adjust_generation_sizes();
+  bool adjust_generation_sizes() const;
+
+  // This may be invoked by a heuristic (from regulator thread) before it
+  // decides to run a collection.
+  bool transfer_capacity(ShenandoahGeneration* target) const;
 };
 
 #endif //SHARE_GC_SHENANDOAH_SHENANDOAHMMUTRACKER_HPP


### PR DESCRIPTION
Before the adaptive heuristic starts a collection, it will attempt to increase the capacity of its generation. If the capacity is increased, the heuristic will re-evaluate the trigger criteria.

There is also a change here to attempt to increase the size of the old generation in response to a promotion failure.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed (1 review required, with at least 1 [Committer](https://openjdk.org/bylaws#committer))

### Reviewers
 * [Kelvin Nilsen](https://openjdk.org/census#kdnilsen) (@kdnilsen - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/shenandoah pull/190/head:pull/190` \
`$ git checkout pull/190`

Update a local copy of the PR: \
`$ git checkout pull/190` \
`$ git pull https://git.openjdk.org/shenandoah pull/190/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 190`

View PR using the GUI difftool: \
`$ git pr show -t 190`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/shenandoah/pull/190.diff">https://git.openjdk.org/shenandoah/pull/190.diff</a>

</details>
