### PR TITLE
Fix verification of remembered set at mark start

### DIFF
--- a/src/hotspot/share/gc/shenandoah/shenandoahHeap.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahHeap.cpp
@@ -3151,6 +3151,7 @@ void ShenandoahHeap::verify_rem_set_at_mark() {
 
   while (iterator.has_next()) {
     ShenandoahHeapRegion* r = iterator.next();
+    HeapWord* tams = ctx? ctx->top_at_mark_start(r): nullptr;
     if (r == nullptr)
       break;
     if (r->is_old() && r->is_active()) {
@@ -3190,7 +3191,8 @@ void ShenandoahHeap::verify_rem_set_at_mark() {
             obj_addr += obj->size();
           } else {
             // This object is not live so we don't verify dirty cards contained therein
-            obj_addr = ctx->get_next_marked_addr(obj_addr, top);
+            assert(tams != nullptr, "If object is not live, ctx and tams should be non-null");
+            obj_addr = ctx->get_next_marked_addr(obj_addr, tams);
           }
         }
       } // else, we ignore humongous continuation region

--- a/src/hotspot/share/gc/shenandoah/shenandoahHeap.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahHeap.cpp
@@ -3172,49 +3172,26 @@ void ShenandoahHeap::verify_rem_set_at_mark() {
                                           "Verify init-mark remembered set violation", "object not properly registered", __FILE__, __LINE__);
         }
       } else if (!r->is_humongous()) {
-        if (ctx) {
-          // Require appropriate dirty card marks on marked objects between bottom and TAMS
-          HeapWord* tams = ctx->top_at_mark_start(r);
-          while (obj_addr < tams) {
-            oop obj = cast_to_oop(obj_addr);
-            if (ctx->is_marked(obj)) {
-              // For regular objects (not object arrays), if the card holding the start of the object is dirty,
-              // we do not need to verify that cards spanning interesting pointers within this object are dirty.
-              if (!scanner->is_card_dirty(obj_addr) || obj->is_objArray()) {
-                obj->oop_iterate(&check_interesting_pointers);
-              }
-              // else, object's start is marked dirty and obj is not an objArray, so any interesting pointers are covered
-              if (!scanner->verify_registration(obj_addr, ctx)) {
-                ShenandoahAsserts::print_failure(ShenandoahAsserts::_safe_all, obj, obj_addr, NULL,
-                                                 "Verify init-mark remembered set violation",
-                                                 "object not properly registered", __FILE__, __LINE__);
-              }
-              obj_addr += obj->size();
-            } else {
-              // This object is not live so we don't verify dirty cards contained therein.  If no more marked objects
-              // below TAMS, get_next_marked_addr() returns TAMS.
-              obj_addr = ctx->get_next_marked_addr(obj_addr, tams);
-            }
-          }
-        }
-        // Require appropriate dirty card marks on all objects throughout the remainder of this heap region.
-        // At this point obj_addr either equals bottom() with ctx == nullptr, or obj_addr == TAMS
-        // Between obj_addr and top, every object is considered live.
         HeapWord* top = r->top();
         while (obj_addr < top) {
           oop obj = cast_to_oop(obj_addr);
-          // For regular objects (not object arrays), if the card holding the start of the object is dirty,
-          // we do not need to verify that cards spanning interesting pointers within this object are dirty.
-          if (!scanner->is_card_dirty(obj_addr) || obj->is_objArray()) {
-            obj->oop_iterate(&check_interesting_pointers);
+          // ctx->is_marked() returns true if mark bit set (TAMS not relevant during init mark)
+          if (!ctx || ctx->is_marked(obj)) {
+            // For regular objects (not object arrays), if the card holding the start of the object is dirty,
+            // we do not need to verify that cards spanning interesting pointers within this object are dirty.
+            if (!scanner->is_card_dirty(obj_addr) || obj->is_objArray()) {
+              obj->oop_iterate(&check_interesting_pointers);
+            }
+            // else, object's start is marked dirty and obj is not an objArray, so any interesting pointers are covered
+            if (!scanner->verify_registration(obj_addr, ctx)) {
+              ShenandoahAsserts::print_failure(ShenandoahAsserts::_safe_all, obj, obj_addr, NULL,
+                                               "Verify init-mark remembered set violation", "object not properly registered", __FILE__, __LINE__);
+            }
+            obj_addr += obj->size();
+          } else {
+            // This object is not live so we don't verify dirty cards contained therein
+            obj_addr = ctx->get_next_marked_addr(obj_addr, top);
           }
-          // else, object's start is marked dirty and obj is not an objArray, so any interesting pointers are covered
-          if (!scanner->verify_registration(obj_addr, ctx)) {
-            ShenandoahAsserts::print_failure(ShenandoahAsserts::_safe_all, obj, obj_addr, NULL,
-                                             "Verify init-mark remembered set violation",
-                                             "object not properly registered", __FILE__, __LINE__);
-          }
-          obj_addr += obj->size();
         }
       } // else, we ignore humongous continuation region
     } // else, this is not an OLD region so we ignore it


### PR DESCRIPTION
All objects residing between TAMS and top() within each old region are examined independent of the marking context.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed (1 review required, with at least 1 [Committer](https://openjdk.org/bylaws#committer))

### Reviewers
 * [William Kemper](https://openjdk.org/census#wkemper) (@earthling-amzn - Committer)
 * [Y. Srinivas Ramakrishna](https://openjdk.org/census#ysr) (@ysramakrishna - Author)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/shenandoah pull/197/head:pull/197` \
`$ git checkout pull/197`

Update a local copy of the PR: \
`$ git checkout pull/197` \
`$ git pull https://git.openjdk.org/shenandoah pull/197/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 197`

View PR using the GUI difftool: \
`$ git pr show -t 197`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/shenandoah/pull/197.diff">https://git.openjdk.org/shenandoah/pull/197.diff</a>

</details>
