### PR TITLE
Tune heuristic defaults and behavior for improved stability

### DIFF
--- a/src/hotspot/share/gc/shenandoah/heuristics/shenandoahAdaptiveHeuristics.cpp
+++ b/src/hotspot/share/gc/shenandoah/heuristics/shenandoahAdaptiveHeuristics.cpp
@@ -62,7 +62,7 @@ ShenandoahAdaptiveHeuristics::ShenandoahAdaptiveHeuristics(ShenandoahGeneration*
   _margin_of_error_sd(ShenandoahAdaptiveInitialConfidence),
   _spike_threshold_sd(ShenandoahAdaptiveInitialSpikeThreshold),
   _last_trigger(OTHER),
-  _available(10, 0.1) { }
+  _available(Moving_Average_Samples, ShenandoahAdaptiveDecayFactor) { }
 
 ShenandoahAdaptiveHeuristics::~ShenandoahAdaptiveHeuristics() {}
 

--- a/src/hotspot/share/gc/shenandoah/heuristics/shenandoahAdaptiveHeuristics.cpp
+++ b/src/hotspot/share/gc/shenandoah/heuristics/shenandoahAdaptiveHeuristics.cpp
@@ -61,7 +61,8 @@ ShenandoahAdaptiveHeuristics::ShenandoahAdaptiveHeuristics(ShenandoahGeneration*
   ShenandoahHeuristics(generation),
   _margin_of_error_sd(ShenandoahAdaptiveInitialConfidence),
   _spike_threshold_sd(ShenandoahAdaptiveInitialSpikeThreshold),
-  _last_trigger(OTHER) { }
+  _last_trigger(OTHER),
+  _available(10, 0.1) { }
 
 ShenandoahAdaptiveHeuristics::~ShenandoahAdaptiveHeuristics() {}
 
@@ -243,19 +244,23 @@ void ShenandoahAdaptiveHeuristics::record_cycle_start() {
 void ShenandoahAdaptiveHeuristics::record_success_concurrent(bool abbreviated) {
   ShenandoahHeuristics::record_success_concurrent(abbreviated);
 
-  size_t available = ShenandoahHeap::heap()->free_set()->available();
+  size_t available = MIN2(_generation->available(), ShenandoahHeap::heap()->free_set()->available());
 
-  _available.add(available);
   double z_score = 0.0;
-  if (_available.sd() > 0) {
-    z_score = (available - _available.avg()) / _available.sd();
+  double available_sd = _available.sd();
+  if (available_sd > 0) {
+    double available_avg = _available.avg();
+    z_score = (double(available) - available_avg) / available_sd;
+    log_debug(gc, ergo)("%s Available: " SIZE_FORMAT " %sB, z-score=%.3f. Average available: %.1f %sB +/- %.1f %sB.",
+                        _generation->name(),
+                        byte_size_in_proper_unit(available), proper_unit_for_byte_size(available), z_score,
+                        byte_size_in_proper_unit(available_avg), proper_unit_for_byte_size(available_avg),
+                        byte_size_in_proper_unit(available_sd), proper_unit_for_byte_size(available_sd));
   }
 
-  log_debug(gc, ergo)("Available: " SIZE_FORMAT " %sB, z-score=%.3f. Average available: %.1f %sB +/- %.1f %sB.",
-                      byte_size_in_proper_unit(available), proper_unit_for_byte_size(available),
-                      z_score,
-                      byte_size_in_proper_unit(_available.avg()), proper_unit_for_byte_size(_available.avg()),
-                      byte_size_in_proper_unit(_available.sd()), proper_unit_for_byte_size(_available.sd()));
+  _available.add(double(available));
+
+  
 
   // In the case when a concurrent GC cycle completes successfully but with an
   // unusually small amount of available memory we will adjust our trigger

--- a/src/hotspot/share/gc/shenandoah/heuristics/shenandoahAdaptiveHeuristics.cpp
+++ b/src/hotspot/share/gc/shenandoah/heuristics/shenandoahAdaptiveHeuristics.cpp
@@ -260,8 +260,6 @@ void ShenandoahAdaptiveHeuristics::record_success_concurrent(bool abbreviated) {
 
   _available.add(double(available));
 
-  
-
   // In the case when a concurrent GC cycle completes successfully but with an
   // unusually small amount of available memory we will adjust our trigger
   // parameters so that they are more likely to initiate a new cycle.

--- a/src/hotspot/share/gc/shenandoah/heuristics/shenandoahHeuristics.cpp
+++ b/src/hotspot/share/gc/shenandoah/heuristics/shenandoahHeuristics.cpp
@@ -57,7 +57,7 @@ ShenandoahHeuristics::ShenandoahHeuristics(ShenandoahGeneration* generation) :
   _last_cycle_end(0),
   _gc_times_learned(0),
   _gc_time_penalties(0),
-  _gc_cycle_time_history(new TruncatedSeq(10, ShenandoahAdaptiveDecayFactor)),
+  _gc_cycle_time_history(new TruncatedSeq(Moving_Average_Samples, ShenandoahAdaptiveDecayFactor)),
   _live_memory_last_cycle(0),
   _live_memory_penultimate_cycle(0),
   _metaspace_oom()

--- a/src/hotspot/share/gc/shenandoah/heuristics/shenandoahHeuristics.hpp
+++ b/src/hotspot/share/gc/shenandoah/heuristics/shenandoahHeuristics.hpp
@@ -65,6 +65,8 @@ class ShenandoahHeuristics : public CHeapObj<mtGC> {
   static const intx Full_Penalty        = 20; // how much to penalize average GC duration history on Full GC
 
 protected:
+  static const uint Moving_Average_Samples = 10; // Number of samples to store in moving averages
+
   typedef struct {
     ShenandoahHeapRegion* _region;
     size_t _garbage;
@@ -77,7 +79,7 @@ protected:
   // if (_generation->generation_mode() == OLD) _region_data represents
   //  the results of most recently completed old-gen marking pass
   // if (_generation->generation_mode() == YOUNG) _region_data represents
-  //  the resulits of most recently completed young-gen marking pass
+  //  the results of most recently completed young-gen marking pass
   //
   // Note that there is some redundancy represented in _region_data because
   // each instance is an array large enough to hold all regions.  However,

--- a/src/hotspot/share/gc/shenandoah/shenandoahControlThread.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahControlThread.cpp
@@ -475,10 +475,14 @@ void ShenandoahControlThread::service_concurrent_normal_cycle(
       ShouldNotReachHere();
   }
   const char* msg;
-  if (heap->cancelled_gc()) {
-    msg = (generation == YOUNG)? "At end of Interrupted Concurrent Young GC": "At end of Interrupted Concurrent Bootstrap GC";
+  if (heap->mode()->is_generational()) {
+    if (heap->cancelled_gc()) {
+      msg = (generation == YOUNG)? "At end of Interrupted Concurrent Young GC": "At end of Interrupted Concurrent Bootstrap GC";
+    } else {
+      msg = (generation == YOUNG)? "At end of Concurrent Young GC": "At end of Concurrent Bootstrap GC";
+    }
   } else {
-    msg = (generation == YOUNG)? "At end of Concurrent Young GC": "At end of Concurrent Bootstrap GC";
+    msg = heap->cancelled_gc() ? "At end of cancelled GC" : "At end of GC";
   }
   heap->log_heap_status(msg);
 }

--- a/src/hotspot/share/gc/shenandoah/shenandoahFreeSet.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahFreeSet.cpp
@@ -329,7 +329,7 @@ HeapWord* ShenandoahFreeSet::try_allocate_in(ShenandoahHeapRegion* r, Shenandoah
         }
         assert (result != NULL, "Allocation must succeed: free " SIZE_FORMAT ", actual " SIZE_FORMAT, free, size);
       } else {
-        log_info(gc, ergo)("Failed to shrink TLAB or GCLAB request (" SIZE_FORMAT ") in region " SIZE_FORMAT " to " SIZE_FORMAT
+        log_trace(gc, ergo)("Failed to shrink TLAB or GCLAB request (" SIZE_FORMAT ") in region " SIZE_FORMAT " to " SIZE_FORMAT
                            " because min_size() is " SIZE_FORMAT, req.size(), r->index(), size, req.min_size());
       }
     }

--- a/src/hotspot/share/gc/shenandoah/shenandoah_globals.hpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoah_globals.hpp
@@ -147,7 +147,7 @@
           "cases. In percents of (soft) max heap size.")                    \
           range(0,100)                                                      \
                                                                             \
-  product(uintx, ShenandoahLearningSteps, 5, EXPERIMENTAL,                  \
+  product(uintx, ShenandoahLearningSteps, 10, EXPERIMENTAL,                 \
           "The number of cycles some heuristics take to collect in order "  \
           "to learn application and GC performance.")                       \
           range(0,100)                                                      \
@@ -181,7 +181,7 @@
           "the heuristic is to allocation spikes. Decreasing this number "  \
           "increases the sensitivity. ")                                    \
                                                                             \
-  product(double, ShenandoahAdaptiveDecayFactor, 0.5, EXPERIMENTAL,         \
+  product(double, ShenandoahAdaptiveDecayFactor, 0.1, EXPERIMENTAL,         \
           "The decay factor (alpha) used for values in the weighted "       \
           "moving average of cycle time and allocation rate. "              \
           "Larger values give more weight to recent values.")               \


### PR DESCRIPTION
Also, some minor changes to logging.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed (1 review required, with at least 1 [Committer](https://openjdk.org/bylaws#committer))

### Reviewers
 * [Kelvin Nilsen](https://openjdk.org/census#kdnilsen) (@kdnilsen - Committer) ⚠️ Review applies to [7e7dfa41](https://git.openjdk.org/shenandoah/pull/209/files/7e7dfa413534219cc3660189d643634cfcb4aaaf)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/shenandoah pull/209/head:pull/209` \
`$ git checkout pull/209`

Update a local copy of the PR: \
`$ git checkout pull/209` \
`$ git pull https://git.openjdk.org/shenandoah pull/209/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 209`

View PR using the GUI difftool: \
`$ git pr show -t 209`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/shenandoah/pull/209.diff">https://git.openjdk.org/shenandoah/pull/209.diff</a>

</details>
