### PR TITLE
Fix use of uninitialized double

### DIFF
--- a/src/hotspot/share/gc/shenandoah/shenandoahGeneration.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahGeneration.cpp
@@ -873,6 +873,7 @@ ShenandoahGeneration::ShenandoahGeneration(GenerationMode generation_mode,
   _generation_mode(generation_mode),
   _task_queues(new ShenandoahObjToScanQueueSet(max_workers)),
   _ref_processor(new ShenandoahReferenceProcessor(MAX2(max_workers, 1U))),
+  _collection_thread_time_s(0.0),
   _affiliated_region_count(0), _used(0), _bytes_allocated_since_gc_start(0),
   _max_capacity(max_capacity), _soft_max_capacity(soft_max_capacity),
   _adjusted_capacity(soft_max_capacity), _heuristics(nullptr) {


### PR DESCRIPTION
Member field was not initialized in constructor

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed (1 review required, with at least 1 [Committer](https://openjdk.org/bylaws#committer))

### Reviewers
 * [Kelvin Nilsen](https://openjdk.org/census#kdnilsen) (@kdnilsen - Committer)
 * [Y. Srinivas Ramakrishna](https://openjdk.org/census#ysr) (@ysramakrishna - Author)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/shenandoah pull/194/head:pull/194` \
`$ git checkout pull/194`

Update a local copy of the PR: \
`$ git checkout pull/194` \
`$ git pull https://git.openjdk.org/shenandoah pull/194/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 194`

View PR using the GUI difftool: \
`$ git pr show -t 194`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/shenandoah/pull/194.diff">https://git.openjdk.org/shenandoah/pull/194.diff</a>

</details>
