### PR TITLE
Fix fullgc assertion

### DIFF
--- a/src/hotspot/share/gc/shenandoah/shenandoahFullGC.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahFullGC.cpp
@@ -175,6 +175,13 @@ void ShenandoahFullGC::op_full(GCCause::Cause cause) {
   metrics.snap_after();
   if (heap->mode()->is_generational()) {
     heap->log_heap_status("At end of Full GC");
+
+    // Since we allow temporary violation of these constraints during Full GC, we want to enforce that the assertions are
+    // made valid by the time Full GC completes.
+    assert(heap->old_generation()->used_regions_size() <= heap->old_generation()->adjusted_capacity(),
+           "Old generation affiliated regions must be less than capacity");
+    assert(heap->young_generation()->used_regions_size() <= heap->young_generation()->adjusted_capacity(),
+           "Young generation affiliated regions must be less than capacity");
   }
   if (metrics.is_good_progress()) {
     ShenandoahHeap::heap()->notify_gc_progress();

--- a/src/hotspot/share/gc/shenandoah/shenandoahHeapRegion.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahHeapRegion.cpp
@@ -982,12 +982,18 @@ void ShenandoahHeapRegion::set_affiliation(ShenandoahRegionAffiliation new_affil
     case YOUNG_GENERATION:
       reset_age();
       regions = heap->young_generation()->increment_affiliated_region_count();
-      assert(regions * ShenandoahHeapRegion::region_size_bytes() <= heap->young_generation()->adjusted_capacity(),
+      // During Full GC, we allow temporary violation of this requirement.  We enforce that this condition is
+      // restored upon completion of Full GC.
+      assert(heap->is_full_gc_in_progress() || 
+             (regions * ShenandoahHeapRegion::region_size_bytes() <= heap->young_generation()->adjusted_capacity()),
              "Number of young regions cannot exceed adjusted capacity");
       break;
     case OLD_GENERATION:
       regions = heap->old_generation()->increment_affiliated_region_count();
-      assert(regions * ShenandoahHeapRegion::region_size_bytes() <= heap->old_generation()->adjusted_capacity(),
+      // During Full GC, we allow temporary violation of this requirement.  We enforce that this condition is
+      // restored upon completion of Full GC.
+      assert(heap->is_full_gc_in_progress() || 
+             (regions * ShenandoahHeapRegion::region_size_bytes() <= heap->old_generation()->adjusted_capacity()),
              "Number of old regions cannot exceed adjusted capacity");
       break;
     default:

--- a/src/hotspot/share/gc/shenandoah/shenandoahHeapRegion.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahHeapRegion.cpp
@@ -984,7 +984,7 @@ void ShenandoahHeapRegion::set_affiliation(ShenandoahRegionAffiliation new_affil
       regions = heap->young_generation()->increment_affiliated_region_count();
       // During Full GC, we allow temporary violation of this requirement.  We enforce that this condition is
       // restored upon completion of Full GC.
-      assert(heap->is_full_gc_in_progress() || 
+      assert(heap->is_full_gc_in_progress() ||
              (regions * ShenandoahHeapRegion::region_size_bytes() <= heap->young_generation()->adjusted_capacity()),
              "Number of young regions cannot exceed adjusted capacity");
       break;
@@ -992,7 +992,7 @@ void ShenandoahHeapRegion::set_affiliation(ShenandoahRegionAffiliation new_affil
       regions = heap->old_generation()->increment_affiliated_region_count();
       // During Full GC, we allow temporary violation of this requirement.  We enforce that this condition is
       // restored upon completion of Full GC.
-      assert(heap->is_full_gc_in_progress() || 
+      assert(heap->is_full_gc_in_progress() ||
              (regions * ShenandoahHeapRegion::region_size_bytes() <= heap->old_generation()->adjusted_capacity()),
              "Number of old regions cannot exceed adjusted capacity");
       break;


### PR DESCRIPTION
Relax generation sizing assertions during Full GC because of the sequencing of operations that occur during Full GC.

Enforce the assertion constraints at the end of Full GC.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed (1 review required, with at least 1 [Committer](https://openjdk.org/bylaws#committer))

### Reviewers
 * [Y. Srinivas Ramakrishna](https://openjdk.org/census#ysr) (@ysramakrishna - Author) ⚠️ Review applies to [b435a34b](https://git.openjdk.org/shenandoah/pull/200/files/b435a34b02f9615c91c840eb1ef411acdbea5fb1)
 * [William Kemper](https://openjdk.org/census#wkemper) (@earthling-amzn - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/shenandoah pull/200/head:pull/200` \
`$ git checkout pull/200`

Update a local copy of the PR: \
`$ git checkout pull/200` \
`$ git pull https://git.openjdk.org/shenandoah pull/200/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 200`

View PR using the GUI difftool: \
`$ git pr show -t 200`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/shenandoah/pull/200.diff">https://git.openjdk.org/shenandoah/pull/200.diff</a>

</details>
