### PR TITLE
Fix build error on MacOS / Clang 14.0.0

### DIFF
--- a/src/hotspot/share/gc/shenandoah/mode/shenandoahGenerationalMode.hpp
+++ b/src/hotspot/share/gc/shenandoah/mode/shenandoahGenerationalMode.hpp
@@ -48,7 +48,7 @@ const char* generation_name(GenerationMode mode);
 class ShenandoahGenerationalMode : public ShenandoahMode {
 public:
   virtual void initialize_flags() const;
-  virtual ShenandoahHeuristics* initialize_heuristics(ShenandoahGeneration* generation) const override;
+  virtual ShenandoahHeuristics* initialize_heuristics(ShenandoahGeneration* generation) const;
   virtual const char* name()     { return "Generational"; }
   virtual bool is_diagnostic()   { return false; }
   virtual bool is_experimental() { return false; }


### PR DESCRIPTION
MacOS / Clang 14.0.0 currently fails with lot of errors like:

```
/Users/shipilev/Work/shipilev-shenandoah/src/hotspot/share/gc/shenandoah/mode/shenandoahGenerationalMode.hpp:55:16: warning: 'is_generational' overrides a member function but is not marked 'override' [-Winconsistent-missing-override]
  virtual bool is_generational() { return true; }
               ^
/Users/shipilev/Work/shipilev-shenandoah/src/hotspot/share/gc/shenandoah/mode/shenandoahMode.hpp:59:16: note: overridden virtual function is here
  virtual bool is_generational() { return false; }
               ^
```

Remarkably, no other heuristics are affected by this, even though they do not have `override`-s on them. I think the actual cause is that we use `override` once in the `ShenandoahGenerationalMode`, that is enough to flag this class for inconsistencies. So the easiest fix is to drop `override`.

Additional testing:
 - [x] macos-aarch64-server-fastdebug build