### PR TITLE
Recompute generation accounts after fullgc

### DIFF
--- a/src/hotspot/share/gc/shenandoah/shenandoahFullGC.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahFullGC.cpp
@@ -323,9 +323,7 @@ void ShenandoahFullGC::do_it(GCCause::Cause gc_cause) {
 
     phase4_compact_objects(worker_slices);
 
-    if (heap->mode()->is_generational()) {
-      phase5_restore_generation_usage();
-    }
+    phase5_epilog();
   }
 
   {
@@ -1450,6 +1448,64 @@ void ShenandoahFullGC::phase4_compact_objects(ShenandoahHeapRegionSet** worker_s
     ShenandoahGCPhase phase(ShenandoahPhaseTimings::full_gc_copy_objects_humong);
     compact_humongous_objects();
   }
+}
+
+static void account_for_region(ShenandoahHeapRegion* r, size_t &region_count, size_t &region_usage, size_t &humongous_waste) {
+  region_count++;
+  region_usage += r->used();
+  if (r->is_humongous_start()) {
+    // For each humongous object, we take this path once regardless of how many regions it spans.
+    HeapWord* obj_addr = r->bottom();
+    oop obj = cast_to_oop(obj_addr);
+    size_t word_size = obj->size();
+    size_t region_size_words = ShenandoahHeapRegion::region_size_words();
+    size_t overreach = word_size % region_size_words;
+    if (overreach != 0) {
+      humongous_waste += (region_size_words - overreach) * HeapWordSize;
+    }
+    // else, this humongous object aligns exactly on region size, so no waste.
+  }
+}
+
+void ShenandoahFullGC::phase5_epilog() {
+  GCTraceTime(Info, gc, phases) time("Phase 5: Full GC epilog", _gc_timer);
+  ShenandoahHeap* heap = ShenandoahHeap::heap();
+  size_t num_regions = heap->num_regions();
+  size_t young_usage = 0;
+  size_t young_regions = 0;
+  size_t young_humongous_waste = 0;
+  size_t old_usage = 0;
+  size_t old_regions = 0;
+  size_t old_humongous_waste = 0;
+  ShenandoahHeapRegion* r;
+
+  if (heap->mode()->is_generational()) {
+    // TODO: We may be able remove code that recomputes generation usage after we fix the incremental updates to generation
+    // usage that are scattered throughout the existing Full GC implementation.  There's an error in there somewhere that
+    // has not yet been figured out.  Or maybe it is easier to just not try to do the generation accounting on the fly, keep
+    // this code, and remove all of the other attempts to increase/decrease affiliated regions, used, and humongous_waste.
+    {
+      ShenandoahGCPhase phase(ShenandoahPhaseTimings::full_gc_recompute_generation_usage);
+      for (size_t i = 0; i < num_regions; i++) {
+        switch (heap->region_affiliation(i)) {
+          case ShenandoahRegionAffiliation::FREE:
+            break;
+          case ShenandoahRegionAffiliation::YOUNG_GENERATION:
+            r = heap->get_region(i);
+            account_for_region(r, young_regions, young_usage, young_humongous_waste);
+            break;
+          case ShenandoahRegionAffiliation::OLD_GENERATION:
+            r = heap->get_region(i);
+            account_for_region(r, old_regions, old_usage, old_humongous_waste);
+            break;
+          default:
+            assert(false, "Should not reach");
+        }
+      }
+      heap->old_generation()->establish_usage(old_regions, old_usage, old_humongous_waste);
+      heap->young_generation()->establish_usage(young_regions, young_usage, young_humongous_waste);
+    }
+  }
 
   // Reset complete bitmap. We're about to reset the complete-top-at-mark-start pointer
   // and must ensure the bitmap is in sync.
@@ -1481,62 +1537,4 @@ void ShenandoahFullGC::phase4_compact_objects(ShenandoahHeapRegionSet** worker_s
   }
 
   heap->clear_cancelled_gc(true /* clear oom handler */);
-}
-
-void ShenandoahFullGC::phase5_restore_generation_usage() {
-  GCTraceTime(Info, gc, phases) time("Phase 5: Restore generation accounts", _gc_timer);
-  ShenandoahHeap* heap = ShenandoahHeap::heap();
-  size_t num_regions = heap->num_regions();
-  size_t young_usage = 0;
-  size_t young_regions = 0;
-  size_t young_humongous_waste = 0;
-  size_t old_usage = 0;
-  size_t old_regions = 0;
-  size_t old_humongous_waste = 0;
-  ShenandoahHeapRegion* r;
-
-  for (size_t i = 0; i < num_regions; i++) {
-    switch (heap->region_affiliation(i)) {
-      case ShenandoahRegionAffiliation::FREE:
-        break;
-      case ShenandoahRegionAffiliation::YOUNG_GENERATION:
-        r = heap->get_region(i);
-        young_regions++;
-        young_usage += r->used();
-        if (r->is_humongous()) {
-          ShenandoahHeapRegion* start = r->humongous_start_region();
-          HeapWord* obj_addr = start->bottom();
-          oop obj = cast_to_oop(obj_addr);
-          size_t word_size = obj->size();
-          HeapWord* end_addr = obj_addr + word_size;
-          if (end_addr < r->end()) {
-            size_t humongous_waste = (r->end() - end_addr) * HeapWordSize;
-            young_humongous_waste += humongous_waste;
-          }
-          // else, this region is entirely spanned by humongous object so contributes no humongous waste
-        }
-        break;
-      case ShenandoahRegionAffiliation::OLD_GENERATION:
-        r = heap->get_region(i);
-        old_regions++;
-        old_usage += r->used();
-        if (r->is_humongous()) {
-          ShenandoahHeapRegion* start = r->humongous_start_region();
-          HeapWord* obj_addr = start->bottom();
-          oop obj = cast_to_oop(obj_addr);
-          size_t word_size = obj->size();
-          HeapWord* end_addr = obj_addr + word_size;
-          if (end_addr < r->end()) {
-            size_t humongous_waste = (r->end() - end_addr) * HeapWordSize;
-            old_humongous_waste += humongous_waste;
-          }
-          // else, this region is entirely spanned by humongous object so contributes no humongous waste
-        }
-        break;
-      default:
-        assert(false, "Should not reach");
-    }
-  }
-  heap->old_generation()->establish_usage(old_regions, old_usage, old_humongous_waste);
-  heap->young_generation()->establish_usage(young_regions, young_usage, young_humongous_waste);
 }

--- a/src/hotspot/share/gc/shenandoah/shenandoahFullGC.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahFullGC.cpp
@@ -324,7 +324,7 @@ void ShenandoahFullGC::do_it(GCCause::Cause gc_cause) {
     phase4_compact_objects(worker_slices);
 
     if (heap->mode()->is_generational()) {
-      phase5_restore_generation_accounts();
+      phase5_restore_generation_usage();
     }
   }
 
@@ -1483,7 +1483,7 @@ void ShenandoahFullGC::phase4_compact_objects(ShenandoahHeapRegionSet** worker_s
   heap->clear_cancelled_gc(true /* clear oom handler */);
 }
 
-void ShenandoahFullGC::phase5_restore_generation_accounts() {
+void ShenandoahFullGC::phase5_restore_generation_usage() {
   GCTraceTime(Info, gc, phases) time("Phase 5: Restore generation accounts", _gc_timer);
   ShenandoahHeap* heap = ShenandoahHeap::heap();
   size_t num_regions = heap->num_regions();

--- a/src/hotspot/share/gc/shenandoah/shenandoahFullGC.hpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahFullGC.hpp
@@ -81,6 +81,7 @@ private:
   void phase2_calculate_target_addresses(ShenandoahHeapRegionSet** worker_slices);
   void phase3_update_references();
   void phase4_compact_objects(ShenandoahHeapRegionSet** worker_slices);
+  void phase5_restore_generation_accounts();
 
   void distribute_slices(ShenandoahHeapRegionSet** worker_slices);
   void calculate_target_humongous_objects();

--- a/src/hotspot/share/gc/shenandoah/shenandoahFullGC.hpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahFullGC.hpp
@@ -81,7 +81,7 @@ private:
   void phase2_calculate_target_addresses(ShenandoahHeapRegionSet** worker_slices);
   void phase3_update_references();
   void phase4_compact_objects(ShenandoahHeapRegionSet** worker_slices);
-  void phase5_restore_generation_accounts();
+  void phase5_restore_generation_usage();
 
   void distribute_slices(ShenandoahHeapRegionSet** worker_slices);
   void calculate_target_humongous_objects();

--- a/src/hotspot/share/gc/shenandoah/shenandoahFullGC.hpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahFullGC.hpp
@@ -81,7 +81,7 @@ private:
   void phase2_calculate_target_addresses(ShenandoahHeapRegionSet** worker_slices);
   void phase3_update_references();
   void phase4_compact_objects(ShenandoahHeapRegionSet** worker_slices);
-  void phase5_restore_generation_usage();
+  void phase5_epilog();
 
   void distribute_slices(ShenandoahHeapRegionSet** worker_slices);
   void calculate_target_humongous_objects();

--- a/src/hotspot/share/gc/shenandoah/shenandoahGeneration.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahGeneration.cpp
@@ -943,6 +943,13 @@ size_t ShenandoahGeneration::decrement_affiliated_region_count() {
   return _affiliated_region_count;
 }
 
+void ShenandoahGeneration::establish_usage(size_t num_regions, size_t num_bytes, size_t humongous_waste) {
+  assert(ShenandoahSafepoint::is_at_shenandoah_safepoint(), "must be at a safepoint");
+  _affiliated_region_count = num_regions;
+  _used = num_bytes;
+  // future improvement: _humongous_waste = humongous_waste;
+}
+
 void ShenandoahGeneration::clear_used() {
   assert(ShenandoahSafepoint::is_at_shenandoah_safepoint(), "must be at a safepoint");
   // Do this atomically to assure visibility to other threads, even though these other threads may be idle "right now"..

--- a/src/hotspot/share/gc/shenandoah/shenandoahGeneration.hpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahGeneration.hpp
@@ -183,6 +183,8 @@ private:
   // Return the updated value of affiliated_region_count
   size_t decrement_affiliated_region_count();
 
+  void establish_usage(size_t num_regions, size_t num_bytes, size_t humongous_waste);
+
   void clear_used();
   void increase_used(size_t bytes);
   void decrease_used(size_t bytes);

--- a/src/hotspot/share/gc/shenandoah/shenandoahPhaseTimings.hpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahPhaseTimings.hpp
@@ -178,6 +178,7 @@ class outputStream;
   f(full_gc_copy_objects,                           "  Copy Objects")                  \
   f(full_gc_copy_objects_regular,                   "    Regular Objects")             \
   f(full_gc_copy_objects_humong,                    "    Humongous Objects")           \
+  f(full_gc_recompute_generation_usage,             "    Recompute generation usage")  \
   f(full_gc_copy_objects_reset_complete,            "    Reset Complete Bitmap")       \
   f(full_gc_copy_objects_rebuild,                   "    Rebuild Region Sets")         \
   f(full_gc_reconstruct_remembered_set,             "    Reconstruct Remembered Set")  \


### PR DESCRIPTION
This fix addresses a problem found during verification following full gcs.  This recomputes the generation usage at the end of full GC as part of a 5th phase of full gc.

We may be able to remove this 5th phase at a later time after we find and fix whatever errors exist in generation accounting in the existing full gc implementation.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed (1 review required, with at least 1 [Committer](https://openjdk.org/bylaws#committer))

### Reviewers
 * [Y. Srinivas Ramakrishna](https://openjdk.org/census#ysr) (@ysramakrishna - Author)
 * [William Kemper](https://openjdk.org/census#wkemper) (@earthling-amzn - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/shenandoah.git pull/235/head:pull/235` \
`$ git checkout pull/235`

Update a local copy of the PR: \
`$ git checkout pull/235` \
`$ git pull https://git.openjdk.org/shenandoah.git pull/235/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 235`

View PR using the GUI difftool: \
`$ git pr show -t 235`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/shenandoah/pull/235.diff">https://git.openjdk.org/shenandoah/pull/235.diff</a>

</details>
