### PR TITLE
Fix Zero builds

### DIFF
--- a/src/hotspot/share/gc/shenandoah/heuristics/shenandoahAdaptiveHeuristics.cpp
+++ b/src/hotspot/share/gc/shenandoah/heuristics/shenandoahAdaptiveHeuristics.cpp
@@ -27,6 +27,7 @@
 #include "gc/shenandoah/heuristics/shenandoahAdaptiveHeuristics.hpp"
 #include "gc/shenandoah/shenandoahCollectionSet.hpp"
 #include "gc/shenandoah/shenandoahFreeSet.hpp"
+#include "gc/shenandoah/shenandoahHeap.inline.hpp"
 #include "gc/shenandoah/shenandoahGeneration.hpp"
 #include "gc/shenandoah/shenandoahYoungGeneration.hpp"
 #include "logging/log.hpp"


### PR DESCRIPTION
Current Zero builds (including ones in GHA) fail like this:

```
In file included from /Users/shipilev/Work/shipilev-shenandoah/src/hotspot/share/gc/shenandoah/heuristics/shenandoahAdaptiveHeuristics.cpp:28:
In file included from /Users/shipilev/Work/shipilev-shenandoah/src/hotspot/share/gc/shenandoah/shenandoahCollectionSet.hpp:30:
/Users/shipilev/Work/shipilev-shenandoah/src/hotspot/share/gc/shenandoah/shenandoahHeap.hpp:452:17: error: inline function 'ShenandoahHeap::get_young_evac_reserve' is not defined [-Werror,-Wundefined-inline]
  inline size_t get_young_evac_reserve() const;
                ^
/Users/shipilev/Work/shipilev-shenandoah/src/hotspot/share/gc/shenandoah/heuristics/shenandoahAdaptiveHeuristics.cpp:110:50: note: used here
      size_t max_young_cset    = (size_t) (heap->get_young_evac_reserve() / ShenandoahEvacWaste);
```

This is because with Zero, we don't have the transitive include to `shenandoahHeap.inline.hpp`, yet `shenandoahAdaptiveHeuristics.cpp` uses it. The fix is -- as usual -- to add the explicit include.

Additional testing:
  - [x] macosx-aarch64-zero-fastdebug
  - [x] GHA

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed (1 review required, with at least 1 [Committer](https://openjdk.org/bylaws#committer))

### Reviewers
 * [Kelvin Nilsen](https://openjdk.org/census#kdnilsen) (@kdnilsen - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/shenandoah.git pull/244/head:pull/244` \
`$ git checkout pull/244`

Update a local copy of the PR: \
`$ git checkout pull/244` \
`$ git pull https://git.openjdk.org/shenandoah.git pull/244/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 244`

View PR using the GUI difftool: \
`$ git pr show -t 244`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/shenandoah/pull/244.diff">https://git.openjdk.org/shenandoah/pull/244.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/shenandoah/pull/244#issuecomment-1496481329)