### PR TITLE
Use whole number of regions when resizing generations

### DIFF
--- a/src/hotspot/share/gc/shenandoah/shenandoahMmuTracker.hpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahMmuTracker.hpp
@@ -101,23 +101,23 @@ private:
   // true otherwise.
   bool _use_adaptive_sizing;
 
-  size_t _min_desired_young_size;
-  size_t _max_desired_young_size;
+  size_t _min_desired_young_regions;
+  size_t _max_desired_young_regions;
 
   double _resize_increment;
   ShenandoahMmuTracker* _mmu_tracker;
 
-  static size_t calculate_min_size(size_t heap_size);
-  static size_t calculate_max_size(size_t heap_size);
+  static size_t calculate_min_young_regions(size_t heap_region_count);
+  static size_t calculate_max_young_regions(size_t heap_region_count);
 
   // Update the given values for minimum and maximum young gen length in regions
   // given the number of heap regions depending on the kind of sizing algorithm.
-  void recalculate_min_max_young_length(size_t heap_size);
+  void recalculate_min_max_young_length(size_t heap_region_count);
 
   // These two methods are responsible for enforcing the minimum and maximum
   // constraints for the size of the generations.
-  size_t adjust_transfer_from_young(ShenandoahGeneration* from, size_t bytes_to_transfer) const;
-  size_t adjust_transfer_to_young(ShenandoahGeneration* to, size_t bytes_to_transfer) const;
+  size_t adjust_transfer_from_young(ShenandoahGeneration* from, size_t regions_to_transfer) const;
+  size_t adjust_transfer_to_young(ShenandoahGeneration* to, size_t regions_to_transfer) const;
 
   // This will attempt to transfer capacity from one generation to the other. It
   // returns true if a transfer is made, false otherwise.
@@ -129,11 +129,16 @@ public:
   // depending on the sizing algorithm.
   void heap_size_changed(size_t heap_size);
 
-  size_t min_young_size() const {
-    return _min_desired_young_size;
+  // Minimum size of young generation in bytes as multiple of region size.
+  size_t min_young_size() const;
+  size_t min_young_regions() const {
+    return _min_desired_young_regions;
   }
-  size_t max_young_size() const {
-    return _max_desired_young_size;
+
+  // Maximum size of young generation in bytes as multiple of region size.
+  size_t max_young_size() const;
+  size_t max_young_regions() const {
+    return _max_desired_young_regions;
   }
 
   bool use_adaptive_sizing() const {


### PR DESCRIPTION
This avoids overflowing calculations when using a 32 bit word - it also simplifies some of the operations. All of the github actions are succeeding now.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed (1 review required, with at least 1 [Committer](https://openjdk.org/bylaws#committer))

### Reviewers
 * [Kelvin Nilsen](https://openjdk.org/census#kdnilsen) (@kdnilsen - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/shenandoah pull/199/head:pull/199` \
`$ git checkout pull/199`

Update a local copy of the PR: \
`$ git checkout pull/199` \
`$ git pull https://git.openjdk.org/shenandoah pull/199/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 199`

View PR using the GUI difftool: \
`$ git pr show -t 199`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/shenandoah/pull/199.diff">https://git.openjdk.org/shenandoah/pull/199.diff</a>

</details>
