### PR TITLE
Broaden plab region search

### DIFF
--- a/src/hotspot/share/gc/shenandoah/shenandoahConcurrentGC.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahConcurrentGC.cpp
@@ -242,14 +242,6 @@ bool ShenandoahConcurrentGC::collect(GCCause::Cause cause) {
       heap->set_old_evac_reserve(0);
       heap->reset_old_evac_expended();
       heap->set_promoted_reserve(0);
-      log_info(gc, ergo)("At end of Concurrent GC, old_available: " SIZE_FORMAT "%s out of total: " SIZE_FORMAT "%s,"
-                         " young_available: " SIZE_FORMAT "%s out of total: " SIZE_FORMAT "%s",
-                         byte_size_in_proper_unit(old_available), proper_unit_for_byte_size(old_available),
-                         byte_size_in_proper_unit(old_gen->soft_max_capacity()),
-                         proper_unit_for_byte_size(old_gen->soft_max_capacity()),
-                         byte_size_in_proper_unit(young_available), proper_unit_for_byte_size(young_available),
-                         byte_size_in_proper_unit(young_gen->soft_max_capacity()),
-                         proper_unit_for_byte_size(young_gen->soft_max_capacity()));
     }
   }
   return true;

--- a/src/hotspot/share/gc/shenandoah/shenandoahConcurrentGC.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahConcurrentGC.cpp
@@ -242,12 +242,16 @@ bool ShenandoahConcurrentGC::collect(GCCause::Cause cause) {
       heap->set_old_evac_reserve(0);
       heap->reset_old_evac_expended();
       heap->set_promoted_reserve(0);
+      log_info(gc, ergo)("At end of Concurrent GC, old_available: " SIZE_FORMAT "%s out of total: " SIZE_FORMAT "%s,"
+                         " young_available: " SIZE_FORMAT "%s out of total: " SIZE_FORMAT "%s",
+                         byte_size_in_proper_unit(old_available), proper_unit_for_byte_size(old_available),
+                         byte_size_in_proper_unit(old_gen->soft_max_capacity()),
+                         proper_unit_for_byte_size(old_gen->soft_max_capacity()),
+                         byte_size_in_proper_unit(young_available), proper_unit_for_byte_size(young_available),
+                         byte_size_in_proper_unit(young_gen->soft_max_capacity()),
+                         proper_unit_for_byte_size(young_gen->soft_max_capacity()));
     }
-    log_info(gc, ergo)("At end of Concurrent GC, old_available: " SIZE_FORMAT "%s, young_available: " SIZE_FORMAT "%s",
-                       byte_size_in_proper_unit(old_available), proper_unit_for_byte_size(old_available),
-                       byte_size_in_proper_unit(young_available), proper_unit_for_byte_size(young_available));
   }
-
   return true;
 }
 

--- a/src/hotspot/share/gc/shenandoah/shenandoahControlThread.hpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahControlThread.hpp
@@ -190,7 +190,6 @@ public:
   void service_concurrent_cycle(const ShenandoahHeap* heap, ShenandoahGeneration* generation, GCCause::Cause &cause,
                                 bool do_old_gc_bootstrap);
 
-  void log_heap_status(const ShenandoahHeap* heap);
 };
 
 #endif // SHARE_GC_SHENANDOAH_SHENANDOAHCONTROLTHREAD_HPP

--- a/src/hotspot/share/gc/shenandoah/shenandoahDegeneratedGC.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahDegeneratedGC.cpp
@@ -56,16 +56,7 @@ bool ShenandoahDegenGC::collect(GCCause::Cause cause) {
   vmop_degenerated();
   ShenandoahHeap* heap = ShenandoahHeap::heap();
   if (heap->mode()->is_generational()) {
-    size_t old_available = heap->old_generation()->available();
-    size_t young_available = heap->young_generation()->available();
-    log_info(gc, ergo)("At end of Degenerated GC, old_available: " SIZE_FORMAT "%s out of total: " SIZE_FORMAT "%s,"
-                       " young_available: " SIZE_FORMAT "%s out of total: " SIZE_FORMAT "%s",
-                       byte_size_in_proper_unit(old_available), proper_unit_for_byte_size(old_available),
-                       byte_size_in_proper_unit(heap->old_generation()->soft_max_capacity()),
-                       proper_unit_for_byte_size(heap->old_generation()->soft_max_capacity()),
-                       byte_size_in_proper_unit(young_available), proper_unit_for_byte_size(young_available),
-                       byte_size_in_proper_unit(heap->young_generation()->soft_max_capacity()),
-                       proper_unit_for_byte_size(heap->young_generation()->soft_max_capacity()));
+    heap->log_heap_status("At end of Degenerated GC");
   }
   return true;
 }

--- a/src/hotspot/share/gc/shenandoah/shenandoahDegeneratedGC.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahDegeneratedGC.cpp
@@ -58,9 +58,14 @@ bool ShenandoahDegenGC::collect(GCCause::Cause cause) {
   if (heap->mode()->is_generational()) {
     size_t old_available = heap->old_generation()->available();
     size_t young_available = heap->young_generation()->available();
-    log_info(gc, ergo)("At end of Degenerated GC, old_available: " SIZE_FORMAT "%s, young_available: " SIZE_FORMAT "%s",
+    log_info(gc, ergo)("At end of Degenerated GC, old_available: " SIZE_FORMAT "%s out of total: " SIZE_FORMAT "%s,"
+                       " young_available: " SIZE_FORMAT "%s out of total: " SIZE_FORMAT "%s",
                        byte_size_in_proper_unit(old_available), proper_unit_for_byte_size(old_available),
-                       byte_size_in_proper_unit(young_available), proper_unit_for_byte_size(young_available));
+                       byte_size_in_proper_unit(heap->old_generation()->soft_max_capacity()),
+                       proper_unit_for_byte_size(heap->old_generation()->soft_max_capacity()),
+                       byte_size_in_proper_unit(young_available), proper_unit_for_byte_size(young_available),
+                       byte_size_in_proper_unit(heap->young_generation()->soft_max_capacity()),
+                       proper_unit_for_byte_size(heap->young_generation()->soft_max_capacity()));
   }
   return true;
 }

--- a/src/hotspot/share/gc/shenandoah/shenandoahFreeSet.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahFreeSet.cpp
@@ -75,7 +75,7 @@ HeapWord* ShenandoahFreeSet::allocate_with_old_affiliation(ShenandoahAllocReques
 
   size_t rightmost = MAX2(_collector_rightmost, _mutator_rightmost);
   size_t leftmost = MIN2(_collector_leftmost, _mutator_leftmost);
-  
+
   for (size_t c = rightmost + 1; c > leftmost; c--) {
     // size_t is unsigned, need to dodge underflow when _leftmost = 0
     size_t idx = c - 1;

--- a/src/hotspot/share/gc/shenandoah/shenandoahFreeSet.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahFreeSet.cpp
@@ -76,53 +76,20 @@ HeapWord* ShenandoahFreeSet::allocate_with_old_affiliation(ShenandoahAllocReques
   size_t rightmost = MAX2(_collector_rightmost, _mutator_rightmost);
   size_t leftmost = MIN2(_collector_leftmost, _mutator_leftmost);
   
-#undef KELVIN_PLAB
-#ifdef KELVIN_PLAB
-  size_t affiliates = 0;
-  size_t uncollecteds = 0;
-  size_t available = 0;
-  size_t largest_free = 0;
-#endif
-
   for (size_t c = rightmost + 1; c > leftmost; c--) {
     // size_t is unsigned, need to dodge underflow when _leftmost = 0
     size_t idx = c - 1;
     ShenandoahHeapRegion* r = _heap->get_region(idx);
     if (r->affiliation() == affiliation && !r->is_humongous()) {
-#ifdef KELVIN_PLAB
-      affiliates++;
-#endif
       if (!r->is_cset() && !has_no_alloc_capacity(r)) {
-#ifdef KELVIN_PLAB
-        uncollecteds++;
-        available += r->free();
-        if (r->free() > largest_free) {
-          largest_free = r->free();
-        }
-#endif
         HeapWord* result = try_allocate_in(r, req, in_new_region);
         if (result != NULL) {
-#ifdef KELVIN_PLAB
-          stringStream ss;
-          ss.print("awoa allocated " SIZE_FORMAT " (target: " SIZE_FORMAT ", min: " SIZE_FORMAT ") in region: ",
-                   req.actual_size(), req.size(), req.min_size());
-          r->print_on(&ss);
-          log_info(gc, ergo)("%s", ss.freeze());
-#endif
           return result;
         }
       }
     }
   }
-
-#ifdef KELVIN_PLAB
-  log_info(gc, ergo)("awoa failed to allocate size: " SIZE_FORMAT ", min: " SIZE_FORMAT ", affiliates: " SIZE_FORMAT
-                     ", uncollecteds: " SIZE_FORMAT ", largest free: " SIZE_FORMAT ", available: " SIZE_FORMAT
-                     " in range " SIZE_FORMAT " to " SIZE_FORMAT,
-                     req.size(), req.min_size(), affiliates, uncollecteds, largest_free / HeapWordSize,
-                     available / HeapWordSize, leftmost, rightmost);
-#endif
-  return NULL;
+  return nullptr;
 }
 
 HeapWord* ShenandoahFreeSet::allocate_with_affiliation(ShenandoahRegionAffiliation affiliation, ShenandoahAllocRequest& req, bool& in_new_region) {

--- a/src/hotspot/share/gc/shenandoah/shenandoahFreeSet.hpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahFreeSet.hpp
@@ -50,6 +50,7 @@ private:
 
   HeapWord* try_allocate_in(ShenandoahHeapRegion* region, ShenandoahAllocRequest& req, bool& in_new_region);
   HeapWord* allocate_with_affiliation(ShenandoahRegionAffiliation affiliation, ShenandoahAllocRequest& req, bool& in_new_region);
+  HeapWord* allocate_with_old_affiliation(ShenandoahAllocRequest& req, bool& in_new_region);
 
   // While holding the heap lock, allocate memory for a single object which is to be entirely contained
   // within a single HeapRegion as characterized by req.  The req.size() value is known to be less than or

--- a/src/hotspot/share/gc/shenandoah/shenandoahFullGC.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahFullGC.cpp
@@ -174,16 +174,7 @@ void ShenandoahFullGC::op_full(GCCause::Cause cause) {
 
   metrics.snap_after();
   if (heap->mode()->is_generational()) {
-    size_t old_available = heap->old_generation()->available();
-    size_t young_available = heap->young_generation()->available();
-    log_info(gc, ergo)("At end of Full GC,  old_available: " SIZE_FORMAT "%s out of total: " SIZE_FORMAT "%s,"
-                       " young_available: " SIZE_FORMAT "%s out of total: " SIZE_FORMAT "%s",
-                       byte_size_in_proper_unit(old_available), proper_unit_for_byte_size(old_available),
-                       byte_size_in_proper_unit(heap->old_generation()->soft_max_capacity()),
-                       proper_unit_for_byte_size(heap->old_generation()->soft_max_capacity()),
-                       byte_size_in_proper_unit(young_available), proper_unit_for_byte_size(young_available),
-                       byte_size_in_proper_unit(heap->young_generation()->soft_max_capacity()),
-                       proper_unit_for_byte_size(heap->young_generation()->soft_max_capacity()));
+    heap->log_heap_status("At end of Full GC");
   }
   if (metrics.is_good_progress()) {
     ShenandoahHeap::heap()->notify_gc_progress();
@@ -751,7 +742,6 @@ void ShenandoahPrepareForCompactionTask::work(uint worker_id) {
       if (from_region->has_live()) {
         _heap->marked_object_iterate(from_region, &cl);
       }
-
       // Compacted the region to somewhere else? From-region is empty then.
       if (!cl.is_compact_same_region()) {
         empty_regions.append(from_region);

--- a/src/hotspot/share/gc/shenandoah/shenandoahFullGC.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahFullGC.cpp
@@ -176,9 +176,14 @@ void ShenandoahFullGC::op_full(GCCause::Cause cause) {
   if (heap->mode()->is_generational()) {
     size_t old_available = heap->old_generation()->available();
     size_t young_available = heap->young_generation()->available();
-    log_info(gc, ergo)("At end of Full GC, old_available: " SIZE_FORMAT "%s, young_available: " SIZE_FORMAT "%s",
+    log_info(gc, ergo)("At end of Full GC,  old_available: " SIZE_FORMAT "%s out of total: " SIZE_FORMAT "%s,"
+                       " young_available: " SIZE_FORMAT "%s out of total: " SIZE_FORMAT "%s",
                        byte_size_in_proper_unit(old_available), proper_unit_for_byte_size(old_available),
-                       byte_size_in_proper_unit(young_available), proper_unit_for_byte_size(young_available));
+                       byte_size_in_proper_unit(heap->old_generation()->soft_max_capacity()),
+                       proper_unit_for_byte_size(heap->old_generation()->soft_max_capacity()),
+                       byte_size_in_proper_unit(young_available), proper_unit_for_byte_size(young_available),
+                       byte_size_in_proper_unit(heap->young_generation()->soft_max_capacity()),
+                       proper_unit_for_byte_size(heap->young_generation()->soft_max_capacity()));
   }
   if (metrics.is_good_progress()) {
     ShenandoahHeap::heap()->notify_gc_progress();

--- a/src/hotspot/share/gc/shenandoah/shenandoahGeneration.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahGeneration.cpp
@@ -142,7 +142,7 @@ void ShenandoahGeneration::increase_allocated(size_t bytes) {
   Atomic::add(&_bytes_allocated_since_gc_start, bytes, memory_order_relaxed);
 }
 
-void ShenandoahGeneration::log_status() const {
+void ShenandoahGeneration::log_status(const char *msg) const {
   typedef LogTarget(Info, gc, ergo) LogGcInfo;
 
   if (!LogGcInfo::is_enabled()) {
@@ -156,14 +156,17 @@ void ShenandoahGeneration::log_status() const {
   size_t v_soft_max_capacity = soft_max_capacity();
   size_t v_max_capacity = max_capacity();
   size_t v_available = available();
-  LogGcInfo::print("%s generation used: " SIZE_FORMAT "%s, used regions: " SIZE_FORMAT "%s, "
-                   "soft capacity: " SIZE_FORMAT "%s, max capacity: " SIZE_FORMAT " %s, available: " SIZE_FORMAT " %s",
-                   name(),
+  size_t v_adjusted_avail = adjusted_available();
+  LogGcInfo::print("%s: %s generation used: " SIZE_FORMAT "%s, used regions: " SIZE_FORMAT "%s, "
+                   "soft capacity: " SIZE_FORMAT "%s, max capacity: " SIZE_FORMAT "%s, available: " SIZE_FORMAT "%s, "
+                   "adjusted available: " SIZE_FORMAT "%s",
+                   msg, name(),
                    byte_size_in_proper_unit(v_used), proper_unit_for_byte_size(v_used),
                    byte_size_in_proper_unit(v_used_regions), proper_unit_for_byte_size(v_used_regions),
                    byte_size_in_proper_unit(v_soft_max_capacity), proper_unit_for_byte_size(v_soft_max_capacity),
                    byte_size_in_proper_unit(v_max_capacity), proper_unit_for_byte_size(v_max_capacity),
-                   byte_size_in_proper_unit(v_available), proper_unit_for_byte_size(v_available));
+                   byte_size_in_proper_unit(v_available), proper_unit_for_byte_size(v_available),
+                   byte_size_in_proper_unit(v_adjusted_avail), proper_unit_for_byte_size(v_adjusted_avail));
 }
 
 void ShenandoahGeneration::reset_mark_bitmap() {

--- a/src/hotspot/share/gc/shenandoah/shenandoahGeneration.hpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahGeneration.hpp
@@ -125,7 +125,7 @@ private:
     _soft_max_capacity = soft_max_capacity;
   }
 
-  void log_status() const;
+  void log_status(const char* msg) const;
 
   // Used directly by FullGC
   void reset_mark_bitmap();

--- a/src/hotspot/share/gc/shenandoah/shenandoahHeap.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahHeap.cpp
@@ -3307,3 +3307,13 @@ ShenandoahGeneration* ShenandoahHeap::generation_for(ShenandoahRegionAffiliation
   ShouldNotReachHere();
   return nullptr;
 }
+
+void ShenandoahHeap::log_heap_status(const char* msg) const {
+  if (mode()->is_generational()) {
+    young_generation()->log_status(msg);
+    old_generation()->log_status(msg);
+  } else {
+    global_generation()->log_status(msg);
+  }
+}
+

--- a/src/hotspot/share/gc/shenandoah/shenandoahHeap.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahHeap.cpp
@@ -3172,48 +3172,26 @@ void ShenandoahHeap::verify_rem_set_at_mark() {
                                           "Verify init-mark remembered set violation", "object not properly registered", __FILE__, __LINE__);
         }
       } else if (!r->is_humongous()) {
-        if (ctx) {
-          // Require appropriate dirty card marks on marked objects between bottom and TAMS
-          HeapWord* tams = ctx->top_at_mark_start(r);
-          while (obj_addr < tams) {
-            oop obj = cast_to_oop(obj_addr);
-            if (ctx->is_marked(obj)) {
-              // For regular objects (not object arrays), if the card holding the start of the object is dirty,
-              // we do not need to verify that cards spanning interesting pointers within this object are dirty.
-              if (!scanner->is_card_dirty(obj_addr) || obj->is_objArray()) {
-                obj->oop_iterate(&check_interesting_pointers);
-              }
-              // else, object's start is marked dirty and obj is not an objArray, so any interesting pointers are covered
-              if (!scanner->verify_registration(obj_addr, ctx)) {
-                ShenandoahAsserts::print_failure(ShenandoahAsserts::_safe_all, obj, obj_addr, NULL,
-                                                 "Verify init-mark remembered set violation",
-                                                 "object not properly registered", __FILE__, __LINE__);
-              }
-              obj_addr += obj->size();
-            } else {
-              // This object is not live so we don't verify dirty cards contained therein.  If no more marked objects
-              // below TAMS, get_next_marked_addr() returns TAMS.
-              obj_addr = ctx->get_next_marked_addr(obj_addr, tams);
-            }
-          }
-        }
-        // At this point obj_addr either equals bottom() with ctx == nullptr, or obj_addr == TAMS
-        // Between obj_addr and top, every object is considered live.
         HeapWord* top = r->top();
         while (obj_addr < top) {
           oop obj = cast_to_oop(obj_addr);
-          // For regular objects (not object arrays), if the card holding the start of the object is dirty,
-          // we do not need to verify that cards spanning interesting pointers within this object are dirty.
-          if (!scanner->is_card_dirty(obj_addr) || obj->is_objArray()) {
-            obj->oop_iterate(&check_interesting_pointers);
+          // ctx->is_marked() returns true if mark bit set (TAMS not relevant during init mark)
+          if (!ctx || ctx->is_marked(obj)) {
+            // For regular objects (not object arrays), if the card holding the start of the object is dirty,
+            // we do not need to verify that cards spanning interesting pointers within this object are dirty.
+            if (!scanner->is_card_dirty(obj_addr) || obj->is_objArray()) {
+              obj->oop_iterate(&check_interesting_pointers);
+            }
+            // else, object's start is marked dirty and obj is not an objArray, so any interesting pointers are covered
+            if (!scanner->verify_registration(obj_addr, ctx)) {
+              ShenandoahAsserts::print_failure(ShenandoahAsserts::_safe_all, obj, obj_addr, NULL,
+                                               "Verify init-mark remembered set violation", "object not properly registered", __FILE__, __LINE__);
+            }
+            obj_addr += obj->size();
+          } else {
+            // This object is not live so we don't verify dirty cards contained therein
+            obj_addr = ctx->get_next_marked_addr(obj_addr, top);
           }
-          // else, object's start is marked dirty and obj is not an objArray, so any interesting pointers are covered
-          if (!scanner->verify_registration(obj_addr, ctx)) {
-            ShenandoahAsserts::print_failure(ShenandoahAsserts::_safe_all, obj, obj_addr, NULL,
-                                             "Verify init-mark remembered set violation",
-                                             "object not properly registered", __FILE__, __LINE__);
-          }
-          obj_addr += obj->size();
         }
       } // else, we ignore humongous continuation region
     } // else, this is not an OLD region so we ignore it

--- a/src/hotspot/share/gc/shenandoah/shenandoahHeap.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahHeap.cpp
@@ -1,4 +1,4 @@
-/*
+*
  * Copyright (c) 2013, 2022, Red Hat, Inc. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
@@ -3190,7 +3190,7 @@ void ShenandoahHeap::verify_rem_set_at_mark() {
             obj_addr += obj->size();
           } else {
             // This object is not live so we don't verify dirty cards contained therein
-            obj_addr = ctx->get_next_marked_addr(obj_addr, top);
+            obj_addr = ctx->get_next_marked_addr(obj_addr, tams);
           }
         }
       } // else, we ignore humongous continuation region

--- a/src/hotspot/share/gc/shenandoah/shenandoahHeap.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahHeap.cpp
@@ -1,4 +1,4 @@
-*
+/*
  * Copyright (c) 2013, 2022, Red Hat, Inc. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
@@ -3151,6 +3151,7 @@ void ShenandoahHeap::verify_rem_set_at_mark() {
 
   while (iterator.has_next()) {
     ShenandoahHeapRegion* r = iterator.next();
+    HeapWord* tams = ctx? ctx->top_at_mark_start(r): nullptr;
     if (r == nullptr)
       break;
     if (r->is_old() && r->is_active()) {
@@ -3190,6 +3191,7 @@ void ShenandoahHeap::verify_rem_set_at_mark() {
             obj_addr += obj->size();
           } else {
             // This object is not live so we don't verify dirty cards contained therein
+            assert(tams != nullptr, "If object is not live, ctx and tams should be non-null");
             obj_addr = ctx->get_next_marked_addr(obj_addr, tams);
           }
         }

--- a/src/hotspot/share/gc/shenandoah/shenandoahHeap.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahHeap.cpp
@@ -3172,27 +3172,48 @@ void ShenandoahHeap::verify_rem_set_at_mark() {
                                           "Verify init-mark remembered set violation", "object not properly registered", __FILE__, __LINE__);
         }
       } else if (!r->is_humongous()) {
+        if (ctx) {
+          // Require appropriate dirty card marks on marked objects between bottom and TAMS
+          HeapWord* tams = ctx->top_at_mark_start(r);
+          while (obj_addr < tams) {
+            oop obj = cast_to_oop(obj_addr);
+            if (ctx->is_marked(obj)) {
+              // For regular objects (not object arrays), if the card holding the start of the object is dirty,
+              // we do not need to verify that cards spanning interesting pointers within this object are dirty.
+              if (!scanner->is_card_dirty(obj_addr) || obj->is_objArray()) {
+                obj->oop_iterate(&check_interesting_pointers);
+              }
+              // else, object's start is marked dirty and obj is not an objArray, so any interesting pointers are covered
+              if (!scanner->verify_registration(obj_addr, ctx)) {
+                ShenandoahAsserts::print_failure(ShenandoahAsserts::_safe_all, obj, obj_addr, NULL,
+                                                 "Verify init-mark remembered set violation",
+                                                 "object not properly registered", __FILE__, __LINE__);
+              }
+              obj_addr += obj->size();
+            } else {
+              // This object is not live so we don't verify dirty cards contained therein.  If no more marked objects
+              // below TAMS, get_next_marked_addr() returns TAMS.
+              obj_addr = ctx->get_next_marked_addr(obj_addr, tams);
+            }
+          }
+        }
+        // At this point obj_addr either equals bottom() with ctx == nullptr, or obj_addr == TAMS
+        // Between obj_addr and top, every object is considered live.
         HeapWord* top = r->top();
         while (obj_addr < top) {
           oop obj = cast_to_oop(obj_addr);
-          // ctx->is_marked() returns true if mark bit set (TAMS not relevant during init mark)
-          if (!ctx || ctx->is_marked(obj)) {
-            // For regular objects (not object arrays), if the card holding the start of the object is dirty,
-            // we do not need to verify that cards spanning interesting pointers within this object are dirty.
-            if (!scanner->is_card_dirty(obj_addr) || obj->is_objArray()) {
-              obj->oop_iterate(&check_interesting_pointers);
-            }
-            // else, object's start is marked dirty and obj is not an objArray, so any interesting pointers are covered
-            if (!scanner->verify_registration(obj_addr, ctx)) {
-              ShenandoahAsserts::print_failure(ShenandoahAsserts::_safe_all, obj, obj_addr, NULL,
-                                            "Verify init-mark remembered set violation", "object not properly registered", __FILE__, __LINE__);
-            }
-            obj_addr += obj->size();
-          } else {
-            // This object is not live so we don't verify dirty cards contained therein
-            assert(ctx->top_at_mark_start(r) == top, "Expect tams == top at start of mark.");
-            obj_addr = ctx->get_next_marked_addr(obj_addr, top);
+          // For regular objects (not object arrays), if the card holding the start of the object is dirty,
+          // we do not need to verify that cards spanning interesting pointers within this object are dirty.
+          if (!scanner->is_card_dirty(obj_addr) || obj->is_objArray()) {
+            obj->oop_iterate(&check_interesting_pointers);
           }
+          // else, object's start is marked dirty and obj is not an objArray, so any interesting pointers are covered
+          if (!scanner->verify_registration(obj_addr, ctx)) {
+            ShenandoahAsserts::print_failure(ShenandoahAsserts::_safe_all, obj, obj_addr, NULL,
+                                             "Verify init-mark remembered set violation",
+                                             "object not properly registered", __FILE__, __LINE__);
+          }
+          obj_addr += obj->size();
         }
       } // else, we ignore humongous continuation region
     } // else, this is not an OLD region so we ignore it

--- a/src/hotspot/share/gc/shenandoah/shenandoahHeap.hpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahHeap.hpp
@@ -855,6 +855,9 @@ public:
   static inline uint get_object_age(oop obj);
 
   void transfer_old_pointers_from_satb();
+
+  void log_heap_status(const char *msg) const;
+
 private:
   void trash_cset_regions();
 


### PR DESCRIPTION
Recent testing revealed that old-gen heap regions were being ignored in the search to satisfy new PLAB allocation requests.  It was discovered that many of these regions are found within ranges of the ShenandoahFreeSet that are not considered to be "is_collector_free()".

This is a first step in a two-step change.  In this patch, we broaden the search for old-gen heap regions that have available memory to include regions that are not is_collector_free.  In a second step of this improvement, we intend to restructure the implementation of the ShenandoahFreeSet to better distinguish ranges of regions that hold young-gen survivors, which ranges hold old-gen, and which ranges are intended to serve as mutator allocations.

On an Extremem workload that allocates roughly 626 M/s in a total heap size of 49G with an old-gen usage of 18.7G, we saw significant improvements compared to mainline generational Shenandoah implementation:

1. Concurrent GC passes decreased from 606 to 493 (19% improvement)
2. Degenerated GC passes decreased from 17 to 3 (82% improvement)
3. Full GCs decreased from 15 to 3 (80% improvement)
4. P50 latency for Customer Preparation Processing (CPP) improved from 1798 us to 1735 us (3.5%)
5. P100 latency for CPP improved from 25_636_285 us to 9_148_580 us (64% improvement)

Across a broad assortment of performance related CI tests, we also benefits on x86:

-74.24% extremem-phased/do_nothing_p99 p=0.00061
  Control:      2.318s  (+/-941.25ms)         80
  Test:         1.330s  (+/-  1.01s )         15

-15.70% extremem-phased/context_switch_count p=0.02032
  Control:  28188.234   (+/-5868.23  )         80
  Test:     24362.538   (+/-4260.19  )         15

-6.26% extremem-phased/do_nothing_p50 p=0.00246
  Control:    603.203us (+/- 38.32us)         80
  Test:       567.692us (+/- 50.34us)         15

And on aarch64:

+22.92% specjbb2015/sla_10000_jops p=0.01104
  Control:   2607.153   (+/-799.74  )         90
  Test:      3204.615   (+/-592.15  )         15

-5.85% extremem-phased/do_nothing_p50 p=0.00675
  Control:    608.153us (+/- 44.52us)         90
  Test:       574.538us (+/- 47.49us)         15

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed (1 review required, with at least 1 [Committer](https://openjdk.org/bylaws#committer))

### Reviewers
 * [William Kemper](https://openjdk.org/census#wkemper) (@earthling-amzn - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/shenandoah pull/198/head:pull/198` \
`$ git checkout pull/198`

Update a local copy of the PR: \
`$ git checkout pull/198` \
`$ git pull https://git.openjdk.org/shenandoah pull/198/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 198`

View PR using the GUI difftool: \
`$ git pr show -t 198`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/shenandoah/pull/198.diff">https://git.openjdk.org/shenandoah/pull/198.diff</a>

</details>
