### PR TITLE
Abandon mixed collections if all candidates are pinned

### DIFF
--- a/src/hotspot/share/gc/shenandoah/heuristics/shenandoahOldHeuristics.hpp
+++ b/src/hotspot/share/gc/shenandoah/heuristics/shenandoahOldHeuristics.hpp
@@ -161,6 +161,7 @@ public:
 
  private:
   void slide_pinned_regions_to_front();
+  bool all_candidates_are_pinned();
 };
 
 #endif // SHARE_GC_SHENANDOAH_HEURISTICS_SHENANDOAHOLDHEURISTICS_HPP

--- a/src/hotspot/share/gc/shenandoah/shenandoahControlThread.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahControlThread.cpp
@@ -507,6 +507,7 @@ void ShenandoahControlThread::service_concurrent_old_cycle(const ShenandoahHeap*
   TraceCollectorStats tcs(heap->monitoring_support()->concurrent_collection_counters());
 
   switch (original_state) {
+    case ShenandoahOldGeneration::WAITING_FOR_FILL:
     case ShenandoahOldGeneration::IDLE: {
       assert(!heap->is_concurrent_old_mark_in_progress(), "Old already in progress.");
       assert(old_generation->task_queues()->is_empty(), "Old mark queues should be empty.");

--- a/src/hotspot/share/gc/shenandoah/shenandoahGeneration.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahGeneration.cpp
@@ -249,9 +249,8 @@ void ShenandoahGeneration::compute_evacuation_budgets(ShenandoahHeap* heap, bool
   // accumulate there until they can be promoted.  This increases the young-gen marking and evacuation work.
 
   // Do not fill up old-gen memory with promotions.  Reserve some amount of memory for compaction purposes.
-  ShenandoahOldHeuristics* old_heuristics = heap->old_heuristics();
   size_t young_evac_reserve_max = 0;
-  if (old_heuristics->unprocessed_old_collection_candidates() > 0) {
+  if (heap->doing_mixed_evacuations()) {
     // Compute old_evacuation_reserve: how much memory are we reserving to hold the results of
     // evacuating old-gen heap regions?  In order to sustain a consistent pace of young-gen collections,
     // the goal is to maintain a consistent value for this parameter (when the candidate set is not

--- a/src/hotspot/share/gc/shenandoah/shenandoahHeap.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahHeap.cpp
@@ -678,7 +678,7 @@ ShenandoahOldHeuristics* ShenandoahHeap::old_heuristics() {
 }
 
 bool ShenandoahHeap::doing_mixed_evacuations() {
-  return old_heuristics()->unprocessed_old_collection_candidates() > 0;
+  return _old_generation->state() == ShenandoahOldGeneration::WAITING_FOR_EVAC;
 }
 
 bool ShenandoahHeap::is_old_bitmap_stable() const {
@@ -1068,10 +1068,7 @@ void ShenandoahHeap::cancel_old_gc() {
 }
 
 bool ShenandoahHeap::is_old_gc_active() {
-  return is_concurrent_old_mark_in_progress()
-         || is_prepare_for_old_mark_in_progress()
-         || old_heuristics()->unprocessed_old_collection_candidates() > 0
-         || young_generation()->old_gen_task_queues() != nullptr;
+  return _old_generation->state() != ShenandoahOldGeneration::IDLE;
 }
 
 void ShenandoahHeap::coalesce_and_fill_old_regions() {

--- a/src/hotspot/share/gc/shenandoah/shenandoahOldGeneration.hpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahOldGeneration.hpp
@@ -80,7 +80,7 @@ class ShenandoahOldGeneration : public ShenandoahGeneration {
   virtual void record_success_concurrent(bool abbreviated) override;
 
   enum State {
-    IDLE, FILLING, BOOTSTRAPPING, MARKING, WAITING
+    IDLE, FILLING, BOOTSTRAPPING, MARKING, WAITING_FOR_EVAC, WAITING_FOR_FILL
   };
 
   static const char* state_name(State state);
@@ -93,6 +93,10 @@ class ShenandoahOldGeneration : public ShenandoahGeneration {
 
   State state() const {
     return _state;
+  }
+
+  bool can_start_gc() {
+    return _state == IDLE || _state == WAITING_FOR_FILL;
   }
 
  private:

--- a/src/hotspot/share/gc/shenandoah/shenandoah_globals.hpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoah_globals.hpp
@@ -451,6 +451,12 @@
   product(bool, ShenandoahAllocFailureALot, false, DIAGNOSTIC,              \
           "Testing: make lots of artificial allocation failures.")          \
                                                                             \
+  product(uintx, ShenandoahCoalesceChance, 0, DIAGNOSTIC,                   \
+          "Testing: Abandon this percentage of mixed collections. "         \
+          "Abandoning a mixed collection will cause the old regions to "    \
+          "be made parseable, rather than being evacuated.")                \
+          range(0, 100)                                                     \
+                                                                            \
   product(intx, ShenandoahMarkScanPrefetch, 32, EXPERIMENTAL,               \
           "How many objects to prefetch ahead when traversing mark bitmaps."\
           "Set to 0 to disable prefetching.")                               \


### PR DESCRIPTION
A new `WAITING_FOR_FILL` state has been added. This state is now entered when all the candidates for a mixed collection cycle are found to be pinned (which should be quite rare). This state permits a new old generation collection cycle to begin (which itself begins with making these regions parseable).

This change also adds a new diagnostic flag `ShenandoahCoalesceChance` which is the probability (expressed as a percentage) of abandoning all the candidates of a mixed collection. Any abandoned candidate regions will be made parseable.