### PR TITLE
Fullgc should honor aging cycle

### DIFF
--- a/src/hotspot/share/gc/shenandoah/shenandoahControlThread.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahControlThread.cpp
@@ -289,6 +289,10 @@ void ShenandoahControlThread::run_service() {
             break;
           }
           case stw_full: {
+            if (age_period-- == 0) {
+              heap->set_aging_cycle(true);
+              age_period = ShenandoahAgingCyclePeriod - 1;
+            }
             service_stw_full_cycle(cause);
             break;
           }

--- a/src/hotspot/share/gc/shenandoah/shenandoahFullGC.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahFullGC.cpp
@@ -597,7 +597,11 @@ public:
 
       // After full gc compaction, all regions have age 0.  Embed the region's age into the object's age in order to preserve
       // tenuring progress.
-      _heap->increase_object_age(p, from_region_age + 1);
+      if (_heap->is_aging_cycle()) {
+        _heap->increase_object_age(p, from_region_age + 1);
+      } else {
+        _heap->increase_object_age(p, from_region_age);
+      }
 
       if (_young_compact_point + obj_size > _young_to_region->end()) {
         ShenandoahHeapRegion* new_to_region;


### PR DESCRIPTION
As previously implemented, Full GC always incremented object ages.  It should only increment object ages if this is an aging cycle.  This was detected during code review.  This is a correctness improvement without known performance implications.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed (1 review required, with at least 1 [Committer](https://openjdk.org/bylaws#committer))

### Reviewers
 * [William Kemper](https://openjdk.org/census#wkemper) (@earthling-amzn - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/shenandoah pull/212/head:pull/212` \
`$ git checkout pull/212`

Update a local copy of the PR: \
`$ git checkout pull/212` \
`$ git pull https://git.openjdk.org/shenandoah pull/212/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 212`

View PR using the GUI difftool: \
`$ git pr show -t 212`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/shenandoah/pull/212.diff">https://git.openjdk.org/shenandoah/pull/212.diff</a>

</details>
