### PR TITLE
Put regulator thread stop after gc thread iteration is prevented

### DIFF
--- a/src/hotspot/share/gc/shenandoah/shenandoahHeap.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahHeap.cpp
@@ -2357,11 +2357,11 @@ uint ShenandoahHeap::max_workers() {
 void ShenandoahHeap::stop() {
   // The shutdown sequence should be able to terminate when GC is running.
 
+  // Step 0. Notify policy to disable event recording and prevent visiting gc threads during shutdown
+  _shenandoah_policy->record_shutdown();
+
   // Step 0a. Stop requesting collections.
   regulator_thread()->stop();
-
-  // Step 0. Notify policy to disable event recording.
-  _shenandoah_policy->record_shutdown();
 
   // Step 1. Notify control thread that we are in shutdown.
   // Note that we cannot do that with stop(), because stop() is blocking and waits for the actual shutdown.


### PR DESCRIPTION
Record that shutdown sequence has begun before we request the regulator thread to stop.