### PR TITLE
Remove assertions constraining card marking for reference processing

### DIFF
--- a/src/hotspot/share/gc/shenandoah/shenandoahReferenceProcessor.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahReferenceProcessor.cpp
@@ -69,7 +69,8 @@ static void card_mark_barrier(T* field, oop value) {
     // of old and young _references_. These references are linked together through the
     // discovered field in java.lang.Reference. In some cases, creating or editing this
     // list may result in the creation of _new_ old-to-young pointers which must dirty
-    // the corresponding card. Failing to do this may cause heap verification errors.
+    // the corresponding card. Failing to do this may cause heap verification errors and
+    // lead to incorrect GC behavior.
     heap->card_scan()->mark_card_as_dirty(reinterpret_cast<HeapWord*>(field));
   }
 }

--- a/src/hotspot/share/gc/shenandoah/shenandoahReferenceProcessor.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahReferenceProcessor.cpp
@@ -64,22 +64,12 @@ static void card_mark_barrier(T* field, oop value) {
   ShenandoahHeap* heap = ShenandoahHeap::heap();
   assert(heap->is_in_or_null(value), "Should be in heap");
   if (heap->mode()->is_generational() && heap->is_in_old(field) && heap->is_in_young(value)) {
-    // We expect this to really be needed only during global collections. Young collections
-    // discover j.l.r.Refs in the old generation during scanning of dirty cards
-    // and these point to (as yet unmarked) referents in the young generation (see
-    // ShenandoahReferenceProcessor::should_discover). Those cards will continue to
-    // remain dirty on account of this cross-generational pointer to the referent.
-    // Similarly, old collections will never discover j.l.r.Refs in the young generation.
-    // It is only global collections that discover in both generations. Here we can
-    // end up with a j.l.R in the old generation on the discovered list that
-    // is not already on a dirty card, but which may here end up with a successor in
-    // the discovered list that is in the young generation. This is the singular case
-    // where the card needs to be dirtied here. We, however, skip the extra global'ness check
-    // and always mark the card (redundantly during young collections).
-    // The asserts below check the expected invariants based on the description above.
-    assert(!heap->active_generation()->is_old(), "Expecting only young or global");
-    assert(heap->card_scan()->is_card_dirty(reinterpret_cast<HeapWord*>(field))
-           || heap->active_generation()->is_global(), "Expecting already dirty if young");
+    // For Shenandoah, each generation collects all the _referents_ that belong to the
+    // collected generation. We can end up with discovered lists that contain a mixture
+    // of old and young _references_. These references are linked together through the
+    // discovered field in java.lang.Reference. In some cases, creating or editing this
+    // list may result in the creation of _new_ old-to-young pointers which must dirty
+    // the corresponding card. Failing to do this may cause heap verification errors.
     heap->card_scan()->mark_card_as_dirty(reinterpret_cast<HeapWord*>(field));
   }
 }


### PR DESCRIPTION
Shenandoah does _referent_ based processing for weak reference processing. We may see a mix of young and old references on the discovered list. We therefore need to mark cards for old references linked on the discovered list to young references to satisfy remembered set verification. These references may be mixed in any collection cycle.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed (1 review required, with at least 1 [Committer](https://openjdk.org/bylaws#committer))

### Reviewers
 * [Kelvin Nilsen](https://openjdk.org/census#kdnilsen) (@kdnilsen - Committer) ⚠️ Review applies to [1185eabf](https://git.openjdk.org/shenandoah/pull/241/files/1185eabfa2705a92bbaa817c2c8834fb8de58677)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/shenandoah.git pull/241/head:pull/241` \
`$ git checkout pull/241`

Update a local copy of the PR: \
`$ git checkout pull/241` \
`$ git pull https://git.openjdk.org/shenandoah.git pull/241/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 241`

View PR using the GUI difftool: \
`$ git pr show -t 241`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/shenandoah/pull/241.diff">https://git.openjdk.org/shenandoah/pull/241.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/shenandoah/pull/241#issuecomment-1496225381)