### PR TITLE
Fix allocate aligned

### DIFF
--- a/src/hotspot/share/gc/shenandoah/shenandoahFreeSet.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahFreeSet.cpp
@@ -267,7 +267,7 @@ HeapWord* ShenandoahFreeSet::try_allocate_in(ShenandoahHeapRegion* r, Shenandoah
         assert(r->top() <= r->end(), "Allocation cannot span end of region");
         // actual_size() will be set to size below.
         assert((result == nullptr) || (size % CardTable::card_size_in_words() == 0),
-               "PLAB size must multiple of card size");
+               "PLAB size must be multiple of card size");
         assert((result == nullptr) || (((uintptr_t) result) % CardTable::card_size_in_words() == 0),
                "PLAB start must align with card boundary");
 

--- a/src/hotspot/share/gc/shenandoah/shenandoahFreeSet.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahFreeSet.cpp
@@ -197,9 +197,7 @@ HeapWord* ShenandoahFreeSet::try_allocate_in(ShenandoahHeapRegion* r, Shenandoah
       r->is_trash()) {
     return NULL;
   }
-
   try_recycle_trashed(r);
-
   if (r->affiliation() == ShenandoahRegionAffiliation::FREE) {
     ShenandoahMarkingContext* const ctx = _heap->complete_marking_context();
     r->set_affiliation(req.affiliation());
@@ -227,7 +225,6 @@ HeapWord* ShenandoahFreeSet::try_allocate_in(ShenandoahHeapRegion* r, Shenandoah
   }
 
   in_new_region = r->is_empty();
-
   HeapWord* result = NULL;
   size_t size = req.size();
 
@@ -239,15 +236,41 @@ HeapWord* ShenandoahFreeSet::try_allocate_in(ShenandoahHeapRegion* r, Shenandoah
       size_t usable_free = (free / CardTable::card_size()) << CardTable::card_shift();
       if ((free != usable_free) && (free - usable_free < ShenandoahHeap::min_fill_size() * HeapWordSize)) {
         // We'll have to add another card's memory to the padding
-        usable_free -= CardTable::card_size();
+        if (usable_free > CardTable::card_size()) {
+          usable_free -= CardTable::card_size();
+        } else {
+          assert(usable_free == 0, "usable_free is a multiple of card_size and card_size > min_fill_size");
+        }
       }
       free /= HeapWordSize;
       usable_free /= HeapWordSize;
+      size_t remnant = size % CardTable::card_size_in_words();
+      if (remnant > 0) {
+        // Since we have Elastic TLABs, align size up.  This is consistent with aligning min_size up.
+        size = size - remnant + CardTable::card_size_in_words();
+      }
       if (size > usable_free) {
         size = usable_free;
+        assert(size % CardTable::card_size_in_words() == 0, "usable_free is a multiple of card table size");
       }
-      if (size >= req.min_size()) {
+
+      size_t adjusted_min_size = req.min_size();
+      remnant = adjusted_min_size % CardTable::card_size_in_words();
+      if (remnant > 0) {
+        // Round up adjusted_min_size to a multiple of alignment size
+        adjusted_min_size = adjusted_min_size - remnant + CardTable::card_size_in_words();
+      }
+      if (size >= adjusted_min_size) {
         result = r->allocate_aligned(size, req, CardTable::card_size());
+        // TODO: Fix allocate_aligned() to provide min_size() allocation if insufficient memory for desired size.
+        //       Then add: assert(result != nullptr, "Allocation cannot fail");
+        assert(r->top() <= r->end(), "Allocation cannot span end of region");
+        // actual_size() will be set to size below.
+        assert((result == nullptr) || (size % CardTable::card_size_in_words() == 0),
+               "PLAB size must multiple of card size");
+        assert((result == nullptr) || (((uintptr_t) result) % CardTable::card_size_in_words() == 0),
+               "PLAB start must align with card boundary");
+
         if (result != nullptr && free > usable_free) {
           // Account for the alignment padding
           size_t padding = (free - usable_free) * HeapWordSize;
@@ -258,6 +281,7 @@ HeapWord* ShenandoahFreeSet::try_allocate_in(ShenandoahHeapRegion* r, Shenandoah
           _heap->increase_used(padding);
         }
       }
+      // Otherwise, leave result == NULL because the adjusted size is smaller than min size.
     } else {
       // This is a GCLAB or a TLAB allocation
       size_t free = align_down(r->free() >> LogHeapWordSize, MinObjAlignment);
@@ -279,13 +303,20 @@ HeapWord* ShenandoahFreeSet::try_allocate_in(ShenandoahHeapRegion* r, Shenandoah
     usable_free /= HeapWordSize;
     if ((free != usable_free) && (free - usable_free < ShenandoahHeap::min_fill_size() * HeapWordSize)) {
       // We'll have to add another card's memory to the padding
-      usable_free -= CardTable::card_size();
+      if (usable_free > CardTable::card_size_in_words()) {
+        usable_free -= CardTable::card_size_in_words();
+      } else {
+        assert(usable_free == 0, "usable_free is a multiple of card_size and card_size > min_fill_size");
+      }
     }
+    assert(size % CardTable::card_size_in_words() == 0, "PLAB size must be multiple of remembered set card size");
     if (size <= usable_free) {
-      assert(size % CardTable::card_size_in_words() == 0, "PLAB size must be multiple of remembered set card size");
-
       result = r->allocate_aligned(size, req, CardTable::card_size());
-      if (result != nullptr) {
+      assert(result != nullptr, "Allocation cannot fail");
+      assert(r->top() <= r->end(), "Allocation cannot span end of region");
+      assert(req.actual_size() % CardTable::card_size_in_words() == 0, "PLAB start must align with card boundary");
+      assert(((uintptr_t) result) % CardTable::card_size_in_words() == 0, "PLAB start must align with card boundary");
+      if (result != nullptr && free > usable_free) {
         // Account for the alignment padding
         size_t padding = (free - usable_free) * HeapWordSize;
         increase_used(padding);
@@ -309,7 +340,7 @@ HeapWord* ShenandoahFreeSet::try_allocate_in(ShenandoahHeapRegion* r, Shenandoah
       _heap->young_generation()->increase_used(size * HeapWordSize);
       increase_used(size * HeapWordSize);
     } else {
-      // assert(req.is_gc_alloc(), "Should be gc_alloc since req wasn't mutator alloc");
+      assert(req.is_gc_alloc(), "Should be gc_alloc since req wasn't mutator alloc");
 
       // For GC allocations, we advance update_watermark because the objects relocated into this memory during
       // evacuation are not updated during evacuation.  For both young and old regions r, it is essential that all

--- a/src/hotspot/share/gc/shenandoah/shenandoahFreeSet.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahFreeSet.cpp
@@ -316,7 +316,7 @@ HeapWord* ShenandoahFreeSet::try_allocate_in(ShenandoahHeapRegion* r, Shenandoah
       assert(r->top() <= r->end(), "Allocation cannot span end of region");
       assert(req.actual_size() % CardTable::card_size_in_words() == 0, "PLAB start must align with card boundary");
       assert(((uintptr_t) result) % CardTable::card_size_in_words() == 0, "PLAB start must align with card boundary");
-      if (result != nullptr && free > usable_free) {
+      if (free > usable_free) {
         // Account for the alignment padding
         size_t padding = (free - usable_free) * HeapWordSize;
         increase_used(padding);

--- a/src/hotspot/share/gc/shenandoah/shenandoahGeneration.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahGeneration.cpp
@@ -990,7 +990,7 @@ size_t ShenandoahGeneration::adjusted_capacity() const {
 size_t ShenandoahGeneration::adjusted_unaffiliated_regions() const {
   assert(adjusted_capacity() >= used_regions_size(), "adjusted_unaffiliated_regions() cannot return negative");
   assert((adjusted_capacity() - used_regions_size()) % ShenandoahHeapRegion::region_size_bytes() == 0,
-         "adjusted_capacity (" SIZE_FORMAT ") and used regions size (" SIZE_FORMAT ") should be multiples of region_size_bytes",
+         "adjusted capacity (" SIZE_FORMAT ") and used regions size (" SIZE_FORMAT ") should be multiples of region_size_bytes",
          adjusted_capacity(), used_regions_size());
   return (adjusted_capacity() - used_regions_size()) / ShenandoahHeapRegion::region_size_bytes();
 }

--- a/src/hotspot/share/gc/shenandoah/shenandoahHeapRegion.inline.hpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahHeapRegion.inline.hpp
@@ -44,18 +44,26 @@ HeapWord* ShenandoahHeapRegion::allocate_aligned(size_t size, ShenandoahAllocReq
   uintptr_t addr_as_int = (uintptr_t) obj;
 
   size_t unalignment_bytes = addr_as_int % alignment_in_bytes;
-  size_t unalignment_words = unalignment_bytes / HeapWordSize;
-  if (pointer_delta(end(), obj + unalignment_words) >= size) {
-    if (unalignment_words > 0) {
-      size_t pad_words = (alignment_in_bytes / HeapWordSize) - unalignment_words;
-      if (pad_words < ShenandoahHeap::min_fill_size()) {
-        pad_words += (alignment_in_bytes / HeapWordSize);
-      }
+  assert(unalignment_bytes % HeapWordSize == 0, "top should be multiple of HeapWordSize");
+
+  size_t pad_words = 0;
+  if (unalignment_bytes > 0) {
+    pad_words = (alignment_in_bytes - unalignment_bytes) / HeapWordSize;
+  }
+  if ((pad_words > 0) && (pad_words < ShenandoahHeap::min_fill_size())) {
+    pad_words += alignment_in_bytes / HeapWordSize;
+  }
+  if (pointer_delta(end(), obj + pad_words) >= size) {
+    if (pad_words > 0) {
       ShenandoahHeap::fill_with_object(obj, pad_words);
+      // register the filled pad object
       ShenandoahHeap::heap()->card_scan()->register_object(obj);
       obj += pad_words;
     }
 
+    // We don't need to register the PLAB.  Its content will be registered as objects are allocated within it and/or
+    // when the PLAB is retired.
+    ShenandoahHeap::heap()->card_scan()->register_object(obj);
     make_regular_allocation(req.affiliation());
     adjust_alloc_metadata(req.type(), size);
 

--- a/src/hotspot/share/gc/shenandoah/shenandoahHeapRegion.inline.hpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahHeapRegion.inline.hpp
@@ -63,7 +63,6 @@ HeapWord* ShenandoahHeapRegion::allocate_aligned(size_t size, ShenandoahAllocReq
 
     // We don't need to register the PLAB.  Its content will be registered as objects are allocated within it and/or
     // when the PLAB is retired.
-    ShenandoahHeap::heap()->card_scan()->register_object(obj);
     make_regular_allocation(req.affiliation());
     adjust_alloc_metadata(req.type(), size);
 

--- a/src/hotspot/share/gc/shenandoah/shenandoahVerifier.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahVerifier.cpp
@@ -792,9 +792,7 @@ void ShenandoahVerifier::verify_at_safepoint(const char* label,
 
     ShenandoahCalculateRegionStatsClosure cl;
     _heap->heap_region_iterate(&cl);
-
     size_t heap_used = _heap->used();
-
     guarantee(cl.used() == heap_used,
               "%s: heap used size must be consistent: heap-used = " SIZE_FORMAT "%s, regions-used = " SIZE_FORMAT "%s",
               label,


### PR DESCRIPTION
An error was discovered in the implementation and use of allocate_aligned(), which is used to allocate PLABs that align with remembered set card boundaries.  In the previous implementation, if the required alignment padding was smaller than the minimum filler object, the additional card's memory worth of padding might cause the PLAB to span beyond the end of the selected heap region.  This PR addresses the error.  This code successfully runs our internal pipeline of tests without any regressions.

In the current context, this code is not fully exercised due to very limited allocation of PLABs within heap regions that already hold previously allocated PLABs.  This code has also been exercised in the context of code that more aggressively packs multiple PLABs into heap regions.  That additional code will be integrated with a future PR.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed (1 review required, with at least 1 [Committer](https://openjdk.org/bylaws#committer))

### Reviewers
 * [William Kemper](https://openjdk.org/census#wkemper) (@earthling-amzn - Committer)
 * [Y. Srinivas Ramakrishna](https://openjdk.org/census#ysr) (@ysramakrishna - Author)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/shenandoah pull/192/head:pull/192` \
`$ git checkout pull/192`

Update a local copy of the PR: \
`$ git checkout pull/192` \
`$ git pull https://git.openjdk.org/shenandoah pull/192/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 192`

View PR using the GUI difftool: \
`$ git pr show -t 192`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/shenandoah/pull/192.diff">https://git.openjdk.org/shenandoah/pull/192.diff</a>

</details>
