### PR TITLE
Following abbreviated cycle, only increment region age if aging cycle

### DIFF
--- a/src/hotspot/share/gc/shenandoah/shenandoahVMOperations.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahVMOperations.cpp
@@ -91,7 +91,7 @@ void VM_ShenandoahFinalRoots::doit() {
         HeapWord* top = r->top();
         if (top > tams) {
           r->reset_age();
-        } else {
+        } else if (heap->is_aging_cycle()){
           r->increment_age();
         }
       }


### PR DESCRIPTION
The previously existing code that processes regions following completion of an abbreviated cycle unconditionally
increased the age of all regions that had not allocated memory during the cycle.  It should only increment age of
regions if this is an aging cycle.  This patch fixes this behavior.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed (1 review required, with at least 1 [Committer](https://openjdk.org/bylaws#committer))

### Reviewers
 * [William Kemper](https://openjdk.org/census#wkemper) (@earthling-amzn - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/shenandoah pull/214/head:pull/214` \
`$ git checkout pull/214`

Update a local copy of the PR: \
`$ git checkout pull/214` \
`$ git pull https://git.openjdk.org/shenandoah pull/214/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 214`

View PR using the GUI difftool: \
`$ git pr show -t 214`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/shenandoah/pull/214.diff">https://git.openjdk.org/shenandoah/pull/214.diff</a>

</details>
