### PR TITLE
Remove unused visualizer option

### DIFF
--- a/src/hotspot/share/gc/shenandoah/shenandoah_globals.hpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoah_globals.hpp
@@ -241,12 +241,6 @@
           "the samples. Higher values provide more fidelity, at expense "   \
           "of more sampling overhead.")                                     \
                                                                             \
-  product(ccstr, ShenandoahRegionSamplingFile,                              \
-          "./shenandoahSnapshots_pid%p.log",                                \
-          "If ShenandoahLogRegionSampling is on, save sampling data stream "\
-          "to this file [default: ./shenandoahSnapshots_pid%p.log] "        \
-          "(%p replaced with pid)")                                         \
-                                                                            \
   product(uintx, ShenandoahControlIntervalMin, 1, EXPERIMENTAL,             \
           "The minimum sleep interval for the control loop that drives "    \
           "the cycles. Lower values would increase GC responsiveness "      \


### PR DESCRIPTION
This option should have been removed when we switched the region sampling to use unified logging framework.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed (1 review required, with at least 1 [Committer](https://openjdk.org/bylaws#committer))

### Reviewers
 * [Kelvin Nilsen](https://openjdk.org/census#kdnilsen) (@kdnilsen - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/shenandoah pull/217/head:pull/217` \
`$ git checkout pull/217`

Update a local copy of the PR: \
`$ git checkout pull/217` \
`$ git pull https://git.openjdk.org/shenandoah pull/217/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 217`

View PR using the GUI difftool: \
`$ git pr show -t 217`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/shenandoah/pull/217.diff">https://git.openjdk.org/shenandoah/pull/217.diff</a>

</details>
