### PR TITLE
Revert unnecessary changes to unified logging

### DIFF
--- a/src/hotspot/share/logging/logFileStreamOutput.cpp
+++ b/src/hotspot/share/logging/logFileStreamOutput.cpp
@@ -74,6 +74,20 @@ int LogFileStreamOutput::write_decorations(const LogDecorations& decorations) {
   return total_written;
 }
 
+class FileLocker : public StackObj {
+private:
+  FILE *_file;
+
+public:
+  FileLocker(FILE *file) : _file(file) {
+    os::flockfile(_file);
+  }
+
+  ~FileLocker() {
+    os::funlockfile(_file);
+  }
+};
+
 bool LogFileStreamOutput::flush() {
   bool result = true;
   if (fflush(_stream) != 0) {

--- a/src/hotspot/share/logging/logFileStreamOutput.hpp
+++ b/src/hotspot/share/logging/logFileStreamOutput.hpp
@@ -90,18 +90,4 @@ class LogStderrOutput : public LogFileStreamOutput {
 extern LogStderrOutput* StderrLog;
 extern LogStdoutOutput* StdoutLog;
 
-class FileLocker : public StackObj {
-private:
-    FILE *_file;
-
-public:
-    FileLocker(FILE *file) : _file(file) {
-      os::flockfile(_file);
-    }
-
-    ~FileLocker() {
-      os::funlockfile(_file);
-    }
-};
-
 #endif // SHARE_LOGGING_LOGFILESTREAMOUTPUT_HPP


### PR DESCRIPTION
These are vestigial changes from the initial approach to support logging for the region sampling. This initial approach was abandoned and these changes should have been reverted at that time.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed (1 review required, with at least 1 [Committer](https://openjdk.org/bylaws#committer))

### Reviewers
 * [Kelvin Nilsen](https://openjdk.org/census#kdnilsen) (@kdnilsen - Committer)
 * [Y. Srinivas Ramakrishna](https://openjdk.org/census#ysr) (@ysramakrishna - Author)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/shenandoah pull/207/head:pull/207` \
`$ git checkout pull/207`

Update a local copy of the PR: \
`$ git checkout pull/207` \
`$ git pull https://git.openjdk.org/shenandoah pull/207/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 207`

View PR using the GUI difftool: \
`$ git pr show -t 207`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/shenandoah/pull/207.diff">https://git.openjdk.org/shenandoah/pull/207.diff</a>

</details>
