### PR TITLE
Fix error in alignment of plabs

### DIFF
--- a/src/hotspot/share/gc/shenandoah/shenandoahFreeSet.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahFreeSet.cpp
@@ -287,10 +287,13 @@ HeapWord* ShenandoahFreeSet::try_allocate_in(ShenandoahHeapRegion* r, Shenandoah
       assert(_heap->mode()->is_generational(), "PLABs are only for generational mode");
       // Need to assure that plabs are aligned on multiple of card region.
       size_t free = r->free();
+      // e.g. card_size is 512, card_shift is 9, min_fill_size() is 8
+      //      free is 514
+      //      usable_free is 512, which is decreased to 0
       size_t usable_free = (free / CardTable::card_size()) << CardTable::card_shift();
       if ((free != usable_free) && (free - usable_free < ShenandoahHeap::min_fill_size() * HeapWordSize)) {
         // We'll have to add another card's memory to the padding
-        if (usable_free > CardTable::card_size()) {
+        if (usable_free >= CardTable::card_size()) {
           usable_free -= CardTable::card_size();
         } else {
           assert(usable_free == 0, "usable_free is a multiple of card_size and card_size > min_fill_size");


### PR DESCRIPTION
A recent test run reported an assertion failure because of the error corrected in this patch.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed (1 review required, with at least 1 [Committer](https://openjdk.org/bylaws#committer))

### Reviewers
 * [William Kemper](https://openjdk.org/census#wkemper) (@earthling-amzn - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/shenandoah.git pull/229/head:pull/229` \
`$ git checkout pull/229`

Update a local copy of the PR: \
`$ git checkout pull/229` \
`$ git pull https://git.openjdk.org/shenandoah.git pull/229/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 229`

View PR using the GUI difftool: \
`$ git pr show -t 229`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/shenandoah/pull/229.diff">https://git.openjdk.org/shenandoah/pull/229.diff</a>

</details>
