### PR TITLE
Do not reset learning cycles after resizing

### DIFF
--- a/src/hotspot/share/gc/shenandoah/heuristics/shenandoahAdaptiveHeuristics.cpp
+++ b/src/hotspot/share/gc/shenandoah/heuristics/shenandoahAdaptiveHeuristics.cpp
@@ -495,6 +495,7 @@ bool ShenandoahAdaptiveHeuristics::resize_and_evaluate() {
     return true;
   }
 
+  log_info(gc)("Increased size of %s generation, re-evaluate trigger criteria", _generation->name());
   return should_start_gc();
 }
 

--- a/src/hotspot/share/gc/shenandoah/heuristics/shenandoahAdaptiveHeuristics.cpp
+++ b/src/hotspot/share/gc/shenandoah/heuristics/shenandoahAdaptiveHeuristics.cpp
@@ -55,6 +55,8 @@ const double ShenandoahAdaptiveHeuristics::HIGHEST_EXPECTED_AVAILABLE_AT_END = 0
 const double ShenandoahAdaptiveHeuristics::MINIMUM_CONFIDENCE = 0.319; // 25%
 const double ShenandoahAdaptiveHeuristics::MAXIMUM_CONFIDENCE = 3.291; // 99.9%
 
+const uint ShenandoahAdaptiveHeuristics::MINIMUM_RESIZE_INTERVAL = 10;
+
 ShenandoahAdaptiveHeuristics::ShenandoahAdaptiveHeuristics(ShenandoahGeneration* generation) :
   ShenandoahHeuristics(generation),
   _margin_of_error_sd(ShenandoahAdaptiveInitialConfidence),
@@ -235,6 +237,7 @@ void ShenandoahAdaptiveHeuristics::choose_collection_set_from_regiondata(Shenand
 void ShenandoahAdaptiveHeuristics::record_cycle_start() {
   ShenandoahHeuristics::record_cycle_start();
   _allocation_rate.allocation_counter_reset();
+  ++_cycles_since_last_resize;
 }
 
 void ShenandoahAdaptiveHeuristics::record_success_concurrent(bool abbreviated) {
@@ -483,15 +486,15 @@ bool ShenandoahAdaptiveHeuristics::resize_and_evaluate() {
     return true;
   }
 
-  if (_gc_times_learned < ShenandoahLearningSteps) {
-    // We aren't going to attempt to resize our generation until we have 'learned'
-    // something about it. This provides a kind of cool down period after we've made
-    // a change, to help prevent thrashing.
+  if (_cycles_since_last_resize <= MINIMUM_RESIZE_INTERVAL) {
+    log_info(gc, ergo)("Not resizing %s for another " UINT32_FORMAT " cycles.",
+        _generation->name(),  _cycles_since_last_resize);
     return true;
   }
 
   if (!heap->generation_sizer()->transfer_capacity(_generation)) {
     // We could not enlarge our generation, so we must start a gc cycle.
+    log_info(gc, ergo)("Could not increase size of %s, begin gc cycle.", _generation->name());
     return true;
   }
 

--- a/src/hotspot/share/gc/shenandoah/heuristics/shenandoahAdaptiveHeuristics.hpp
+++ b/src/hotspot/share/gc/shenandoah/heuristics/shenandoahAdaptiveHeuristics.hpp
@@ -85,6 +85,13 @@ public:
   const static double LOWEST_EXPECTED_AVAILABLE_AT_END;
   const static double HIGHEST_EXPECTED_AVAILABLE_AT_END;
 
+  // At least this many cycles must execute before the heuristic will attempt
+  // to resize its generation. This is to prevent the heuristic from rapidly
+  // maxing out the generation size (which only forces the collector for the
+  // other generation to run more frequently, defeating the purpose of improving
+  // MMU).
+  const static uint MINIMUM_RESIZE_INTERVAL;
+
   friend class ShenandoahAllocationRate;
 
   // Used to record the last trigger that signaled to start a GC.
@@ -128,6 +135,10 @@ public:
   // establishes what is 'normal' for the application and is used as a
   // source of feedback to adjust trigger parameters.
   TruncatedSeq _available;
+
+  // Do not attempt to resize the generation for this heuristic until this
+  // value is greater than MINIMUM_RESIZE_INTERVAL.
+  uint _cycles_since_last_resize;
 };
 
 #endif // SHARE_GC_SHENANDOAH_HEURISTICS_SHENANDOAHADAPTIVEHEURISTICS_HPP

--- a/src/hotspot/share/gc/shenandoah/shenandoahGeneration.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahGeneration.cpp
@@ -1002,7 +1002,6 @@ void ShenandoahGeneration::increase_capacity(size_t increment) {
   _max_capacity += increment;
   _soft_max_capacity += increment;
   _adjusted_capacity += increment;
-  heuristics()->reset_gc_learning();
 }
 
 void ShenandoahGeneration::decrease_capacity(size_t decrement) {
@@ -1011,7 +1010,6 @@ void ShenandoahGeneration::decrease_capacity(size_t decrement) {
   _max_capacity -= decrement;
   _soft_max_capacity -= decrement;
   _adjusted_capacity -= decrement;
-  heuristics()->reset_gc_learning();
 }
 
 void ShenandoahGeneration::record_success_concurrent(bool abbreviated) {


### PR DESCRIPTION
Also, require more than 10 gc cycles before trigger can resize generations. The behavior on the extremem 'phased' workload looks much better:
```
[1334.381s][info][gc,stats       ]    66 Successful Concurrent GCs
[1334.381s][info][gc,stats       ]       0 invoked explicitly
[1334.381s][info][gc,stats       ]       0 invoked implicitly
[1334.381s][info][gc,stats       ] 
[1334.381s][info][gc,stats       ]     7 Completed Old GCs
[1334.381s][info][gc,stats       ]       0 mixed
[1334.381s][info][gc,stats       ]       0 interruptions
[1334.381s][info][gc,stats       ] 
[1334.381s][info][gc,stats       ]     1 Degenerated GCs
[1334.381s][info][gc,stats       ]       1 caused by allocation failure
[1334.381s][info][gc,stats       ]         1 happened at Mark
[1334.381s][info][gc,stats       ]       1 upgraded to Full GC
[1334.381s][info][gc,stats       ] 
[1334.381s][info][gc,stats       ]     0 Abbreviated GCs
[1334.381s][info][gc,stats       ] 
[1334.381s][info][gc,stats       ]     1 Full GCs
[1334.381s][info][gc,stats       ]       0 invoked explicitly
[1334.381s][info][gc,stats       ]       0 invoked implicitly
[1334.381s][info][gc,stats       ]       0 caused by allocation failure
[1334.381s][info][gc,stats       ]       1 upgraded from Degenerated GC
```
The full cycle here was the first cycle after the last of the initial learning cycles.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed (1 review required, with at least 1 [Committer](https://openjdk.org/bylaws#committer))

### Reviewers
 * [Y. Srinivas Ramakrishna](https://openjdk.org/census#ysr) (@ysramakrishna - Author)
 * [Kelvin Nilsen](https://openjdk.org/census#kdnilsen) (@kdnilsen - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/shenandoah pull/203/head:pull/203` \
`$ git checkout pull/203`

Update a local copy of the PR: \
`$ git checkout pull/203` \
`$ git pull https://git.openjdk.org/shenandoah pull/203/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 203`

View PR using the GUI difftool: \
`$ git pr show -t 203`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/shenandoah/pull/203.diff">https://git.openjdk.org/shenandoah/pull/203.diff</a>

</details>
