### PR TITLE
Enforce that generation sizes align with region sizes

### DIFF
--- a/src/hotspot/share/gc/shenandoah/shenandoahGeneration.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahGeneration.cpp
@@ -989,6 +989,9 @@ size_t ShenandoahGeneration::adjusted_capacity() const {
 
 size_t ShenandoahGeneration::adjusted_unaffiliated_regions() const {
   assert(adjusted_capacity() >= used_regions_size(), "adjusted_unaffiliated_regions() cannot return negative");
+  assert((adjusted_capacity() - used_regions_size()) % ShenandoahHeapRegion::region_size_bytes() == 0,
+         "adjusted_capacity (" SIZE_FORMAT ") and used regions size (" SIZE_FORMAT ") should be multiples of region_size_bytes",
+         adjusted_capacity(), used_regions_size());
   return (adjusted_capacity() - used_regions_size()) / ShenandoahHeapRegion::region_size_bytes();
 }
 

--- a/src/hotspot/share/gc/shenandoah/shenandoahMmuTracker.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahMmuTracker.cpp
@@ -159,11 +159,13 @@ ShenandoahGenerationSizer::ShenandoahGenerationSizer(ShenandoahMmuTracker* mmu_t
 
 size_t ShenandoahGenerationSizer::calculate_min_size(size_t heap_size) {
   size_t default_value = (heap_size * ShenandoahMinYoungPercentage) / 100;
+  default_value &= ~ShenandoahHeapRegion::region_size_bytes_mask();
   return MAX2(ShenandoahHeapRegion::region_size_bytes(), default_value);
 }
 
 size_t ShenandoahGenerationSizer::calculate_max_size(size_t heap_size) {
   size_t default_value = (heap_size * ShenandoahMaxYoungPercentage) / 100;
+  default_value &= ~ShenandoahHeapRegion::region_size_bytes_mask();
   return MAX2(ShenandoahHeapRegion::region_size_bytes(), default_value);
 }
 


### PR DESCRIPTION
For correctness, the size of each generation should be a multiple of the region size.

A recent change violated this requirement.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed (1 review required, with at least 1 [Committer](https://openjdk.org/bylaws#committer))

### Reviewers
 * [Y. Srinivas Ramakrishna](https://openjdk.org/census#ysr) (@ysramakrishna - Author)
 * [William Kemper](https://openjdk.org/census#wkemper) (@earthling-amzn - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/shenandoah pull/191/head:pull/191` \
`$ git checkout pull/191`

Update a local copy of the PR: \
`$ git checkout pull/191` \
`$ git pull https://git.openjdk.org/shenandoah pull/191/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 191`

View PR using the GUI difftool: \
`$ git pr show -t 191`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/shenandoah/pull/191.diff">https://git.openjdk.org/shenandoah/pull/191.diff</a>

</details>
