### PR TITLE
Combine bitmap clearing with region resetting closure

### DIFF
--- a/src/hotspot/share/gc/shenandoah/shenandoahGeneration.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahGeneration.cpp
@@ -39,12 +39,18 @@
 
 class ShenandoahResetUpdateRegionStateClosure : public ShenandoahHeapRegionClosure {
  private:
+  ShenandoahHeap* _heap;
   ShenandoahMarkingContext* const _ctx;
  public:
   ShenandoahResetUpdateRegionStateClosure() :
-    _ctx(ShenandoahHeap::heap()->marking_context()) {}
+    _heap(ShenandoahHeap::heap()),
+    _ctx(_heap->marking_context()) {}
 
-  void heap_region_do(ShenandoahHeapRegion* r) {
+  void heap_region_do(ShenandoahHeapRegion* r) override {
+    if (_heap->is_bitmap_slice_committed(r)) {
+      _ctx->clear_bitmap(r);
+    }
+
     if (r->is_active()) {
       // Reset live data and set TAMS optimistically. We would recheck these under the pause
       // anyway to capture any updates that happened since now.
@@ -53,7 +59,7 @@ class ShenandoahResetUpdateRegionStateClosure : public ShenandoahHeapRegionClosu
     }
   }
 
-  bool is_thread_safe() { return true; }
+  bool is_thread_safe() override { return true; }
 };
 
 class ShenandoahResetBitmapTask : public ShenandoahHeapRegionClosure {
@@ -209,9 +215,10 @@ void ShenandoahGeneration::merge_write_table() {
 }
 
 void ShenandoahGeneration::prepare_gc() {
-  // Reset mark bitmap for this generation (typically young)
-  reset_mark_bitmap();
-  // Capture Top At Mark Start for this generation (typically young)
+  // Invalidate the marking context
+  set_mark_incomplete();
+
+  // Capture Top At Mark Start for this generation (typically young) and reset mark bitmap.
   ShenandoahResetUpdateRegionStateClosure cl;
   parallel_heap_region_iterate(&cl);
 }


### PR DESCRIPTION
This change combines the two closures used to `prepare_gc`. This removes a second iteration over the regions.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed (1 review required, with at least 1 [Committer](https://openjdk.org/bylaws#committer))

### Reviewers
 * [Kelvin Nilsen](https://openjdk.org/census#kdnilsen) (@kdnilsen - Committer)
 * [Y. Srinivas Ramakrishna](https://openjdk.org/census#ysr) (@ysramakrishna - Author)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/shenandoah pull/208/head:pull/208` \
`$ git checkout pull/208`

Update a local copy of the PR: \
`$ git checkout pull/208` \
`$ git pull https://git.openjdk.org/shenandoah pull/208/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 208`

View PR using the GUI difftool: \
`$ git pr show -t 208`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/shenandoah/pull/208.diff">https://git.openjdk.org/shenandoah/pull/208.diff</a>

</details>
