### PR TITLE
Age objects during degeneration

### DIFF
--- a/src/hotspot/share/gc/shenandoah/shenandoahControlThread.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahControlThread.cpp
@@ -267,7 +267,8 @@ void ShenandoahControlThread::run_service() {
         ShenandoahHeapLocker locker(heap->lock());
         heap->free_set()->log_status();
       }
-
+      // In case this is a degenerated cycle, remember whether original cycle was aging.
+      bool was_aging_cycle = heap->is_aging_cycle();
       heap->set_aging_cycle(false);
       {
         switch (_mode) {
@@ -280,6 +281,7 @@ void ShenandoahControlThread::run_service() {
             break;
           }
           case stw_degenerated: {
+            heap->set_aging_cycle(was_aging_cycle);
             if (!service_stw_degenerated_cycle(cause, degen_point)) {
               // The degenerated GC was upgraded to a Full GC
               generation = GLOBAL;

--- a/src/hotspot/share/gc/shenandoah/shenandoahDegeneratedGC.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahDegeneratedGC.cpp
@@ -74,11 +74,6 @@ void ShenandoahDegenGC::entry_degenerated() {
   ShenandoahPausePhase gc_phase(msg, ShenandoahPhaseTimings::degen_gc, true /* log_heap_usage */);
   EventMark em("%s", msg);
   ShenandoahHeap* const heap = ShenandoahHeap::heap();
-
-  // In case degenerated GC preempted evacuation or update-refs, clear the aging cycle now.  No harm in clearing it
-  // redundantly if it is already clear.  We don't age during degenerated cycles.
-  heap->set_aging_cycle(false);
-
   ShenandoahWorkerScope scope(heap->workers(),
                               ShenandoahWorkerPolicy::calc_workers_for_stw_degenerated(),
                               "stw degenerated gc");


### PR DESCRIPTION
We found that not aging during degenerated cycles can cause large amounts of memory (e.g. 15 GB) to accumulate in young-gen when it ought to be promoted to old gen.  This creates serious performance degradation.  This patch allows degenerated cycles to age objects.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed (1 review required, with at least 1 [Committer](https://openjdk.org/bylaws#committer))

### Reviewers
 * [William Kemper](https://openjdk.org/census#wkemper) (@earthling-amzn - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/shenandoah pull/210/head:pull/210` \
`$ git checkout pull/210`

Update a local copy of the PR: \
`$ git checkout pull/210` \
`$ git pull https://git.openjdk.org/shenandoah pull/210/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 210`

View PR using the GUI difftool: \
`$ git pr show -t 210`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/shenandoah/pull/210.diff">https://git.openjdk.org/shenandoah/pull/210.diff</a>

</details>
