### PR TITLE
Plab fallback to minsize

### DIFF
--- a/src/hotspot/share/gc/shenandoah/shenandoahFreeSet.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahFreeSet.cpp
@@ -261,16 +261,8 @@ HeapWord* ShenandoahFreeSet::try_allocate_in(ShenandoahHeapRegion* r, Shenandoah
         adjusted_min_size = adjusted_min_size - remnant + CardTable::card_size_in_words();
       }
       if (size >= adjusted_min_size) {
-#undef KELVIN_DEBUG
-#ifdef KELVIN_DEBUG
-        log_info(gc, ergo)("tai() size (" SIZE_FORMAT ") > adjusted_min_size (" SIZE_FORMAT ")",
-                           size, adjusted_min_size);
-#endif
         result = r->allocate_aligned(size, req, CardTable::card_size());
         assert(result != nullptr, "Allocation cannot fail");
-#ifdef KELVIN_DEBUG
-        log_info(gc, ergo)("aa() returned " PTR_FORMAT, p2i(result));
-#endif
         size = req.actual_size();
         assert(r->top() <= r->end(), "Allocation cannot span end of region");
         // actual_size() will be set to size below.

--- a/src/hotspot/share/gc/shenandoah/shenandoahFreeSet.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahFreeSet.cpp
@@ -262,16 +262,14 @@ HeapWord* ShenandoahFreeSet::try_allocate_in(ShenandoahHeapRegion* r, Shenandoah
       }
       if (size >= adjusted_min_size) {
         result = r->allocate_aligned(size, req, CardTable::card_size());
-        // TODO: Fix allocate_aligned() to provide min_size() allocation if insufficient memory for desired size.
-        //       Then add: assert(result != nullptr, "Allocation cannot fail");
+        assert(result != nullptr, "Allocation cannot fail");
         assert(r->top() <= r->end(), "Allocation cannot span end of region");
         // actual_size() will be set to size below.
         assert((result == nullptr) || (size % CardTable::card_size_in_words() == 0),
                "PLAB size must be multiple of card size");
         assert((result == nullptr) || (((uintptr_t) result) % CardTable::card_size_in_words() == 0),
                "PLAB start must align with card boundary");
-
-        if (result != nullptr && free > usable_free) {
+        if (free > usable_free) {
           // Account for the alignment padding
           size_t padding = (free - usable_free) * HeapWordSize;
           increase_used(padding);

--- a/src/hotspot/share/gc/shenandoah/shenandoahHeapRegion.hpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahHeapRegion.hpp
@@ -348,7 +348,7 @@ public:
   }
 
   // Allocation (return NULL if full)
-  inline HeapWord* allocate_aligned(size_t word_size, ShenandoahAllocRequest req, size_t alignment_in_words);
+  inline HeapWord* allocate_aligned(size_t word_size, ShenandoahAllocRequest &req, size_t alignment_in_words);
 
   // Allocation (return NULL if full)
   inline HeapWord* allocate(size_t word_size, ShenandoahAllocRequest req);


### PR DESCRIPTION
If there is not sufficient memory within a region to allocate the desired size of a PLAB, try to allocate a smaller PLAB that is still larger than the minimum PLAB size.  This allows more efficient packing of PLABs into available old-gen heap regions.

This patch has been exercised by an internal CI regression testing pipeline and has not introduced any regressions.

Modest reductions in evacuation efforts are seen on benchmarks that do heavy promotion.  This is presumably because there are fewer promotion failures, thus less need to repeatedly copy "old" objects within young-gen spaces.  Of note, but not entirely explained, is the observation that some evacuation effort has shifted from mutator threads to GC worker threads.

Some regression in jhiccup pause times were observed.  This will be explored further after additional patches are integrated.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed (1 review required, with at least 1 [Committer](https://openjdk.org/bylaws#committer))

### Reviewers
 * [William Kemper](https://openjdk.org/census#wkemper) (@earthling-amzn - Committer)
 * [Y. Srinivas Ramakrishna](https://openjdk.org/census#ysr) (@ysramakrishna - Author)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/shenandoah pull/195/head:pull/195` \
`$ git checkout pull/195`

Update a local copy of the PR: \
`$ git checkout pull/195` \
`$ git pull https://git.openjdk.org/shenandoah pull/195/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 195`

View PR using the GUI difftool: \
`$ git pr show -t 195`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/shenandoah/pull/195.diff">https://git.openjdk.org/shenandoah/pull/195.diff</a>

</details>
