### PR TITLE
Bootstrap old gc should honor aging cycle

### DIFF
--- a/src/hotspot/share/gc/shenandoah/shenandoahControlThread.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahControlThread.cpp
@@ -273,7 +273,12 @@ void ShenandoahControlThread::run_service() {
       {
         switch (_mode) {
           case concurrent_normal: {
-            if ((generation == YOUNG) && (age_period-- == 0)) {
+            // At this point:
+            //  if (generation == YOUNG), this is a normal YOUNG cycle
+            //  if (generation == OLD), this is a bootstrap OLD cycle
+            //  if (generation == GLOBAL), this is a GLOBAL cycle triggered by System.gc()
+            // In all three cases, we want to age old objects if this is an aging cycle
+            if (age_period-- == 0) {
               heap->set_aging_cycle(true);
               age_period = ShenandoahAgingCyclePeriod - 1;
             }


### PR DESCRIPTION
A bootstrap old gc should increment object and region ages if this is an aging cycle.  This patch implements this fix.

The patch is motivated by observations that performance degradation occurs when timely promotions do not occur because bootstrap old GCs are not incrementing ages.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed (1 review required, with at least 1 [Committer](https://openjdk.org/bylaws#committer))

### Reviewers
 * [William Kemper](https://openjdk.org/census#wkemper) (@earthling-amzn - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/shenandoah pull/215/head:pull/215` \
`$ git checkout pull/215`

Update a local copy of the PR: \
`$ git checkout pull/215` \
`$ git pull https://git.openjdk.org/shenandoah pull/215/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 215`

View PR using the GUI difftool: \
`$ git pr show -t 215`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/shenandoah/pull/215.diff">https://git.openjdk.org/shenandoah/pull/215.diff</a>

</details>
