### PR TITLE
DRAFT: Expand old on demand

### DIFF
--- a/src/hotspot/share/gc/shenandoah/heuristics/shenandoahAdaptiveHeuristics.hpp
+++ b/src/hotspot/share/gc/shenandoah/heuristics/shenandoahAdaptiveHeuristics.hpp
@@ -39,7 +39,6 @@ class ShenandoahAllocationRate : public CHeapObj<mtGC> {
 
   double upper_bound(double sds) const;
   bool is_spiking(double rate, double threshold) const;
-
  private:
 
   double instantaneous_rate(double time, size_t allocated) const;
@@ -47,7 +46,14 @@ class ShenandoahAllocationRate : public CHeapObj<mtGC> {
   double _last_sample_time;
   size_t _last_sample_value;
   double _interval_sec;
+#undef KELVIN_HACK
+#ifdef KELVIN_HACK
+  public:
   TruncatedSeq _rate;
+  private:
+#else
+  TruncatedSeq _rate;
+#endif
   TruncatedSeq _rate_avg;
 };
 
@@ -72,6 +78,8 @@ public:
   virtual bool is_diagnostic()   { return false; }
   virtual bool is_experimental() { return false; }
 
+  virtual size_t evac_slack(size_t young_regions_to_be_recycled);
+
  private:
   // These are used to adjust the margin of error and the spike threshold
   // in response to GC cycle outcomes. These values are shared, but the
@@ -84,13 +92,6 @@ public:
 
   const static double LOWEST_EXPECTED_AVAILABLE_AT_END;
   const static double HIGHEST_EXPECTED_AVAILABLE_AT_END;
-
-  // At least this many cycles must execute before the heuristic will attempt
-  // to resize its generation. This is to prevent the heuristic from rapidly
-  // maxing out the generation size (which only forces the collector for the
-  // other generation to run more frequently, defeating the purpose of improving
-  // MMU).
-  const static uint MINIMUM_RESIZE_INTERVAL;
 
   friend class ShenandoahAllocationRate;
 
@@ -105,8 +106,6 @@ public:
   void adjust_last_trigger_parameters(double amount);
   void adjust_margin_of_error(double amount);
   void adjust_spike_threshold(double amount);
-
-  bool resize_and_evaluate();
 
   ShenandoahAllocationRate _allocation_rate;
 
@@ -135,10 +134,6 @@ public:
   // establishes what is 'normal' for the application and is used as a
   // source of feedback to adjust trigger parameters.
   TruncatedSeq _available;
-
-  // Do not attempt to resize the generation for this heuristic until this
-  // value is greater than MINIMUM_RESIZE_INTERVAL.
-  uint _cycles_since_last_resize;
 };
 
 #endif // SHARE_GC_SHENANDOAH_HEURISTICS_SHENANDOAHADAPTIVEHEURISTICS_HPP

--- a/src/hotspot/share/gc/shenandoah/heuristics/shenandoahHeuristics.cpp
+++ b/src/hotspot/share/gc/shenandoah/heuristics/shenandoahHeuristics.cpp
@@ -39,11 +39,22 @@
 #include "logging/log.hpp"
 #include "logging/logTag.hpp"
 #include "runtime/globals_extension.hpp"
+#include "utilities/quickSort.hpp"
 
+// sort by decreasing garbage (so most garbage comes first)
 int ShenandoahHeuristics::compare_by_garbage(RegionData a, RegionData b) {
-  if (a._garbage > b._garbage)
+  if (a._u._garbage > b._u._garbage)
     return -1;
-  else if (a._garbage < b._garbage)
+  else if (a._u._garbage < b._u._garbage)
+    return 1;
+  else return 0;
+}
+
+// sort by increasing live (so least live comes first)
+int ShenandoahHeuristics::compare_by_live(RegionData a, RegionData b) {
+  if (a._u._live_data < b._u._live_data)
+    return -1;
+  else if (a._u._live_data > b._u._live_data)
     return 1;
   else return 0;
 }
@@ -76,23 +87,196 @@ ShenandoahHeuristics::~ShenandoahHeuristics() {
   FREE_C_HEAP_ARRAY(RegionGarbage, _region_data);
 }
 
+typedef struct {
+  ShenandoahHeapRegion* _region;
+  size_t _live_data;
+} AgedRegionData;
+
+static int compare_by_aged_live(AgedRegionData a, AgedRegionData b) {
+  if (a._live_data < b._live_data)
+    return -1;
+  else if (a._live_data > b._live_data)
+    return 1;
+  else return 0;
+}
+
+// Returns bytes of old-gen memory consumed by selected aged regions
 size_t ShenandoahHeuristics::select_aged_regions(size_t old_available, size_t num_regions, bool preselected_regions[]) {
   ShenandoahHeap* heap = ShenandoahHeap::heap();
+  ShenandoahMarkingContext* const ctx = heap->marking_context();
   size_t old_consumed = 0;
+  size_t promo_potential = 0;
+  size_t anticipated_promote_in_place_live = 0;
+#undef KELVIN_PRESELECT
+#ifdef KELVIN_PRESELECT
+  log_info(gc, ergo)("selecting aged regions with budget " SIZE_FORMAT, old_available);
+#endif
   if (heap->mode()->is_generational()) {
+    heap->clear_promotion_in_place_potential();
+    heap->clear_promotion_potential();
+    size_t candidates = 0;
+    size_t candidates_live = 0;
+    size_t old_garbage_threshold = (ShenandoahHeapRegion::region_size_bytes() * ShenandoahOldGarbageThreshold) / 100;
+    size_t promote_in_place_regions = 0;
+    size_t promote_in_place_live = 0;
+    size_t promote_in_place_pad = 0;
+    size_t anticipated_candidates = 0;
+    size_t anticipated_promote_in_place_regions = 0;
+
+    // sort the promotion-eligible regions according to live-data-bytes so that we can first reclaim the larger numbers
+    // of regions that require less evacuation effort.  This prioritizes garbage first, expanding the allocation pool before
+    // we begin the work of reclaiming regions that require more effort.
+    AgedRegionData* sorted_regions = (AgedRegionData*) alloca(num_regions * sizeof(AgedRegionData));
     for (size_t i = 0; i < num_regions; i++) {
-      ShenandoahHeapRegion* region = heap->get_region(i);
-      if (in_generation(region) && !region->is_empty() && region->is_regular() && (region->age() >= InitialTenuringThreshold)) {
-        size_t promotion_need = (size_t) (region->get_live_data_bytes() * ShenandoahEvacWaste);
-        if (old_consumed + promotion_need < old_available) {
-          old_consumed += promotion_need;
-          preselected_regions[i] = true;
+      ShenandoahHeapRegion* r = heap->get_region(i);
+      if (r->is_empty() || !r->has_live() || !r->is_young() || !r->is_regular()) {
+        continue;
+      }
+      if (r->age() >= InitialTenuringThreshold) {
+#ifdef KELVIN_PRESELECT
+        log_info(gc, ergo)("Consider selection of region " SIZE_FORMAT " (candidate: " SIZE_FORMAT
+                           ", age: %d, garbage: " SIZE_FORMAT " < " SIZE_FORMAT ")"
+                           ", min_fill: " SIZE_FORMAT ", original top: " PTR_FORMAT,
+                           i, promote_in_place_regions, r->age(), r->garbage(), old_garbage_threshold,
+                           ShenandoahHeap::min_fill_size(), p2i(r->top()));
+#endif
+        r->save_top_before_promote();
+        if ((r->garbage() < old_garbage_threshold)) {
+          HeapWord* tams = ctx->top_at_mark_start(r);
+          HeapWord* original_top = r->top();
+          if (tams == original_top) {
+            // Fill the remnant memory within this region to assure no allocations prior to promote in place.  Otherwise,
+            // newly allocated objects will not be parseable when promote in place tries to register them.  Furthermore, any
+            // new allocations would not necessarily be eligible for promotion.  This addresses both issues.
+            size_t remnant_size = r->free() / HeapWordSize;
+            if (remnant_size > ShenandoahHeap::min_fill_size()) {
+              ShenandoahHeap::fill_with_object(original_top, remnant_size);
+              r->set_top(r->end());
+	      promote_in_place_pad += remnant_size * HeapWordSize;
+            }
+            // else, the remnant is too small to be allocated by any thread, so we don't have a problem.
+#ifdef KELVIN_PRESELECT
+            log_info(gc, ergo)("Promote in place region " SIZE_FORMAT " (candidate: " SIZE_FORMAT
+                               ", age: %d, garbage: " SIZE_FORMAT " < " SIZE_FORMAT ")"
+                               ", remnant: " SIZE_FORMAT ", min_fill: " SIZE_FORMAT
+                               ", original top: " PTR_FORMAT ", adjusted top: " PTR_FORMAT,
+                               i, promote_in_place_regions, r->age(), r->garbage(), old_garbage_threshold,
+                               remnant_size, ShenandoahHeap::min_fill_size(), p2i(original_top), p2i(r->top()));
+#endif
+            promote_in_place_regions++;
+            promote_in_place_live += r->get_live_data_bytes();
+          }
+          // Else, we do not promote this region (either in place or by copy) because it has received new allocations.
+
+          // During evacuation, we exclude from promotion regions for which age > tenure threshold, garbage < garbage-threshold,
+          //  and get_top_before_promote() != tams
+        } else {
+          // After sorting and selecting best candidates below, we may decide to exclude this promotion-eligible region
+          // from the current collection sets.  If this happens, we will consider this region as part of the anticipated
+          // promotion potential for the next GC pass.
+#ifdef KELVIN_PRESELECT
+          log_info(gc, ergo)("Consider promoting region " SIZE_FORMAT " (candidate: " SIZE_FORMAT ", age: %d, garbage: " SIZE_FORMAT " >= " SIZE_FORMAT ")",
+                             i, candidates, r->age(), r->garbage(), old_garbage_threshold);
+#endif
+          size_t live_data = r->get_live_data_bytes();
+          candidates_live += live_data;
+          sorted_regions[candidates]._region = r;
+          sorted_regions[candidates++]._live_data = live_data;
         }
-        // Note that we keep going even if one region is excluded from selection.  Subsequent regions may be selected
-        // if they have smaller live data.
+      } else {
+
+        // Only anticipate to promote regular regions if garbage() is above threshold.  Note that certain regions that are
+        // excluded from anticipated promotion because their garbage content is too low (causing us to anticipate that
+        // the region would be promoted in place) may be eligible for promotion by the time promotion takes place because
+        // more garbage is found within the region between now and then.  This should not happen if we are properly adapting
+        // the tenure age.  We won't tenure objects until they exhibit at least one full GC pass without further decline
+        // in population.
+        //
+        // If this does occur by accident, the most likely impact is that there will not be sufficient available space in
+        // old-gen to hold the live data to be copied out of this region, so the region will not be selected for the
+        // current collection set.  The region will be tallied into the anticipated promotion for the next cycle and
+        // will be collected at that time.
+        //
+        // TODO:
+        //   If we are auto-tuning the tenure age and this occurs, use this as guidance that tenure age should be increased.
+
+        if (r->age() + 1 == InitialTenuringThreshold) {
+          if (r->garbage() >= old_garbage_threshold) {
+#ifdef KELVIN_PRESELECT
+            log_info(gc, ergo)("Anticipating promotion of regular region " SIZE_FORMAT " (candidate: " SIZE_FORMAT ", age %u, live: " SIZE_FORMAT
+                               ", garbage: " SIZE_FORMAT ")",
+                               r->index(), anticipated_candidates, r->age(), r->get_live_data_bytes(), r->garbage());
+#endif
+            anticipated_candidates++;
+            promo_potential += r->get_live_data_bytes();
+          }
+          else {
+#ifdef KELVIN_PRESELECT
+            log_info(gc, ergo)("Anticipating promote-in-place of %s region " SIZE_FORMAT " (candidate: " SIZE_FORMAT
+                               ", age %u, live: " SIZE_FORMAT ", garbage: " SIZE_FORMAT ")",
+                               r->is_regular()? "regular": "humongous",
+                               r->index(), anticipated_promote_in_place_regions, r->age(), r->get_live_data_bytes(), r->garbage());
+#endif
+            anticipated_promote_in_place_regions++;
+            anticipated_promote_in_place_live += r->get_live_data_bytes();
+          }
+        }
       }
     }
+#ifdef KELVIN_PRESELECT
+    log_info(gc, ergo)("Preselect midpoint: regular regions to promote in place: " SIZE_FORMAT ", representing " SIZE_FORMAT
+                       " live, promo candidates: " SIZE_FORMAT ", spanning live: " SIZE_FORMAT,
+                       promote_in_place_regions, promote_in_place_live, candidates, candidates_live);
+    log_info(gc, ergo)("  anticipated regular regions to promote in place candidates: " SIZE_FORMAT ", representing " SIZE_FORMAT
+                       " live, anticipated promote by copy candidates: " SIZE_FORMAT " with potential: " SIZE_FORMAT,
+                       anticipated_promote_in_place_regions, anticipated_promote_in_place_live,
+                       anticipated_candidates, promo_potential);
+#endif
+    // Sort in increasing order according to live data bytes.  Note that candidates represents the number of regions
+    // that qualify to be promoted by evacuation.
+    if (candidates > 0) {
+      QuickSort::sort<AgedRegionData>(sorted_regions, candidates, compare_by_aged_live, false);
+      for (size_t i = 0; i < candidates; i++) {
+        size_t region_live_data = sorted_regions[i]._live_data;
+        size_t promotion_need = (size_t) (region_live_data * ShenandoahPromoEvacWaste);
+        if (old_consumed + promotion_need <= old_available) {
+          ShenandoahHeapRegion* region = sorted_regions[i]._region;
+#ifdef KELVIN_PRESELECT
+          log_info(gc, ergo)("Preselecting regular region " SIZE_FORMAT " with age %u, live: " SIZE_FORMAT
+                             ", garbage: " SIZE_FORMAT,
+                             region->index(), region->age(), region->get_live_data_bytes(), region->garbage());
+#endif
+          old_consumed += promotion_need;
+          preselected_regions[region->index()] = true;
+        } else {
+#ifdef KELVIN_PRESELECT
+          ShenandoahHeapRegion* region = sorted_regions[i]._region;
+          log_info(gc, ergo)("Region " SIZE_FORMAT " rejected because old_consumed: " SIZE_FORMAT ", budget: " SIZE_FORMAT
+                             ", adding to future promo potential (age: %d, live: " SIZE_FORMAT ", garbage: "
+                             SIZE_FORMAT " >= " SIZE_FORMAT ")", region->index(), old_consumed, old_available,
+                             region->age(), region->get_live_data_bytes(),
+                             region->garbage(), old_garbage_threshold);
+#endif
+          // We rejected this promotable region from the collection set because we had no room to hold its copy.
+          // Add this region to promo potential for next GC.
+          promo_potential += region_live_data;
+        }
+        // Note that we keep going even if one region is excluded from selection because we need to accumulate all
+        // eligible regions into promo_potential if not preselected.
+      }
+    }
+    heap->set_pad_for_promote_in_place(promote_in_place_pad);
+#undef KELVIN_PROMO_POTENTIAL
+#ifdef KELVIN_PROMO_POTENTIAL
+    log_info(gc, ergo)("Establishing promo potential as " SIZE_FORMAT, promo_potential);
+#endif
+    heap->set_promotion_potential(promo_potential);
+    heap->set_promotion_in_place_potential(anticipated_promote_in_place_live);
   }
+#ifdef KELVIN_PRESELECT
+  log_info(gc, ergo)("select_aged_regions consumed old reserve of " SIZE_FORMAT ", promo potential: " SIZE_FORMAT,
+                     old_consumed, promo_potential);
+#endif
   return old_consumed;
 }
 
@@ -113,6 +297,7 @@ void ShenandoahHeuristics::choose_collection_set(ShenandoahCollectionSet* collec
   RegionData* candidates = _region_data;
 
   size_t cand_idx = 0;
+  size_t preselected_candidates = 0;
 
   size_t total_garbage = 0;
 
@@ -123,37 +308,102 @@ void ShenandoahHeuristics::choose_collection_set(ShenandoahCollectionSet* collec
   size_t free_regions = 0;
   size_t live_memory = 0;
 
+  size_t old_garbage_threshold = (ShenandoahHeapRegion::region_size_bytes() * ShenandoahOldGarbageThreshold) / 100;
+  // This counts number of humongous regions that we intend to promote in this cycle.
+  size_t humongous_regions_promoted = 0;
+  // This counts bytes of memory used by hunongous regions to be promoted in place.
+  size_t humongous_bytes_promoted = 0;
+  // This counts number of regular regions that will be promoted in place.
+  size_t regular_regions_promoted_in_place = 0;
+  // This counts bytes of memory used by regular regions to be promoted in place.
+  size_t regular_regions_promoted_usage = 0;
+
+#undef KELVIN_CSET
+#ifdef KELVIN_CSET
+  log_info(gc, ergo)("Choosing collection set, confirm that young capacity greater than used_regions, old_heuristics: %s",
+                     old_heuristics? "NOT NULL": "NULL");
+  heap->young_generation()->log_status("At start choose_collection set");
+#endif
   for (size_t i = 0; i < num_regions; i++) {
     ShenandoahHeapRegion* region = heap->get_region(i);
+
     if (is_generational && !in_generation(region)) {
+#ifdef KELVIN_CSET
+      log_info(gc, ergo)("Ignoring %s region " SIZE_FORMAT " because not in generation",
+                         affiliation_name(region->affiliation()), region->index());
+#endif
       continue;
     }
 
     size_t garbage = region->garbage();
     total_garbage += garbage;
     if (region->is_empty()) {
+#ifdef KELVIN_CSET
+      log_info(gc, ergo)("Treating %s region " SIZE_FORMAT " as free",
+                         affiliation_name(region->affiliation()), region->index());
+#endif
       free_regions++;
       free += ShenandoahHeapRegion::region_size_bytes();
     } else if (region->is_regular()) {
       if (!region->has_live()) {
         // We can recycle it right away and put it in the free set.
+#ifdef KELVIN_CSET
+      log_info(gc, ergo)("Treating %s region " SIZE_FORMAT " as immediate garbage",
+                         affiliation_name(region->affiliation()), region->index());
+#endif
         immediate_regions++;
         immediate_garbage += garbage;
         region->make_trash_immediate();
       } else {
         assert (_generation->generation_mode() != OLD, "OLD is handled elsewhere");
         live_memory += region->get_live_data_bytes();
+        bool is_candidate;
         // This is our candidate for later consideration.
-        candidates[cand_idx]._region = region;
         if (is_generational && collection_set->is_preselected(i)) {
-          // If region is preselected, we know mode()->is_generational() and region->age() >= InitialTenuringThreshold)
-          garbage = ShenandoahHeapRegion::region_size_bytes();
+          // If !is_generational, we cannot ask if is_preselected.  If is_preselected, we know
+          //   region->age() >= InitialTenuringThreshold).
+          // Set garbage value to maximum value to force this into the sorted collection set.
+          is_candidate = true;
+#ifdef KELVIN_CSET
+          log_info(gc, ergo)("Preselected Region " SIZE_FORMAT " is placed in candidate set", region->index());
+#endif
+          preselected_candidates++;
+        } else if (is_generational && region->is_young() && (region->age() >= InitialTenuringThreshold)) {
+          // Note that for GLOBAL GC, region may be OLD, and OLD regions do not qualify for pre-selection
+
+          // This region is old enough to be promoted but it was not preselected, either because its garbage is below
+          // ShenandoahOldGarbageThreshold so it will be promoted in place, or because there is not sufficient room
+          // in old gen to hold the evacuated copies of this region's live data.  In both cases, we choose not to
+          // place this region into the collection set.
+          if (region->garbage_before_padded_for_promote() < old_garbage_threshold) {
+#ifdef KELVIN_CSET
+            log_info(gc, ergo)("Excluding region " SIZE_FORMAT " which will be promoted in place has usage: " SIZE_FORMAT,
+                               region->index(), region->used_before_promote());
+#endif
+            regular_regions_promoted_in_place++;
+            regular_regions_promoted_usage += region->used_before_promote();
+          } else {
+#ifdef KELVIN_CSET
+            log_info(gc, ergo)("Excluding aged region "
+                               SIZE_FORMAT " for which there is not sufficient old-gen space to promote at this time",
+                               region->index());
+#endif
+          }
+          is_candidate = false;
+        } else {
+#ifdef KELVIN_CSET
+          log_info(gc, ergo)("Regular unaged (%d) Region " SIZE_FORMAT ", is candidate for evacuation",
+                             region->age(), region->index());
+#endif
+          is_candidate = true;
         }
-        candidates[cand_idx]._garbage = garbage;
-        cand_idx++;
+        if (is_candidate) {
+          candidates[cand_idx]._region = region;
+          candidates[cand_idx]._u._garbage = garbage;
+          cand_idx++;
+        }
       }
     } else if (region->is_humongous_start()) {
-
       // Reclaim humongous regions here, and count them as the immediate garbage
 #ifdef ASSERT
       bool reg_live = region->has_live();
@@ -163,6 +413,9 @@ void ShenandoahHeuristics::choose_collection_set(ShenandoahCollectionSet* collec
              BOOL_TO_STR(reg_live), BOOL_TO_STR(bm_live), region->get_live_data_words());
 #endif
       if (!region->has_live()) {
+#ifdef KELVIN_CSET
+        log_info(gc, ergo)("Humongous region " SIZE_FORMAT ", is immediate trash", region->index());
+#endif
         heap->trash_humongous_region_at(region);
 
         // Count only the start. Continuations would be counted on "trash" path
@@ -170,15 +423,63 @@ void ShenandoahHeuristics::choose_collection_set(ShenandoahCollectionSet* collec
         immediate_garbage += garbage;
       } else {
         live_memory += region->get_live_data_bytes();
+        if (region->is_young() && region->age() >= InitialTenuringThreshold) {
+          oop obj = cast_to_oop(region->bottom());
+          size_t humongous_regions = ShenandoahHeapRegion::required_regions(obj->size() * HeapWordSize);
+          humongous_regions_promoted += humongous_regions;
+          humongous_bytes_promoted += obj->size() * HeapWordSize;
+
+#undef KELVIN_REPROMOTE
+#ifdef KELVIN_REPROMOTE
+          HeapWord* end_addr = region->bottom() + obj->size();
+          size_t waste = (region->bottom() + humongous_regions * ShenandoahHeapRegion::region_size_bytes()) - end_addr;
+          waste *= HeapWordSize;
+          log_info(gc, ergo)("Planning to promote " SIZE_FORMAT " %s humongous regions starting with index " SIZE_FORMAT
+                             ", representing " SIZE_FORMAT " used (live) bytes, waste: " SIZE_FORMAT,
+                             humongous_regions, affiliation_name(region->affiliation()),
+                             region->index(),  obj->size() * HeapWordSize, waste);
+#endif
+
+#ifdef KELVIN_CSET
+          log_info(gc, ergo)("Planning to promote " SIZE_FORMAT " humongous regions starting with index " SIZE_FORMAT
+                             ", representing " SIZE_FORMAT " used (live) bytes",
+                             humongous_regions, humongous_regions_promoted,  obj->size() * HeapWordSize);
+#endif
+        }
+#ifdef KELVIN_CSET
+        else {
+          log_info(gc, ergo)("Humongous %s region " SIZE_FORMAT " is not in collection candidates",
+                             affiliation_name(region->affiliation()), region->index());
+        }
+#endif
       }
     } else if (region->is_trash()) {
+#ifdef KELVIN_CSET
+      log_info(gc, ergo)("Treating %s region " SIZE_FORMAT " as trash", affiliation_name(region->affiliation()), region->index());
+#endif
       // Count in just trashed collection set, during coalesced CM-with-UR
       immediate_regions++;
       immediate_garbage += garbage;
     } else {                      // region->is_humongous_cont() and !region->is_trash()
+#ifdef KELVIN_CSET
+      log_info(gc, ergo)("Ignoring %s region " SIZE_FORMAT " with live memory: " SIZE_FORMAT,
+                         affiliation_name(region->affiliation()), region->index(), region->get_live_data_bytes());
+#endif
       live_memory += region->get_live_data_bytes();
     }
   }
+  heap->reserve_promotable_humongous_regions(humongous_regions_promoted);
+  heap->reserve_promotable_humongous_usage(humongous_bytes_promoted);
+  heap->reserve_promotable_regular_regions(regular_regions_promoted_in_place);
+  heap->reserve_promotable_regular_usage(regular_regions_promoted_usage);
+
+  log_info(gc, ergo)("Planning to promote in place " SIZE_FORMAT " humongous regions and " SIZE_FORMAT
+                     " regular regions, spanning a total of " SIZE_FORMAT " used bytes",
+                     humongous_regions_promoted, regular_regions_promoted_in_place,
+                     humongous_regions_promoted * ShenandoahHeapRegion::region_size_bytes() + regular_regions_promoted_usage);
+#ifdef KELVIN_CSET
+  log_info(gc, ergo)("Regular regions promoted usage: " SIZE_FORMAT, regular_regions_promoted_usage);
+#endif
 
   // Step 2. Look back at garbage statistics, and decide if we want to collect anything,
   // given the amount of immediately reclaimable garbage. If we do, figure out the collection set.
@@ -191,11 +492,23 @@ void ShenandoahHeuristics::choose_collection_set(ShenandoahCollectionSet* collec
   size_t immediate_percent = (total_garbage == 0) ? 0 : (immediate_garbage * 100 / total_garbage);
   collection_set->set_immediate_trash(immediate_garbage);
 
-  if (immediate_percent <= ShenandoahImmediateThreshold) {
+  ShenandoahGeneration* young_gen = heap->young_generation();
+  bool doing_promote_in_place = (humongous_regions_promoted + regular_regions_promoted_in_place > 0);
+#ifdef KELVIN_CSET
+  log_info(gc, ergo)("Promoted in place regions: " SIZE_FORMAT ", preselected_candidates: " SIZE_FORMAT
+                     ", immediate_percent: " SIZE_FORMAT ", threshold: " SIZE_FORMAT,
+                     humongous_regions_promoted + regular_regions_promoted_in_place, preselected_candidates,
+                     immediate_percent, ShenandoahImmediateThreshold);
+#endif
+  if (doing_promote_in_place || (preselected_candidates > 0) || (immediate_percent <= ShenandoahImmediateThreshold)) {
+#ifdef KELVIN_CSET
+    log_info(gc, ergo)("Prime the collection set here, old_heuristics: %s",
+                       old_heuristics? "NOT NULL": "NULL");
+#endif
     if (old_heuristics != nullptr) {
       old_heuristics->prime_collection_set(collection_set);
     }
-    // else, this is global collection and doesn't need to prime_collection_set
+    // else, this is non-generational or global collection and doesn't need to prime_collection_set
 
     // Add young-gen regions into the collection set.  This is a virtual call, implemented differently by each
     // of the heuristics subclasses.
@@ -231,11 +544,12 @@ void ShenandoahHeuristics::choose_collection_set(ShenandoahCollectionSet* collec
                      cset_percent,
                      collection_set->count());
 
-  if (collection_set->garbage() > 0) {
+  if (!collection_set->is_empty()) {
     size_t young_evac_bytes = collection_set->get_young_bytes_reserved_for_evacuation();
     size_t promote_evac_bytes = collection_set->get_young_bytes_to_be_promoted();
     size_t old_evac_bytes = collection_set->get_old_bytes_reserved_for_evacuation();
     size_t total_evac_bytes = young_evac_bytes + promote_evac_bytes + old_evac_bytes;
+
     log_info(gc, ergo)("Evacuation Targets: YOUNG: " SIZE_FORMAT "%s, "
                        "PROMOTE: " SIZE_FORMAT "%s, "
                        "OLD: " SIZE_FORMAT "%s, "
@@ -364,6 +678,12 @@ void ShenandoahHeuristics::initialize() {
   // Nothing to do by default.
 }
 
+size_t ShenandoahHeuristics::evac_slack(size_t young_regions_to_be_recycled) {
+  assert(false, "evac_slack() only implemented for young Adaptive Heuristics");
+  return 0;
+}
+
+
 double ShenandoahHeuristics::elapsed_cycle_time() const {
   return os::elapsedTime() - _cycle_start;
 }
@@ -375,9 +695,6 @@ bool ShenandoahHeuristics::in_generation(ShenandoahHeapRegion* region) {
 }
 
 size_t ShenandoahHeuristics::min_free_threshold() {
-  size_t min_free_threshold =
-      _generation->generation_mode() == GenerationMode::OLD
-          ? ShenandoahOldMinFreeThreshold
-          : ShenandoahMinFreeThreshold;
+  size_t min_free_threshold = ShenandoahMinFreeThreshold;
   return _generation->soft_max_capacity() / 100 * min_free_threshold;
 }

--- a/src/hotspot/share/gc/shenandoah/heuristics/shenandoahHeuristics.hpp
+++ b/src/hotspot/share/gc/shenandoah/heuristics/shenandoahHeuristics.hpp
@@ -70,7 +70,10 @@ protected:
 
   typedef struct {
     ShenandoahHeapRegion* _region;
-    size_t _garbage;
+    union {
+      size_t _garbage;          // Not used by old-gen heuristics.
+      size_t _live_data;        // Only used for old-gen heuristics, which prioritizes retention of _live_data over garbage reclaim
+    } _u;
   } RegionData;
 
   ShenandoahGeneration* _generation;
@@ -106,6 +109,7 @@ protected:
   ShenandoahSharedFlag _metaspace_oom;
 
   static int compare_by_garbage(RegionData a, RegionData b);
+  static int compare_by_live(RegionData a, RegionData b);
 
   // TODO: We need to enhance this API to give visibility to accompanying old-gen evacuation effort.
   // In the case that the old-gen evacuation effort is small or zero, the young-gen heuristics
@@ -169,6 +173,8 @@ public:
   virtual bool is_diagnostic() = 0;
   virtual bool is_experimental() = 0;
   virtual void initialize();
+
+  virtual size_t evac_slack(size_t region_to_be_recycled);
 
   double elapsed_cycle_time() const;
 };

--- a/src/hotspot/share/gc/shenandoah/heuristics/shenandoahOldHeuristics.hpp
+++ b/src/hotspot/share/gc/shenandoah/heuristics/shenandoahOldHeuristics.hpp
@@ -72,12 +72,18 @@ private:
   // This can be the 'static' or 'adaptive' heuristic.
   ShenandoahHeuristics* _trigger_heuristic;
 
+  // Keep a pointer to our generation that we can use without down casting a protected member from the base class.
+  ShenandoahOldGeneration* _old_generation;
+
   // Flag is set when promotion failure is detected (by gc thread), and cleared when
   // old generation collection begins (by control thread).
   volatile bool _promotion_failed;
 
-  // Keep a pointer to our generation that we can use without down casting a protected member from the base class.
-  ShenandoahOldGeneration* _old_generation;
+  // Flags are set when promotion failure is detected (by gc thread), and cleared when
+  // old generation collection begins (by control thread).  Flags are set and cleared at safepoints.
+  bool _cannot_expand_trigger;
+  bool _fragmentation_trigger;
+  bool _growth_trigger;
 
  protected:
   virtual void choose_collection_set_from_regiondata(ShenandoahCollectionSet* set, RegionData* data, size_t data_size,
@@ -126,6 +132,11 @@ public:
   // be evacuated into the young generation. The collection should complete normally, but we want to schedule
   // an old collection as soon as possible.
   void handle_promotion_failure();
+
+  void trigger_cannot_expand() { _cannot_expand_trigger = true; };
+  void trigger_old_is_fragmented() { _fragmentation_trigger = true; }
+  void trigger_old_has_grown() { _growth_trigger = true; }
+  void clear_triggers();
 
   virtual void record_cycle_start() override;
 

--- a/src/hotspot/share/gc/shenandoah/shenandoahAsserts.hpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahAsserts.hpp
@@ -168,6 +168,10 @@ public:
 
 #define shenandoah_assert_heaplocked_or_fullgc_safepoint() \
                     ShenandoahAsserts::assert_heaplocked_or_fullgc_safepoint(__FILE__, __LINE__)
+
+#define shenandoah_assert_control_thread() \
+                    assert(Thread::current() == ShenandoahHeap::heap()->control_thread(), "Expected control thread")
+
 #define shenandoah_assert_control_or_vm_thread() \
                     assert(Thread::current()->is_VM_thread() || Thread::current() == ShenandoahHeap::heap()->control_thread(), "Expected control thread or vm thread")
 
@@ -224,6 +228,7 @@ public:
 #define shenandoah_assert_not_heaplocked()
 #define shenandoah_assert_heaplocked_or_safepoint()
 #define shenandoah_assert_heaplocked_or_fullgc_safepoint()
+#define shenandoah_assert_control_thread()
 #define shenandoah_assert_control_or_vm_thread()
 #define shenandoah_assert_generational()
 

--- a/src/hotspot/share/gc/shenandoah/shenandoahCollectionSet.hpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahCollectionSet.hpp
@@ -64,6 +64,11 @@ private:
                                                 // for inclusion in collection set.  This field is only valid during brief
                                                 // spans of time while collection set is being constructed.
 
+  // When a region having memory available to be allocated is added to the collection set, the region's available memory
+  // should be subtracted from what's available.
+  size_t		_young_available_bytes_collected;
+  size_t		_old_available_bytes_collected;
+
   shenandoah_padding(0);
   volatile size_t       _current_index;
   shenandoah_padding(1);
@@ -108,6 +113,10 @@ public:
   inline size_t get_old_bytes_reserved_for_evacuation();
 
   inline size_t get_young_bytes_to_be_promoted();
+
+  size_t get_young_available_bytes_collected() { return _young_available_bytes_collected; }
+
+  size_t get_old_available_bytes_collected() { return _old_available_bytes_collected; }
 
   inline size_t get_old_region_count();
 

--- a/src/hotspot/share/gc/shenandoah/shenandoahControlThread.hpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahControlThread.hpp
@@ -172,11 +172,11 @@ public:
   void prepare_for_graceful_shutdown();
   bool in_graceful_shutdown();
 
-  void service_concurrent_normal_cycle(const ShenandoahHeap* heap,
+  void service_concurrent_normal_cycle(ShenandoahHeap* heap,
                                        const GenerationMode generation,
                                        GCCause::Cause cause);
 
-  void service_concurrent_old_cycle(const ShenandoahHeap* heap,
+  void service_concurrent_old_cycle(ShenandoahHeap* heap,
                                     GCCause::Cause &cause);
 
   void set_gc_mode(GCMode new_mode);

--- a/src/hotspot/share/gc/shenandoah/shenandoahFreeSet.hpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahFreeSet.hpp
@@ -64,17 +64,20 @@ private:
 
   void flip_to_gc(ShenandoahHeapRegion* r);
 
+  void adjust_bounds_for_additional_old_collector_free_region(size_t idx);
+
   void recompute_bounds();
   void adjust_bounds();
   bool touches_bounds(size_t num) const;
 
+  // Used of free set represents the amount of is_mutator_free set that has been consumed since most recent rebuild.
   void increase_used(size_t amount);
   void clear_internal();
 
   void try_recycle_trashed(ShenandoahHeapRegion *r);
 
   bool can_allocate_from(ShenandoahHeapRegion *r);
-  size_t alloc_capacity(ShenandoahHeapRegion *r);
+  size_t alloc_capacity(ShenandoahHeapRegion *r) const;
   bool has_no_alloc_capacity(ShenandoahHeapRegion *r);
 
 public:
@@ -87,7 +90,10 @@ public:
   size_t mutator_count()   const { return _mutator_free_bitmap.count_one_bits();   }
 
   void clear();
-  void rebuild();
+  void prepare_to_rebuild(size_t &young_cset_regions, size_t &old_cset_regions);
+  void rebuild(size_t young_reserve);
+
+  void add_old_collector_free_region(ShenandoahHeapRegion* region);
 
   void recycle_trash();
 

--- a/src/hotspot/share/gc/shenandoah/shenandoahFullGC.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahFullGC.cpp
@@ -1340,8 +1340,8 @@ public:
         account_for_region(r, _old_regions, _old_usage, _old_humongous_waste);
       } else if (r->is_young()) {
         account_for_region(r, _young_regions, _young_usage, _young_humongous_waste);
+      }
     }
-
     r->set_live_data(live);
     r->reset_alloc_metadata();
     _live += live;

--- a/src/hotspot/share/gc/shenandoah/shenandoahGeneration.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahGeneration.cpp
@@ -162,17 +162,18 @@ void ShenandoahGeneration::log_status(const char *msg) const {
   size_t v_soft_max_capacity = soft_max_capacity();
   size_t v_max_capacity = max_capacity();
   size_t v_available = available();
-  size_t v_adjusted_avail = adjusted_available();
+  size_t v_humongous_waste = get_humongous_waste();
   LogGcInfo::print("%s: %s generation used: " SIZE_FORMAT "%s, used regions: " SIZE_FORMAT "%s, "
-                   "soft capacity: " SIZE_FORMAT "%s, max capacity: " SIZE_FORMAT "%s, available: " SIZE_FORMAT "%s, "
-                   "adjusted available: " SIZE_FORMAT "%s",
-                   msg, name(),
+                   "humongous waste: " SIZE_FORMAT "%s, soft capacity: " SIZE_FORMAT "%s, max capacity: " SIZE_FORMAT "%s, "
+                   "available: " SIZE_FORMAT "%s", msg, name(),
                    byte_size_in_proper_unit(v_used), proper_unit_for_byte_size(v_used),
                    byte_size_in_proper_unit(v_used_regions), proper_unit_for_byte_size(v_used_regions),
+                   byte_size_in_proper_unit(v_humongous_waste), proper_unit_for_byte_size(v_humongous_waste),
                    byte_size_in_proper_unit(v_soft_max_capacity), proper_unit_for_byte_size(v_soft_max_capacity),
                    byte_size_in_proper_unit(v_max_capacity), proper_unit_for_byte_size(v_max_capacity),
-                   byte_size_in_proper_unit(v_available), proper_unit_for_byte_size(v_available),
-                   byte_size_in_proper_unit(v_adjusted_avail), proper_unit_for_byte_size(v_adjusted_avail));
+                   byte_size_in_proper_unit(v_available), proper_unit_for_byte_size(v_available));
+  // This detects arithmetic underflow of unsigned usage value
+  assert(v_used <= ShenandoahHeap::heap()->capacity(), "Generation capacity must be less than heap capacity");
 }
 
 void ShenandoahGeneration::reset_mark_bitmap() {
@@ -250,162 +251,114 @@ void ShenandoahGeneration::compute_evacuation_budgets(ShenandoahHeap* heap, bool
 
   // Do not fill up old-gen memory with promotions.  Reserve some amount of memory for compaction purposes.
   size_t young_evac_reserve_max = 0;
-  if (heap->doing_mixed_evacuations()) {
-    // Compute old_evacuation_reserve: how much memory are we reserving to hold the results of
-    // evacuating old-gen heap regions?  In order to sustain a consistent pace of young-gen collections,
-    // the goal is to maintain a consistent value for this parameter (when the candidate set is not
-    // empty).  This value is the minimum of:
-    //   1. old_gen->available()
-    //   2. old-gen->capacity() * ShenandoahOldEvacReserve) / 100
-    //       (e.g. old evacuation should be no larger than 5% of old_gen capacity)
-    //   3. ((young_gen->capacity * ShenandoahEvacReserve / 100) * ShenandoahOldEvacRatioPercent) / 100
-    //       (e.g. old evacuation should be no larger than 12% of young-gen evacuation)
-    old_evacuation_reserve = old_generation->available();
-    assert(old_evacuation_reserve > minimum_evacuation_reserve, "Old-gen available has not been preserved!");
-    size_t old_evac_reserve_max = old_generation->soft_max_capacity() * ShenandoahOldEvacReserve / 100;
-    if (old_evac_reserve_max < old_evacuation_reserve) {
-      old_evacuation_reserve = old_evac_reserve_max;
-    }
-    young_evac_reserve_max =
-      (((young_generation->soft_max_capacity() * ShenandoahEvacReserve) / 100) * ShenandoahOldEvacRatioPercent) / 100;
-    if (young_evac_reserve_max < old_evacuation_reserve) {
-      old_evacuation_reserve = young_evac_reserve_max;
-    }
-  }
 
-  if (minimum_evacuation_reserve > old_generation->available()) {
-    // Due to round-off errors during enforcement of minimum_evacuation_reserve during previous GC passes,
-    // there can be slight discrepancies here.
-    minimum_evacuation_reserve = old_generation->available();
-  }
+  // First priority is to reclaim the easy garbage out of young-gen.
 
-  heap->set_old_evac_reserve(old_evacuation_reserve);
-  heap->reset_old_evac_expended();
-
-  // Compute the young evacuation reserve: This is how much memory is available for evacuating young-gen objects.
-  // We ignore the possible effect of promotions, which reduce demand for young-gen evacuation memory.
-  //
-  // TODO: We could give special treatment to the regions that have reached promotion age, because we know their
-  // live data is entirely eligible for promotion.  This knowledge can feed both into calculations of young-gen
-  // evacuation reserve and promotion reserve.
-  //
-  //  young_evacuation_reserve for young generation: how much memory are we reserving to hold the results
-  //  of evacuating young collection set regions?  This is typically smaller than the total amount
-  //  of available memory, and is also smaller than the total amount of marked live memory within
-  //  young-gen.  This value is the smaller of
-  //
-  //    1. (young_gen->capacity() * ShenandoahEvacReserve) / 100
-  //    2. (young_gen->available() + old_gen_memory_available_to_be_loaned
-  //
-  //  ShenandoahEvacReserve represents the configured target size of the evacuation region.  We can only honor
-  //  this target if there is memory available to hold the evacuations.  Memory is available if it is already
-  //  free within young gen, or if it can be borrowed from old gen.  Since we have not yet chosen the collection
-  //  sets, we do not yet know the exact accounting of how many regions will be freed by this collection pass.
-  //  What we do know is that there will be at least one evacuated young-gen region for each old-gen region that
-  //  is loaned to the evacuation effort (because regions to be collected consume more memory than the compacted
-  //  regions that will replace them).  In summary, if there are old-gen regions that are available to hold the
-  //  results of young-gen evacuations, it is safe to loan them for this purpose.  At this point, we have not yet
-  //  established a promoted_reserve.  We'll do that after we choose the collection set and analyze its impact
-  //  on available memory.
-  //
-  // We do not know the evacuation_supplement until after we have computed the collection set.  It is not always
-  // the case that young-regions inserted into the collection set will result in net decrease of in-use regions
-  // because ShenandoahEvacWaste times multiplied by memory within the region may be larger than the region size.
-  // The problem is especially relevant to regions that have been inserted into the collection set because they have
-  // reached tenure age.  These regions tend to have much higher utilization (e.g. 95%).  These regions also offer
-  // a unique opportunity because we know that every live object contained within the region is elgible to be
-  // promoted.  Thus, the following implementation treats these regions specially:
-  //
-  //  1. Before beginning collection set selection, we tally the total amount of live memory held within regions
-  //     that are known to have reached tenure age.  If this memory times ShenandoahEvacWaste is available within
-  //     old-gen memory, establish an advance promotion reserve to hold all or some percentage of these objects.
-  //     This advance promotion reserve is excluded from memory available for holding old-gen evacuations and cannot
-  //     be "loaned" to young gen.
-  //
-  //  2. Tenure-aged regions are included in the collection set iff their evacuation size * ShenandoahEvacWaste fits
-  //     within the advance promotion reserve.  It is counter productive to evacuate these regions if they cannot be
-  //     evacuated directly into old-gen memory.  So if there is not sufficient memory to hold copies of their
-  //     live data right now, we'll just let these regions remain in young for now, to be evacuated by a subsequent
-  //     evacuation pass.
-  //
-  //  3. Next, we calculate a young-gen evacuation budget, which is the smaller of the two quantities mentioned
-  //     above.  old_gen_memory_available_to_be_loaned is calculated as:
-  //       old_gen->available - (advance-promotion-reserve + old-gen_evacuation_reserve)
-  //
-  //  4. When choosing the collection set, special care is taken to assure that the amount of loaned memory required to
-  //     hold the results of evacuation is smaller than the total memory occupied by the regions added to the collection
-  //     set.  We need to take these precautions because we do not know how much memory will be reclaimed by evacuation
-  //     until after the collection set has been constructed.  The algorithm is as follows:
-  //
-  //     a. We feed into the algorithm (i) young available at the start of evacuation and (ii) the amount of memory
-  //        loaned from old-gen that is available to hold the results of evacuation.
-  //     b. As candidate regions are added into the young-gen collection set, we maintain accumulations of the amount
-  //        of memory spanned by the collection set regions and the amount of memory that must be reserved to hold
-  //        evacuation results (by multiplying live-data size by ShenandoahEvacWaste).  We process candidate regions
-  //        in order of decreasing amounts of garbage.  We skip over (and do not include into the collection set) any
-  //        regions that do not satisfy all of the following conditions:
-  //
-  //          i. The amount of live data within the region as scaled by ShenandoahEvacWaste must fit within the
-  //             relevant evacuation reserve (live data of old-gen regions must fit within the old-evac-reserve, live
-  //             data of young-gen tenure-aged regions must fit within the advance promotion reserve, live data within
-  //             other young-gen regions must fit within the youn-gen evacuation reserve).
-  //         ii. The accumulation of memory consumed by evacuation must not exceed the accumulation of memory reclaimed
-  //             through evacuation by more than young-gen available.
-  //        iii. Other conditions may be enforced as appropriate for specific heuristics.
-  //
-  //       Note that regions are considered for inclusion in the selection set in order of decreasing amounts of garbage.
-  //       It is possible that a region with a larger amount of garbage will be rejected because it also has a larger
-  //       amount of live data and some region that follows this region in candidate order is included in the collection
-  //       set (because it has less live data and thus can fit within the evacuation limits even though it has less
-  //       garbage).
-
-  size_t young_evacuation_reserve = (young_generation->max_capacity() * ShenandoahEvacReserve) / 100;
-  // old evacuation can pack into existing partially used regions.  young evacuation and loans for young allocations
-  // need to target regions that do not already hold any old-gen objects.  Round down.
-  regions_available_to_loan = old_generation->free_unaffiliated_regions();
-
-  size_t required_evacuation_reserve;
-  // Memory evacuated from old-gen on this pass will be available to hold old-gen evacuations in next pass.
-  if (old_evacuation_reserve > minimum_evacuation_reserve) {
-    required_evacuation_reserve = 0;
+  // maximum_old_evacuations limits the sum of old collections and promotions to old
+  size_t maximum_young_evacuation_reserve = (young_generation->max_capacity() * ShenandoahEvacReserve) / 100;
+  size_t young_evacuation_reserve = maximum_young_evacuation_reserve;
+  size_t excess_young;
+  if (young_generation->available() > young_evacuation_reserve) {
+    excess_young = young_generation->available() - young_evacuation_reserve;
   } else {
-    required_evacuation_reserve = minimum_evacuation_reserve - old_evacuation_reserve;
+    young_evacuation_reserve = young_generation->available();
+    excess_young = 0;
+  }
+  size_t unaffiliated_young = young_generation->free_unaffiliated_regions() * region_size_bytes;
+  if (excess_young > unaffiliated_young) {
+    excess_young = unaffiliated_young;
+  } else {
+    // round down to multiple of region size
+    excess_young /= region_size_bytes;
+    excess_young *= region_size_bytes;
+  }
+  // excess_young is available to be transferred to OLD.  Assume that OLD will not request any more than had
+  // already been set aside for its promotion and evacuation needs at the end of previous GC.  No need to
+  // hold back memory for allocation runway.
+
+  ShenandoahOldHeuristics* old_heuristics = heap->old_heuristics();
+
+  // maximum_old_evacuation_reserve is an upper bound on memory evacuated from old and evacuated to old (promoted).
+  size_t maximum_old_evacuation_reserve =
+    maximum_young_evacuation_reserve * ShenandoahOldEvacRatioPercent / (100 - ShenandoahOldEvacRatioPercent);
+  // Here's the algebra:
+  //  TotalEvacuation = OldEvacuation + YoungEvacuation
+  //  OldEvacuation = TotalEvacuation * (ShenandoahOldEvacRatioPercent/100)
+  //  OldEvacuation = YoungEvacuation * (ShenandoahOldEvacRatioPercent/100)/(1 - ShenandoahOldEvacRatioPercent/100)
+  //  OldEvacuation = YoungEvacuation * ShenandoahOldEvacRatioPercent/(100 - ShenandoahOldEvacRatioPercent)
+
+  if (maximum_old_evacuation_reserve > old_generation->available()) {
+#undef KELVIN_DURESS
+#ifdef KELVIN_DURESS
+    log_info(gc, ergo)("YOUNG GC IN DURESS! maximum_old_evacuation_reserve: " SIZE_FORMAT ", old available: " SIZE_FORMAT
+                       ", mixed-evac candidates: %u",
+                       maximum_old_evacuation_reserve, old_generation->available(),
+                       old_heuristics->unprocessed_old_collection_candidates());
+#endif
+
+    maximum_old_evacuation_reserve = old_generation->available();
   }
 
-  consumed_by_advance_promotion = _heuristics->select_aged_regions(
-    old_generation->available() - old_evacuation_reserve - required_evacuation_reserve, num_regions, preselected_regions);
-  size_t net_available_old_regions =
-    (old_generation->available() - old_evacuation_reserve - consumed_by_advance_promotion) / region_size_bytes;
+  // Second priority is to reclaim garbage out of old-gen if there are old-gen collection candidates.  Third priority
+  // is to promote as much as we have room to promote.  However, if old-gen memory is in short supply, this means young
+  // GC is operating under "duress" and was unable to transfer the memory that we would normally expect.  In this case,
+  // old-gen will refrain from compacting itself in order to allow a quicker young-gen cycle (by avoiding the update-refs
+  // through ALL of old-gen).  If there is some memory available in old-gen, we will use this for promotions as promotions
+  // do not add to the update-refs burden of GC.
 
- if (regions_available_to_loan > net_available_old_regions) {
-    regions_available_to_loan = net_available_old_regions;
+  size_t old_promo_reserve;
+  if (old_heuristics->unprocessed_old_collection_candidates() > 0) {
+    // We reserved all old-gen memory at end of previous GC to hold anticipated evacuations to old-gen.  If this is
+    // mixed evacuation, reserve all of this memory for compaction of old-gen and do not promote.  Prioritize compaction
+    // over promotion in order to defragment OLD so that it will be better prepared to efficiently receive promoted memory.
+    old_evacuation_reserve = maximum_old_evacuation_reserve;
+    old_promo_reserve = 0;
+  } else {
+    // Make all old-evacuation memory for promotion, but if we can't use it all for promotion, we'll allow some evacuation.
+    old_evacuation_reserve = 0;
+    old_promo_reserve = maximum_old_evacuation_reserve;
   }
 
-  // Otherwise, regions_available_to_loan is less than net_available_old_regions because available memory is
-  // scattered between multiple partially used regions.
+  // We see too many old-evacuation failures if we force ourselves to evacuate into regions that are not initially empty.
+  // So we limit the old-evacuation reserve to unfragmented memory.  Even so, old-evacuation is free to fill in nooks and
+  // crannies within existing partially used regions and it generally tries to do so.
+  size_t old_free_regions = old_generation->free_unaffiliated_regions();
+  size_t old_free_unfragmented = old_free_regions * region_size_bytes;
+  if (old_evacuation_reserve > old_free_unfragmented) {
+#undef KELVIN_MIXED_PREP
+#ifdef KELVIN_MIXED_PREP
+    log_info(gc, ergo)("KELVIN IS LIMITING OLD_EVACUATION RESERVE TO " SIZE_FORMAT " FROM " SIZE_FORMAT,
+                       old_free_unfragmented, old_evacuation_reserve);
+#endif
+    size_t delta = old_evacuation_reserve - old_free_unfragmented;
+    old_evacuation_reserve -= delta;
 
-  if (young_evacuation_reserve > young_generation->available()) {
-    size_t short_fall = young_evacuation_reserve - young_generation->available();
-    if (regions_available_to_loan * region_size_bytes >= short_fall) {
-      old_regions_loaned_for_young_evac = (short_fall + region_size_bytes - 1) / region_size_bytes;
-      regions_available_to_loan -= old_regions_loaned_for_young_evac;
-    } else {
-      old_regions_loaned_for_young_evac = regions_available_to_loan;
-      regions_available_to_loan = 0;
-      young_evacuation_reserve = young_generation->available() + old_regions_loaned_for_young_evac * region_size_bytes;
-      // In this case, there's no memory available for new allocations while evacuating and updating, unless we
-      // find more old-gen memory to borrow below.
-    }
+    // Let promo consume fragments of old-gen memory.
+    old_promo_reserve += delta;
   }
-  // In generational mode, we may end up choosing a young collection set that contains so many promotable objects
-  // that there is not sufficient space in old generation to hold the promoted objects.  That is ok because we have
-  // assured there is sufficient space in young generation to hold the rejected promotion candidates.  These rejected
-  // promotion candidates will presumably be promoted in a future evacuation cycle.
-  heap->set_young_evac_reserve(young_evacuation_reserve);
+
+#undef KELVIN_PRESELECT
+#ifdef KELVIN_PRESELECT
+  log_info(gc, ergo)("Preselecting region with promo evac budget: " SIZE_FORMAT ", computed from old available: " SIZE_FORMAT
+                     ",  max_old_evac_reserve: " SIZE_FORMAT " with %u old-gen mixed evacuation candidates",
+                     old_promo_reserve, old_generation->available(), maximum_old_evacuation_reserve,
+                     old_heuristics->unprocessed_old_collection_candidates());
+#endif
   collection_set->establish_preselected(preselected_regions);
+  consumed_by_advance_promotion = _heuristics->select_aged_regions(old_promo_reserve, num_regions, preselected_regions);
+  assert(consumed_by_advance_promotion <= maximum_old_evacuation_reserve, "Cannot promote more than available old-gen memory");
+  if (consumed_by_advance_promotion < old_promo_reserve) {
+    // If we're in a global collection, this memory can be used for old evacuations
+    old_evacuation_reserve += old_promo_reserve - consumed_by_advance_promotion;
+  }
+  heap->set_young_evac_reserve(young_evacuation_reserve);
+  heap->set_old_evac_reserve(old_evacuation_reserve);
+  heap->set_promoted_reserve(consumed_by_advance_promotion);
+
+  // There is no need to expand OLD because all memory used here was set aside at end of previous GC
 }
 
-// Having chosen the collection set, adjust the budgets for generatioal mode based on its composition.  Note
+// Having chosen the collection set, adjust the budgets for generational mode based on its composition.  Note
 // that young_generation->available() now knows about recently discovered immediate garbage.
 
 void ShenandoahGeneration::adjust_evacuation_budgets(ShenandoahHeap* heap, ShenandoahCollectionSet* collection_set,
@@ -426,350 +379,115 @@ void ShenandoahGeneration::adjust_evacuation_budgets(ShenandoahHeap* heap, Shena
   // to young-gen.
 
   assert(heap->mode()->is_generational(), "Only generational mode uses evacuation budgets.");
-  size_t old_regions_loaned_for_young_evac, regions_available_to_loan;
+
+#undef KELVIN_SEE_THIS
   size_t region_size_bytes = ShenandoahHeapRegion::region_size_bytes();
   ShenandoahOldGeneration* old_generation = heap->old_generation();
   ShenandoahYoungGeneration* young_generation = heap->young_generation();
-  size_t old_evacuated = collection_set->get_old_bytes_reserved_for_evacuation();
-  size_t old_evacuated_committed = (size_t) (ShenandoahEvacWaste * old_evacuated);
-  size_t old_evacuation_reserve = heap->get_old_evac_reserve();
-  // Immediate garbage found during choose_collection_set() is all young
-  size_t immediate_garbage = collection_set->get_immediate_trash();
-  size_t old_available = old_generation->available();
-  size_t young_available = young_generation->available() + immediate_garbage;
-  size_t loaned_regions = 0;
-  size_t available_loan_remnant = 0; // loaned memory that is not yet dedicated to any particular budget
+  // With auto-sizing of generations, adjust_evacuation_budgets is much simpler
 
-  assert(((consumed_by_advance_promotion * 33) / 32) >= collection_set->get_young_bytes_to_be_promoted() * ShenandoahEvacWaste,
-         "Advance promotion (" SIZE_FORMAT ") should be at least young_bytes_to_be_promoted (" SIZE_FORMAT
-         ")* ShenandoahEvacWaste, totalling: " SIZE_FORMAT ", within round-off errors of up to 3.125%%",
-         consumed_by_advance_promotion, collection_set->get_young_bytes_to_be_promoted(),
-         (size_t) (collection_set->get_young_bytes_to_be_promoted() * ShenandoahEvacWaste));
-
-  assert(consumed_by_advance_promotion <= (collection_set->get_young_bytes_to_be_promoted() * ShenandoahEvacWaste * 33) / 32,
-         "Round-off errors should be less than 3.125%%, consumed by advance: " SIZE_FORMAT ", promoted: " SIZE_FORMAT,
-         consumed_by_advance_promotion, (size_t) (collection_set->get_young_bytes_to_be_promoted() * ShenandoahEvacWaste));
-
+  // Preselected regions have been inserted into the collection set, so we no longer need the preselected array.
   collection_set->abandon_preselected();
 
+  size_t old_evacuated = collection_set->get_old_bytes_reserved_for_evacuation();
+  size_t old_evacuated_committed = (size_t) (ShenandoahOldEvacWaste * old_evacuated);
+  size_t old_evacuation_reserve = heap->get_old_evac_reserve();
+
   if (old_evacuated_committed > old_evacuation_reserve) {
-    // This should only happen due to round-off errors when enforcing ShenandoahEvacWaste
+    // This should only happen due to round-off errors when enforcing ShenandoahOldEvacWaste
     assert(old_evacuated_committed <= (33 * old_evacuation_reserve) / 32,
            "Round-off errors should be less than 3.125%%, committed: " SIZE_FORMAT ", reserved: " SIZE_FORMAT,
            old_evacuated_committed, old_evacuation_reserve);
     old_evacuated_committed = old_evacuation_reserve;
+    // Leave old_evac_reserve as previously configured
   } else if (old_evacuated_committed < old_evacuation_reserve) {
-    // This may happen if the old-gen collection consumes less than full budget.
+    // This happens if the old-gen collection consumes less than full budget.
     old_evacuation_reserve = old_evacuated_committed;
     heap->set_old_evac_reserve(old_evacuation_reserve);
   }
 
-  // Recompute old_regions_loaned_for_young_evac because young-gen collection set may not need all the memory
-  // originally reserved.
-  size_t young_promoted = collection_set->get_young_bytes_to_be_promoted();
-  size_t young_promoted_reserve_used = (size_t) (ShenandoahEvacWaste * young_promoted);
+  size_t young_advance_promoted = collection_set->get_young_bytes_to_be_promoted();
+  size_t young_advance_promoted_reserve_used = (size_t) (ShenandoahPromoEvacWaste * young_advance_promoted);
 
   size_t young_evacuated = collection_set->get_young_bytes_reserved_for_evacuation();
   size_t young_evacuated_reserve_used = (size_t) (ShenandoahEvacWaste * young_evacuated);
 
-  // We'll invoke heap->set_young_evac_reserve() further below, after we make additional adjustments to its value
+#ifdef KELVIN_SEE_THIS
+  log_info(gc, ergo)("adjust_budgets(young_advance_promoted: " SIZE_FORMAT ", used: " SIZE_FORMAT
+                     ", young_evacuated: " SIZE_FORMAT ", used: " SIZE_FORMAT ")",
+                     young_advance_promoted, young_advance_promoted_reserve_used,
+                     young_evacuated, young_evacuated_reserve_used);
+#endif
 
-  // Adjust old_regions_loaned_for_young_evac to feed into calculations of promoted_reserve
-  if (young_evacuated_reserve_used > young_available) {
-    size_t short_fall = young_evacuated_reserve_used - young_available;
-
-    // region_size_bytes is a power of 2.  loan an integral number of regions.
-    size_t revised_loan_for_young_evacuation = (short_fall + region_size_bytes - 1) / region_size_bytes;
-
-    // available_loan_remnant represents memory loaned from old-gen but not required for young evacuation.
-    // This is the excess loaned memory that results from rounding the required loan up to an integral number
-    // of heap regions.  This will be dedicated to alloc_supplement below.
-    available_loan_remnant = (revised_loan_for_young_evacuation * region_size_bytes) - short_fall;
-
-    // We previously loaned more than was required by young-gen evacuation.  So claw some of this memory back.
-    old_regions_loaned_for_young_evac = revised_loan_for_young_evacuation;
-    loaned_regions = old_regions_loaned_for_young_evac;
-  } else {
-    // Undo the prevous loan, if any.
-    old_regions_loaned_for_young_evac = 0;
-    loaned_regions = 0;
-  }
-
-  size_t old_bytes_loaned_for_young_evac = old_regions_loaned_for_young_evac * region_size_bytes - available_loan_remnant;
-
-  // Recompute regions_available_to_loan based on possible changes to old_regions_loaned_for_young_evac and
-  // old_evacuation_reserve.
-
-  // Any decrease in old_regions_loaned_for_young_evac are immediately available to be loaned
-  // However, a change to old_evacuation_reserve() is not necessarily available to loan, because this memory may
-  // reside within many fragments scattered throughout old-gen.
-
-  regions_available_to_loan = old_generation->free_unaffiliated_regions();
-  size_t working_old_available = old_generation->available();
-
-  assert(regions_available_to_loan * region_size_bytes <= working_old_available,
-         "Regions available to loan  must be less than available memory");
-
-  // fragmented_old_total is the amount of memory in old-gen beyond regions_available_to_loan that is otherwise not
-  // yet dedicated to a particular budget.  This memory can be used for promotion_reserve.
-  size_t fragmented_old_total = working_old_available - regions_available_to_loan * region_size_bytes;
-
-  // fragmented_old_usage is the memory that is dedicated to holding evacuated old-gen objects, which does not need
-  // to be an integral number of regions.
-  size_t fragmented_old_usage = old_evacuated_committed + consumed_by_advance_promotion;
-
-
-
-  if (fragmented_old_total >= fragmented_old_usage) {
-    // Seems this will be rare.  In this case, all of the memory required for old-gen evacuations and promotions can be
-    // taken from the existing fragments within old-gen.  Reduce this fragmented total by this amount.
-    fragmented_old_total -= fragmented_old_usage;
-    // And reduce regions_available_to_loan by the regions dedicated to young_evac.
-    regions_available_to_loan -= old_regions_loaned_for_young_evac;
-  } else {
-    // In this case, we need to dedicate some of the regions_available_to_loan to hold the results of old-gen evacuations
-    // and promotions.
-
-    size_t unaffiliated_memory_required_for_old = fragmented_old_usage - fragmented_old_total;
-    size_t unaffiliated_regions_used_by_old = (unaffiliated_memory_required_for_old + region_size_bytes - 1) / region_size_bytes;
-    regions_available_to_loan -= (unaffiliated_regions_used_by_old + old_regions_loaned_for_young_evac);
-
-    size_t memory_for_promotions_and_old_evac = fragmented_old_total + unaffiliated_regions_used_by_old;
-    size_t memory_required_for_promotions_and_old_evac = fragmented_old_usage;
-    size_t excess_fragmented = memory_for_promotions_and_old_evac - memory_required_for_promotions_and_old_evac;
-    fragmented_old_total = excess_fragmented;
-  }
-
-  // Subtract from working_old_available old_evacuated_committed and consumed_by_advance_promotion
-  working_old_available -= fragmented_old_usage;
-  // And also subtract out the regions loaned for young evacuation
-  working_old_available -= old_regions_loaned_for_young_evac * region_size_bytes;
-
-  // Assure that old_evacuated_committed + old_bytes_loaned_for_young_evac >= the minimum evacuation reserve
-  // in order to prevent promotion reserve from violating minimum evacuation reserve.
-  size_t old_regions_reserved_for_alloc_supplement = 0;
-  size_t old_bytes_reserved_for_alloc_supplement = 0;
-  size_t reserved_bytes_for_future_old_evac = 0;
-
-  old_bytes_reserved_for_alloc_supplement = available_loan_remnant;
-  available_loan_remnant = 0;
-
-  // Memory that has been loaned for young evacuations and old-gen regions in the current mixed-evacuation collection
-  // set will be available to hold future old-gen evacuations.  If this memory is less than the desired amount of memory
-  // set aside for old-gen compaction reserve, try to set aside additional memory so that it will be available during
-  // the next mixed evacuation cycle.  Note that memory loaned to young-gen for allocation supplement is excluded from
-  // the old-gen promotion reserve.
-  size_t future_evac_reserve_regions = old_regions_loaned_for_young_evac + collection_set->get_old_region_count();
-  size_t collected_regions = collection_set->get_young_region_count();
-
-  if (future_evac_reserve_regions < ShenandoahOldCompactionReserve) {
-    // Require that we loan more memory for holding young evacuations to assure that we have adequate reserves to receive
-    // old-gen evacuations during subsequent collections.  Loaning this memory for an allocation supplement does not
-    // satisfy our needs because newly allocated objects are not necessarily counter-balanced by reclaimed collection
-    // set regions.
-
-    // Put this memory into reserve by identifying it as old_regions_loaned_for_young_evac
-    size_t additional_regions_to_loan = ShenandoahOldCompactionReserve - future_evac_reserve_regions;
-
-    // We can loan additional regions to be repaid from the anticipated recycling of young collection set regions
-    // provided that these regions are currently available within old-gen memory.
-    size_t collected_regions_to_loan;
-    if (collected_regions >= additional_regions_to_loan) {
-      collected_regions_to_loan = additional_regions_to_loan;
-      additional_regions_to_loan = 0;
-    } else if (collected_regions > 0) {
-      collected_regions_to_loan = collected_regions;
-      additional_regions_to_loan -= collected_regions_to_loan;
-    } else {
-      collected_regions_to_loan = 0;
-    }
-
-    if (collected_regions_to_loan > 0) {
-      // We're evacuating at least this many regions, it's ok to use these regions for allocation supplement since
-      // we'll be able to repay the loan at end of this GC pass, assuming the regions are available.
-      if (collected_regions_to_loan > regions_available_to_loan) {
-        collected_regions_to_loan = regions_available_to_loan;
-      }
-      old_bytes_reserved_for_alloc_supplement += collected_regions_to_loan * region_size_bytes;
-      regions_available_to_loan -= collected_regions_to_loan;
-      loaned_regions += collected_regions_to_loan;
-      working_old_available -= collected_regions_to_loan * region_size_bytes;
-    }
-
-    // If there's still memory that we want to exclude from the current promotion reserve, but we are unable to loan
-    // this memory because fully empty old-gen regions are not available, decrement the working_old_available to make
-    // sure that this memory is not used to hold the results of old-gen evacuation.
-    if (additional_regions_to_loan > regions_available_to_loan) {
-      size_t unloaned_regions = additional_regions_to_loan - regions_available_to_loan;
-      size_t unloaned_bytes = unloaned_regions * region_size_bytes;
-
-      if (working_old_available < unloaned_bytes) {
-        // We're in dire straits.  We won't be able to reserve all the memory that we want to make available for the
-        // next old-gen evacuation.  We'll reserve as much of it as possible.  Setting working_old_available to zero
-        // means there will be no promotion except for the advance promotion.  Note that if some advance promotion fails,
-        // the object will be evacuated to young-gen so we should still end up reclaiming the entire advance promotion
-        // collection set.
-        reserved_bytes_for_future_old_evac = working_old_available;
-        working_old_available = 0;
-      } else {
-        reserved_bytes_for_future_old_evac = unloaned_bytes;
-        working_old_available -= unloaned_bytes;
-      }
-      size_t regions_reserved_for_future_old_evac =
-        (reserved_bytes_for_future_old_evac + region_size_bytes - 1) / region_size_bytes;
-
-      if (regions_reserved_for_future_old_evac < regions_available_to_loan) {
-        regions_available_to_loan -= regions_reserved_for_future_old_evac;
-      } else {
-        regions_available_to_loan = 0;
-      }
-
-      // Since we're in dire straits, zero out fragmented_old_total so this won't be used for promotion;
-      if (working_old_available > fragmented_old_total) {
-        working_old_available -= fragmented_old_total;
-      } else {
-        working_old_available = 0;
-      }
-      fragmented_old_total = 0;
-    }
-  }
-
-  // Establish young_evac_reserve so that this young-gen memory is not used for new allocations, allowing the memory
-  // to be returned to old-gen as soon as the current collection set regions are reclaimed.
+  assert(young_evacuated_reserve_used <= young_generation->available(), "Cannot evacuate more than is available in young");
   heap->set_young_evac_reserve(young_evacuated_reserve_used);
 
-  // Limit promoted_reserve so that we can set aside memory to be loaned from old-gen to young-gen.  This
-  // value is not "critical".  If we underestimate, certain promotions will simply be deferred.  If we put
-  // "all the rest" of old-gen memory into the promotion reserve, we'll have nothing left to loan to young-gen
-  // during the evac and update phases of GC.  So we "limit" the sizes of the promotion budget to be the smaller of:
-  //
-  //  1. old_available
-  //     (old_available is old_gen->available() -
-  //      (old_evacuated_committed + consumed_by_advance_promotion + loaned_for_young_evac + reserved_for_alloc_supplement))
-  //  2. young bytes reserved for evacuation (we can't promote more than young is evacuating)
-  size_t promotion_reserve = working_old_available;
+#ifdef KELVIN_SEE_THIS
+  log_info(gc, ergo)("after setting young_evac_reserve");
+#endif
 
-  // We experimented with constraining promoted_reserve to be no larger than 4 times the size of previously_promoted,
-  // but this constraint was too limiting, resulting in failure of legitimate promotions.  This was tried before we
-  // had special handling in place for advance promotion.  We should retry now that advance promotion is handled
-  // specially.
+  size_t old_available = old_generation->available();
 
-  // We had also experimented with constraining promoted_reserve to be no more than young_evacuation_committed
-  // divided by promotion_divisor, where:
-  //  size_t promotion_divisor = (0x02 << InitialTenuringThreshold) - 1;
-  // This also was found to be too limiting, resulting in failure of legitimate promotions.
-  //
-  // Both experiments were conducted in the presence of other bugs which could have been the root cause for
-  // the failures identified above as being "too limiting".  TODO: conduct new experiments with the more limiting
-  // values of young_evacuation_reserved_used.
+#ifdef KELVIN_SEE_THIS
+  log_info(gc, ergo)("after resetting promoted_reserve");
+#endif
 
-  // young_evacuation_reserve_used already excludes bytes known to be promoted, which equals consumed_by_advance_promotion
-  if (young_evacuated_reserve_used < promotion_reserve) {
-    // Shrink promotion_reserve if it is larger than the memory to be consumed by evacuating all young objects in
-    // collection set, including anticipated waste.  There's no benefit in using a larger promotion_reserve.
-    // young_evacuation_reserve_used does not include live memory within tenure-aged regions.
-    promotion_reserve = young_evacuated_reserve_used;
-  }
-  assert(working_old_available >= promotion_reserve, "Cannot reserve for promotion more than is available");
-  working_old_available -= promotion_reserve;
-  // Having reserved this memory for promotion, the regions are no longer available to be loaned.
-  size_t regions_consumed_by_promotion_reserve = (promotion_reserve + region_size_bytes - 1) / region_size_bytes;
-  if (regions_consumed_by_promotion_reserve > regions_available_to_loan) {
-    // This can happen if the promotion reserve makes use of memory that is fragmented between many partially available
-    // old-gen regions.
-    regions_available_to_loan = 0;
-  } else {
-    regions_available_to_loan -= regions_consumed_by_promotion_reserve;
-  }
+  // Now that we've established the collection set, we know how much memory is really required by old-gen for evacuation
+  // and promotion reserves.  Try shrinking OLD now in case that gives us a bit more runway for mutator allocations during
+  // evac and update phases.
+  size_t old_consumed = old_evacuated_committed + young_advance_promoted_reserve_used;
+  assert(old_available >= old_consumed, "Cannot consume more than is available");
+  size_t excess_old = old_available - old_consumed;
+  size_t unaffiliated_old_regions = old_generation->free_unaffiliated_regions();
+  size_t unaffiliated_old = unaffiliated_old_regions * region_size_bytes;
+  assert(old_available >= unaffiliated_old, "Unaffiliated old is a subset of old available");
 
-  log_debug(gc)("old_gen->available(): " SIZE_FORMAT " divided between promotion reserve: " SIZE_FORMAT
-                ", old evacuation reserve: " SIZE_FORMAT ", advance promotion reserve supplement: " SIZE_FORMAT
-                ", old loaned for young evacuation: " SIZE_FORMAT ", old reserved for alloc supplement: " SIZE_FORMAT,
-                old_generation->available(), promotion_reserve, old_evacuated_committed, consumed_by_advance_promotion,
-                old_regions_loaned_for_young_evac * region_size_bytes, old_bytes_reserved_for_alloc_supplement);
+#ifdef KELVIN_SEE_THIS
+  log_info(gc, ergo)("computed excess_old: " SIZE_FORMAT ", unaffiliated_old: " SIZE_FORMAT, excess_old, unaffiliated_old);
+#endif
 
-  promotion_reserve += consumed_by_advance_promotion;
-  heap->set_promoted_reserve(promotion_reserve);
-
-  heap->reset_promoted_expended();
-  if (collection_set->get_old_bytes_reserved_for_evacuation() == 0) {
-    // Setting old evacuation reserve to zero denotes that there is no old-gen evacuation in this pass.
-    heap->set_old_evac_reserve(0);
-  }
-
-  size_t old_gen_usage_base = old_generation->used() - collection_set->get_old_garbage();
-  heap->capture_old_usage(old_gen_usage_base);
-
-  // Compute additional evacuation supplement, which is extra memory borrowed from old-gen that can be allocated
-  // by mutators while GC is working on evacuation and update-refs.  This memory can be temporarily borrowed
-  // from old-gen allotment, then repaid at the end of update-refs from the recycled collection set.  After
-  // we have computed the collection set based on the parameters established above, we can make additional
-  // loans based on our knowledge of the collection set to determine how much allocation we can allow
-  // during the evacuation and update-refs phases of execution.  The total available supplement is the result
-  // of adding old_bytes_reserved_for_alloc_supplement to the smaller of:
-  //
-  //   1. regions_available_to_loan * region_size_bytes
-  //   2. The replenishment budget (number of regions in collection set - the number of regions already
-  //         under lien for the young_evacuation_reserve)
-  //
-
-  // Regardless of how many regions may be available to be loaned, we can loan no more regions than
-  // the total number of young regions to be evacuated.  Call this the regions_for_runway.
-
-  if (regions_available_to_loan > 0 && (collected_regions > loaned_regions)) {
-    assert(regions_available_to_loan * region_size_bytes <= working_old_available,
-           "regions_available_to_loan should not exceed working_old_available");
-
-    size_t additional_regions_to_loan = collected_regions - loaned_regions;
-    if (additional_regions_to_loan > regions_available_to_loan) {
-      additional_regions_to_loan = regions_available_to_loan;
+  // Make sure old_evac_committed is unaffiliated
+  if (old_evacuated_committed > 0) {
+    if (unaffiliated_old > old_evacuated_committed) {
+      size_t giveaway = unaffiliated_old - old_evacuated_committed;
+      size_t giveaway_regions = giveaway / region_size_bytes;  // round down
+      if (giveaway_regions > 0) {
+        excess_old = MIN2(excess_old, giveaway_regions * region_size_bytes);
+      } else {
+        excess_old = 0;
+      }
+    } else {
+      excess_old = 0;
     }
-    loaned_regions += additional_regions_to_loan;
-    old_bytes_reserved_for_alloc_supplement += additional_regions_to_loan * region_size_bytes;
-    working_old_available -= additional_regions_to_loan * region_size_bytes;
   }
-  size_t allocation_supplement = old_bytes_reserved_for_alloc_supplement + old_bytes_loaned_for_young_evac;
-  assert(allocation_supplement % ShenandoahHeapRegion::region_size_bytes() == 0,
-         "allocation_supplement must be multiple of region size");
 
-  heap->set_alloc_supplement_reserve(allocation_supplement);
+  // If we find that OLD has excess regions, give them back to YOUNG now to reduce likelihood we run out of allocation
+  // runway during evacuation and update-refs.
+  size_t regions_to_xfer = 0;
+  if (excess_old > unaffiliated_old) {
+    // we can give back unaffiliated_old (all of unaffiliated is excess)
+    if (unaffiliated_old_regions > 0) {
+      regions_to_xfer = unaffiliated_old_regions;
+    }
+  } else if (unaffiliated_old_regions > 0) {
+    // excess_old < unaffiliated old: we can give back MIN(excess_old/region_size_bytes, unaffiliated_old_regions)
+    size_t excess_regions = excess_old / region_size_bytes;
+    size_t regions_to_xfer = MIN2(excess_regions, unaffiliated_old_regions);
+  }
 
-  // TODO: young_available, which feeds into alloc_budget_evac_and_update is lacking memory available within
-  // existing young-gen regions that were not selected for the collection set.  Add this in and adjust the
-  // log message (where it says "empty-region allocation budget").
+  if (regions_to_xfer > 0) {
+    bool result = heap->generation_sizer()->transfer_to_young(regions_to_xfer);
+    assert(excess_old > regions_to_xfer * region_size_bytes, "Cannot xfer more than excess old");
+    excess_old -= regions_to_xfer * region_size_bytes;
+    log_info(gc, ergo)("%s transferred " SIZE_FORMAT " excess regions to young before start of evacuation",
+                       result? "Successfully": "Unsuccessfully", regions_to_xfer);
+  }
 
-
-  log_debug(gc)("Memory reserved for young evacuation: " SIZE_FORMAT "%s for evacuating " SIZE_FORMAT
-                "%s out of young available: " SIZE_FORMAT "%s",
-                byte_size_in_proper_unit(young_evacuated_reserve_used),
-                proper_unit_for_byte_size(young_evacuated_reserve_used),
-                byte_size_in_proper_unit(young_evacuated), proper_unit_for_byte_size(young_evacuated),
-                byte_size_in_proper_unit(young_available), proper_unit_for_byte_size(young_available));
-
-  log_debug(gc)("Memory reserved for old evacuation: " SIZE_FORMAT "%s for evacuating " SIZE_FORMAT
-                "%s out of old available: " SIZE_FORMAT "%s",
-                byte_size_in_proper_unit(old_evacuated), proper_unit_for_byte_size(old_evacuated),
-                byte_size_in_proper_unit(old_evacuated), proper_unit_for_byte_size(old_evacuated),
-                byte_size_in_proper_unit(old_available), proper_unit_for_byte_size(old_available));
-
-  size_t regular_promotion = promotion_reserve - consumed_by_advance_promotion;
-  size_t excess =
-    old_available - (old_evacuation_reserve + promotion_reserve + old_bytes_loaned_for_young_evac + allocation_supplement);
-  log_info(gc, ergo)("Old available: " SIZE_FORMAT "%s is partitioned into old evacuation budget: " SIZE_FORMAT
-                     "%s, aged region promotion budget: " SIZE_FORMAT
-                     "%s, regular region promotion budget: " SIZE_FORMAT
-                     "%s, loaned for young evacuation: " SIZE_FORMAT
-                     "%s, loaned for young allocations: " SIZE_FORMAT
-                     "%s, excess: " SIZE_FORMAT "%s",
-                     byte_size_in_proper_unit(old_available), proper_unit_for_byte_size(old_available),
-                     byte_size_in_proper_unit(old_evacuation_reserve), proper_unit_for_byte_size(old_evacuation_reserve),
-                     byte_size_in_proper_unit(consumed_by_advance_promotion),
-                     proper_unit_for_byte_size(consumed_by_advance_promotion),
-                     byte_size_in_proper_unit(regular_promotion), proper_unit_for_byte_size(regular_promotion),
-                     byte_size_in_proper_unit(old_bytes_loaned_for_young_evac),
-                     proper_unit_for_byte_size(old_bytes_loaned_for_young_evac),
-                     byte_size_in_proper_unit(allocation_supplement), proper_unit_for_byte_size(allocation_supplement),
-                     byte_size_in_proper_unit(excess), proper_unit_for_byte_size(excess));
+  // Add in the excess_old memory to hold unanticipated promotions, if any.  If there are more unanticipated
+  // promotions than fit in reserved memory, they will be deferred until a future GC pass.
+  size_t total_promotion_reserve = young_advance_promoted_reserve_used + excess_old;
+  heap->set_promoted_reserve(total_promotion_reserve);
+  heap->reset_promoted_expended();
 }
 
 void ShenandoahGeneration::prepare_regions_and_collection_set(bool concurrent) {
@@ -817,7 +535,6 @@ void ShenandoahGeneration::prepare_regions_and_collection_set(bool concurrent) {
 
       // Budgeting parameters to compute_evacuation_budgets are passed by reference.
       compute_evacuation_budgets(heap, preselected_regions, collection_set, consumed_by_advance_promotion);
-
       _heuristics->choose_collection_set(collection_set, heap->old_heuristics());
       if (!collection_set->is_empty()) {
         // only make use of evacuation budgets when we are evacuating
@@ -827,12 +544,19 @@ void ShenandoahGeneration::prepare_regions_and_collection_set(bool concurrent) {
       _heuristics->choose_collection_set(collection_set, heap->old_heuristics());
     }
   }
+#ifdef KELVIN_SEE_THIS
+  log_info(gc, ergo)("returning from adjust_evacuation_budgets");
+#endif
 
   {
     ShenandoahGCPhase phase(concurrent ? ShenandoahPhaseTimings::final_rebuild_freeset :
                             ShenandoahPhaseTimings::degen_gc_final_rebuild_freeset);
     ShenandoahHeapLocker locker(heap->lock());
-    heap->free_set()->rebuild();
+    size_t young_cset_regions, old_cset_regions;
+
+    // We are preparing for evacuation.  At this time, we ignore cset region tallies.
+    heap->free_set()->prepare_to_rebuild(young_cset_regions, old_cset_regions);
+    heap->free_set()->rebuild((size_t)(collection_set->get_young_bytes_reserved_for_evacuation() * ShenandoahEvacWaste));
   }
 }
 
@@ -887,7 +611,7 @@ ShenandoahGeneration::ShenandoahGeneration(GenerationMode generation_mode,
   _task_queues(new ShenandoahObjToScanQueueSet(max_workers)),
   _ref_processor(new ShenandoahReferenceProcessor(MAX2(max_workers, 1U))),
   _collection_thread_time_s(0.0),
-  _affiliated_region_count(0), _used(0), _bytes_allocated_since_gc_start(0),
+  _affiliated_region_count(0), _humongous_waste(0), _used(0), _bytes_allocated_since_gc_start(0),
   _max_capacity(max_capacity), _soft_max_capacity(soft_max_capacity),
   _adjusted_capacity(soft_max_capacity), _heuristics(nullptr) {
   _is_marking_complete.set();
@@ -938,6 +662,10 @@ size_t ShenandoahGeneration::increment_affiliated_region_count() {
   // on read and write of _affiliated_region_count.  At the end of full gc, a single thread overwrites the count with
   // a coherent value.
   _affiliated_region_count++;
+#undef KELVIN_AFFILIATIONS
+#ifdef KELVIN_AFFILIATIONS
+  log_info(gc, ergo)("%s ++affiliated_region_count yields " SIZE_FORMAT, name(), _affiliated_region_count);
+#endif
   return _affiliated_region_count;
 }
 
@@ -947,6 +675,37 @@ size_t ShenandoahGeneration::decrement_affiliated_region_count() {
   // on read and write of _affiliated_region_count.  At the end of full gc, a single thread overwrites the count with
   // a coherent value.
   _affiliated_region_count--;
+  assert(ShenandoahHeap::heap()->is_full_gc_in_progress() ||
+         (_used + _humongous_waste <= _affiliated_region_count * ShenandoahHeapRegion::region_size_bytes()),
+         "used + humongous cannot exceed regions");
+#ifdef KELVIN_AFFILIATIONS
+  log_info(gc, ergo)("%s --affiliated_region_count yields " SIZE_FORMAT, name(), _affiliated_region_count);
+#endif
+  return _affiliated_region_count;
+}
+
+size_t ShenandoahGeneration::increase_affiliated_region_count(size_t delta) {
+  shenandoah_assert_heaplocked_or_fullgc_safepoint();
+  _affiliated_region_count += delta;
+#ifdef KELVIN_AFFILIATIONS
+  log_info(gc, ergo)("%s (affiliated_region_count += " SIZE_FORMAT " yields " SIZE_FORMAT, name(), delta,
+                     _affiliated_region_count);
+#endif
+  return _affiliated_region_count;
+}
+
+size_t ShenandoahGeneration::decrease_affiliated_region_count(size_t delta) {
+  shenandoah_assert_heaplocked_or_fullgc_safepoint();
+  assert(_affiliated_region_count > delta, "Affiliated region count cannot be negative");
+
+  _affiliated_region_count -= delta;
+  assert(ShenandoahHeap::heap()->is_full_gc_in_progress() ||
+         (_used + _humongous_waste <= _affiliated_region_count * ShenandoahHeapRegion::region_size_bytes()),
+         "used + humongous cannot exceed regions");
+#ifdef KELVIN_AFFILIATIONS
+  log_info(gc, ergo)("%s (affiliated_region_count -= " SIZE_FORMAT " yields " SIZE_FORMAT, name(), delta,
+                     _affiliated_region_count);
+#endif
   return _affiliated_region_count;
 }
 
@@ -954,7 +713,7 @@ void ShenandoahGeneration::establish_usage(size_t num_regions, size_t num_bytes,
   assert(ShenandoahSafepoint::is_at_shenandoah_safepoint(), "must be at a safepoint");
   _affiliated_region_count = num_regions;
   _used = num_bytes;
-  // future improvement: _humongous_waste = humongous_waste;
+  _humongous_waste = humongous_waste;
 }
 
 void ShenandoahGeneration::clear_used() {
@@ -964,12 +723,62 @@ void ShenandoahGeneration::clear_used() {
 }
 
 void ShenandoahGeneration::increase_used(size_t bytes) {
+  assert(ShenandoahHeap::heap()->mode()->is_generational(), "Only generational mode accounts for used within generations");
   Atomic::add(&_used, bytes);
+#undef KELVIN_TRACE_GENERATIONS
+#ifdef KELVIN_TRACE_GENERATIONS
+  log_info(gc, ergo)("increasing %s used by " SIZE_FORMAT ", yielding " SIZE_FORMAT " vs capacity: " SIZE_FORMAT,
+		     name(), bytes, _used, _max_capacity);
+#endif
+  // This detects arithmetic wraparound on _used.  Non-generational mode does not keep track of _affiliated_region_count
+  assert(ShenandoahHeap::heap()->is_full_gc_in_progress() ||
+         (_used + _humongous_waste <= _affiliated_region_count * ShenandoahHeapRegion::region_size_bytes()),
+         "used cannot exceed regions");
+}
+
+void ShenandoahGeneration::increase_humongous_waste(size_t bytes) {
+  assert(ShenandoahHeap::heap()->mode()->is_generational(), "Only generational mode accounts for used within generations");
+  if (bytes > 0) {
+    shenandoah_assert_heaplocked_or_fullgc_safepoint();
+    _humongous_waste += bytes;
+    assert(ShenandoahHeap::heap()->is_full_gc_in_progress() ||
+           (_used + _humongous_waste <= _affiliated_region_count * ShenandoahHeapRegion::region_size_bytes()),
+           "waste cannot exceed regions");
+#ifdef KELVIN_TRACE_GENERATIONS
+    log_info(gc, ergo)("increasing %s humongous waste by " SIZE_FORMAT ", yielding " SIZE_FORMAT,
+                       name(), bytes, _humongous_waste);
+#endif
+  }
+}
+
+void ShenandoahGeneration::decrease_humongous_waste(size_t bytes) {
+  assert(ShenandoahHeap::heap()->mode()->is_generational(), "Only generational mode accounts for used within generations");
+  if (bytes > 0) {
+    shenandoah_assert_heaplocked_or_fullgc_safepoint();
+    assert(ShenandoahHeap::heap()->is_full_gc_in_progress() || (_humongous_waste >= bytes),
+           "Waste (" SIZE_FORMAT ") cannot be negative (after subtracting " SIZE_FORMAT ")", _humongous_waste, bytes);
+    _humongous_waste -= bytes;
+#ifdef KELVIN_TRACE_GENERATIONS
+    log_info(gc, ergo)("decreasing %s humongous waste by " SIZE_FORMAT ", yielding " SIZE_FORMAT,
+                       name(), bytes, _humongous_waste);
+#endif
+  }
 }
 
 void ShenandoahGeneration::decrease_used(size_t bytes) {
+  assert(ShenandoahHeap::heap()->mode()->is_generational(), "Only generational mode accounts for used within generations");
   assert(_used >= bytes, "cannot reduce bytes used by generation below zero");
   Atomic::sub(&_used, bytes);
+
+  // Non-generational mode does not maintain affiliated region counts
+  assert(ShenandoahHeap::heap()->is_full_gc_in_progress() ||
+         (_affiliated_region_count * ShenandoahHeapRegion::region_size_bytes() >= _used),
+         "Affiliated regions must hold more than what is currently used");
+
+#ifdef KELVIN_TRACE_GENERATIONS
+  log_info(gc, ergo)("decreasing %s used by " SIZE_FORMAT ", yielding " SIZE_FORMAT " vs capacity: " SIZE_FORMAT,
+		     name(), bytes, _used, _max_capacity);
+#endif
 }
 
 size_t ShenandoahGeneration::used_regions() const {
@@ -991,7 +800,7 @@ size_t ShenandoahGeneration::used_regions_size() const {
 }
 
 size_t ShenandoahGeneration::available() const {
-  size_t in_use = used();
+  size_t in_use = used() + get_humongous_waste();
   size_t soft_capacity = soft_max_capacity();
   return in_use > soft_capacity ? 0 : soft_capacity - in_use;
 }
@@ -1014,7 +823,7 @@ size_t ShenandoahGeneration::unadjust_available() {
 }
 
 size_t ShenandoahGeneration::adjusted_available() const {
-  size_t in_use = used();
+  size_t in_use = used() + get_humongous_waste();
   size_t capacity = _adjusted_capacity;
   return in_use > capacity ? 0 : capacity - in_use;
 }
@@ -1033,30 +842,52 @@ size_t ShenandoahGeneration::adjusted_unaffiliated_regions() const {
 
 void ShenandoahGeneration::increase_capacity(size_t increment) {
   shenandoah_assert_heaplocked_or_safepoint();
-  assert(_max_capacity + increment <= ShenandoahHeap::heap()->max_size_for(this), "Cannot increase generation capacity beyond maximum.");
-  assert(increment % ShenandoahHeapRegion::region_size_bytes() == 0, "Region-sized changes only");
-  // TODO: ysr: remove this check and warning
-  if (increment % ShenandoahHeapRegion::region_size_bytes() != 0) {
-    log_warning(gc)("Increment (" INTPTR_FORMAT ") should be a multiple of region size (" SIZE_FORMAT ")",
-                    increment, ShenandoahHeapRegion::region_size_bytes());
-  }
+
+  // We do not enforce that new capacity >= heap->max_size_for(this).  The maximum generation size is treated as a rule of thumb
+  // which may be violated during certain transitions, such as when we are forcing transfers for the purpose of promoting regions
+  // in place.
+  assert(_max_capacity + increment <= ShenandoahHeap::heap()->max_capacity(), "Generation cannot be larger than heap size");
+  assert(increment % ShenandoahHeapRegion::region_size_bytes() == 0, "Generation capacity must be multiple of region size");
   _max_capacity += increment;
   _soft_max_capacity += increment;
   _adjusted_capacity += increment;
+
+  // This detects arithmetic wraparound on _used
+  assert(!ShenandoahHeap::heap()->mode()->is_generational() ||
+         (_affiliated_region_count * ShenandoahHeapRegion::region_size_bytes() >= _used),
+         "Affiliated regions must hold more than what is currently used");
+
+#ifdef KELVIN_TRACE_GENERATIONS
+  log_info(gc, ergo)("increasing %s capacity by " SIZE_FORMAT ", yielding " SIZE_FORMAT, name(), increment, _max_capacity);
+#endif
 }
 
 void ShenandoahGeneration::decrease_capacity(size_t decrement) {
   shenandoah_assert_heaplocked_or_safepoint();
-  assert(_max_capacity - decrement >= ShenandoahHeap::heap()->min_size_for(this), "Cannot decrease generation capacity beyond minimum.");
-  assert(decrement % ShenandoahHeapRegion::region_size_bytes() == 0, "Region-sized changes only");
-  // TODO: ysr: remove this check and warning
-  if (decrement % ShenandoahHeapRegion::region_size_bytes() != 0) {
-    log_warning(gc)("Decrement (" INTPTR_FORMAT ") should be a multiple of region size (" SIZE_FORMAT ")",
-                    decrement, ShenandoahHeapRegion::region_size_bytes());
-  }
+
+  // We do not enforce that new capacity >= heap->min_size_for(this).  The minimum generation size is treated as a rule of thumb
+  // which may be violated during certain transitions, such as when we are forcing transfers for the purpose of promoting regions
+  // in place.
+  assert(decrement % ShenandoahHeapRegion::region_size_bytes() == 0, "Generation capacity must be multiple of region size");
+  assert(_max_capacity >= decrement, "Generation capacity cannot be negative");
+  assert(_soft_max_capacity >= decrement, "Generation soft capacity cannot be negative");
+
   _max_capacity -= decrement;
   _soft_max_capacity -= decrement;
   _adjusted_capacity -= decrement;
+
+  // This detects arithmetic wraparound on _used
+  assert(!ShenandoahHeap::heap()->mode()->is_generational() ||
+         (_affiliated_region_count * ShenandoahHeapRegion::region_size_bytes() >= _used),
+         "Affiliated regions must hold more than what is currently used");
+  assert(_used <= _max_capacity, "Cannot use more than capacity");
+  assert(!ShenandoahHeap::heap()->mode()->is_generational() ||
+         (_affiliated_region_count * ShenandoahHeapRegion::region_size_bytes() <= _max_capacity),
+         "Cannot use more than capacity");
+
+#ifdef KELVIN_TRACE_GENERATIONS
+  log_info(gc, ergo)("decreasing %s capacity by " SIZE_FORMAT ", yielding " SIZE_FORMAT, name(), decrement, _max_capacity);
+#endif
 }
 
 void ShenandoahGeneration::record_success_concurrent(bool abbreviated) {

--- a/src/hotspot/share/gc/shenandoah/shenandoahGeneration.hpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahGeneration.hpp
@@ -48,9 +48,11 @@ private:
 
   double _collection_thread_time_s;
 
+  size_t _affiliated_region_count;
+  size_t _humongous_waste;      // how much waste for padding in humongous objects
+
 protected:
   // Usage
-  size_t _affiliated_region_count;
   volatile size_t _used;
   volatile size_t _bytes_allocated_since_gc_start;
   size_t _max_capacity;
@@ -183,11 +185,21 @@ private:
   // Return the updated value of affiliated_region_count
   size_t decrement_affiliated_region_count();
 
+  // Return the updated value of affiliated_region_count
+  size_t increase_affiliated_region_count(size_t delta);
+
+  // Return the updated value of affiliated_region_count
+  size_t decrease_affiliated_region_count(size_t delta);
+
   void establish_usage(size_t num_regions, size_t num_bytes, size_t humongous_waste);
 
   void clear_used();
   void increase_used(size_t bytes);
   void decrease_used(size_t bytes);
+
+  void increase_humongous_waste(size_t bytes);
+  void decrease_humongous_waste(size_t bytes);
+  size_t get_humongous_waste() const { return _humongous_waste; }
 
   virtual bool is_concurrent_mark_in_progress() = 0;
   void confirm_heuristics_mode();

--- a/src/hotspot/share/gc/shenandoah/shenandoahHeapRegion.inline.hpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahHeapRegion.inline.hpp
@@ -82,6 +82,7 @@ HeapWord* ShenandoahHeapRegion::allocate_aligned(size_t size, ShenandoahAllocReq
   if (size >= req.min_size()) {
     // Even if req.min_size() is not a multiple of card size, we know that size is.
     if (pad_words > 0) {
+      assert(pad_words >= ShenandoahHeap::min_fill_size(), "pad_words expanded above to meet size constraint");
       ShenandoahHeap::fill_with_object(orig_top, pad_words);
       ShenandoahHeap::heap()->card_scan()->register_object(orig_top);
     }
@@ -189,6 +190,17 @@ inline size_t ShenandoahHeapRegion::garbage() const {
   return result;
 }
 
+inline size_t ShenandoahHeapRegion::garbage_before_padded_for_promote() const {
+  size_t used_before_promote = byte_size(bottom(), get_top_before_promote());
+  assert(get_top_before_promote() != nullptr, "top before promote should not equal null");
+  assert(used_before_promote >= get_live_data_bytes(),
+         "Live Data must be a subset of used before promotion live: " SIZE_FORMAT " used: " SIZE_FORMAT,
+         get_live_data_bytes(), used_before_promote);
+  size_t result = used_before_promote - get_live_data_bytes();
+  return result;
+
+}
+
 inline HeapWord* ShenandoahHeapRegion::get_update_watermark() const {
   HeapWord* watermark = Atomic::load_acquire(&_update_watermark);
   assert(bottom() <= watermark && watermark <= top(), "within bounds");
@@ -230,5 +242,25 @@ inline bool ShenandoahHeapRegion::is_young() const {
 inline bool ShenandoahHeapRegion::is_old() const {
   return ShenandoahHeap::heap()->region_affiliation(this) == OLD_GENERATION;
 }
+
+inline void ShenandoahHeapRegion::save_top_before_promote() {
+  _top_before_promoted = _top; 
+#undef KELVIN_B4_PROMOTE
+#ifdef KELVIN_B4_PROMOTE
+  log_info(gc, ergo)("Saving _top_before_promoted as " PTR_FORMAT " for region " SIZE_FORMAT, p2i(_top), index());
+#endif
+}
+
+inline void ShenandoahHeapRegion::restore_top_before_promote() {
+  _top = _top_before_promoted;
+#ifdef ASSERT
+  _top_before_promoted = nullptr;
+#endif
+#ifdef KELVIN_B4_PROMOTE
+  log_info(gc, ergo)("Restoring from _top_before_promoted to " PTR_FORMAT " for region " SIZE_FORMAT, p2i(_top), index());
+#endif
+ }
+
+
 
 #endif // SHARE_GC_SHENANDOAH_SHENANDOAHHEAPREGION_INLINE_HPP

--- a/src/hotspot/share/gc/shenandoah/shenandoahMmuTracker.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahMmuTracker.cpp
@@ -32,7 +32,6 @@
 #include "runtime/os.hpp"
 #include "runtime/task.hpp"
 
-
 class ShenandoahMmuTask : public PeriodicTask {
   ShenandoahMmuTracker* _mmu_tracker;
 public:
@@ -53,12 +52,35 @@ class ThreadTimeAccumulator : public ThreadClosure {
   }
 };
 
-double ShenandoahMmuTracker::gc_thread_time_seconds() {
+ShenandoahMmuTracker::ShenandoahMmuTracker() :
+    _most_recent_timestamp(0.0),
+    _most_recent_gc_time(0.0),
+    _most_recent_gcu(0.0),
+    _most_recent_mutator_time(0.0),
+    _most_recent_mu(0.0),
+    _most_recent_periodic_time_stamp(0.0),
+    _most_recent_periodic_gc_time(0.0),
+    _most_recent_periodic_mutator_time(0.0),
+    _mmu_periodic_task(new ShenandoahMmuTask(this)) {
+}
+
+ShenandoahMmuTracker::~ShenandoahMmuTracker() {
+  _mmu_periodic_task->disenroll();
+  delete _mmu_periodic_task;
+}
+
+void ShenandoahMmuTracker::fetch_cpu_times(double &gc_time, double &mutator_time) {
   ThreadTimeAccumulator cl;
   // We include only the gc threads because those are the only threads
   // we are responsible for.
   ShenandoahHeap::heap()->gc_threads_do(&cl);
-  return double(cl.total_time) / NANOSECS_PER_SEC;
+  double most_recent_gc_thread_time = double(cl.total_time) / NANOSECS_PER_SEC;
+  gc_time = most_recent_gc_thread_time;
+
+  double process_real_time(0.0), process_user_time(0.0), process_system_time(0.0);
+  bool valid = os::getTimesSecs(&process_real_time, &process_user_time, &process_system_time);
+  assert(valid, "don't know why this would not be valid");
+  mutator_time =(process_user_time + process_system_time) - most_recent_gc_thread_time;
 }
 
 double ShenandoahMmuTracker::process_time_seconds() {
@@ -70,49 +92,112 @@ double ShenandoahMmuTracker::process_time_seconds() {
   return 0.0;
 }
 
-ShenandoahMmuTracker::ShenandoahMmuTracker() :
-    _generational_reference_time_s(0.0),
-    _process_reference_time_s(0.0),
-    _collector_reference_time_s(0.0),
-    _mmu_periodic_task(new ShenandoahMmuTask(this)),
-    _mmu_average(10, ShenandoahAdaptiveDecayFactor) {
+void ShenandoahMmuTracker::help_record_concurrent(ShenandoahGeneration* generation, uint gcid, const char *msg) {
+  double current = os::elapsedTime();
+  _most_recent_gcid = gcid;
+  _most_recent_is_full = false;
+
+  if (gcid == 0) {
+    fetch_cpu_times(_most_recent_gc_time, _most_recent_mutator_time);
+
+    _most_recent_timestamp = current;
+  } else {
+    double gc_cycle_duration = current - _most_recent_timestamp;
+    _most_recent_timestamp = current;
+
+    double gc_thread_time, mutator_thread_time;
+    fetch_cpu_times(gc_thread_time, mutator_thread_time);
+    double gc_time = gc_thread_time - _most_recent_gc_time;
+    _most_recent_gc_time = gc_thread_time;
+    _most_recent_gcu = gc_time / (_active_processors * gc_cycle_duration);
+    double mutator_time = mutator_thread_time - _most_recent_mutator_time;
+    _most_recent_mutator_time = mutator_thread_time;
+    _most_recent_mu = mutator_time / (_active_processors * gc_cycle_duration);
+    log_info(gc, ergo)("At end of %s: GCU: %.1f%%, MU: %.1f%% for duration %.3fs",
+                       msg, _most_recent_gcu * 100, _most_recent_mu * 100, gc_cycle_duration);
+  }
 }
 
-ShenandoahMmuTracker::~ShenandoahMmuTracker() {
-  _mmu_periodic_task->disenroll();
-  delete _mmu_periodic_task;
+void ShenandoahMmuTracker::record_young(ShenandoahGeneration* generation, uint gcid) {
+  help_record_concurrent(generation, gcid, "Concurrent Young GC");
 }
 
-void ShenandoahMmuTracker::record(ShenandoahGeneration* generation) {
-  shenandoah_assert_control_or_vm_thread();
-  double collector_time_s = gc_thread_time_seconds();
-  double elapsed_gc_time_s = collector_time_s - _generational_reference_time_s;
-  generation->add_collection_time(elapsed_gc_time_s);
-  _generational_reference_time_s = collector_time_s;
+void ShenandoahMmuTracker::record_bootstrap(ShenandoahGeneration* generation, uint gcid, bool candidates_for_mixed) {
+  // Not likely that this will represent an "ideal" GCU, but doesn't hurt to try
+  help_record_concurrent(generation, gcid, "Bootstrap Old GC");
+  if (candidates_for_mixed) {
+    _doing_mixed_evacuations = true;
+  }
+  // Else, there are no candidates for mixed evacuations, so we are not going to do mixed evacuations.
+}
+
+void ShenandoahMmuTracker::record_old_marking_increment(ShenandoahGeneration* generation, uint gcid, bool old_marking_done,
+                                                        bool has_old_candidates) {
+  // No special processing for old marking
+  double duration = os::elapsedTime() - _most_recent_timestamp;
+  double gc_time, mutator_time;
+  fetch_cpu_times(gc_time, mutator_time);
+  double gcu = (gc_time - _most_recent_gc_time) / duration;
+  double mu = (mutator_time - _most_recent_mutator_time) / duration;
+  if (has_old_candidates) {
+    _doing_mixed_evacuations = true;
+  }
+  log_info(gc, ergo)("At end of %s: GC Utilization: %.1f%% for duration %.3fs (which is subsumed in next concurrent gc report)",
+                     old_marking_done? "last OLD marking increment": "OLD marking increment",
+                     _most_recent_gcu * 100, duration);
+}
+
+void ShenandoahMmuTracker::record_mixed(ShenandoahGeneration* generation, uint gcid, bool is_mixed_done) {
+  help_record_concurrent(generation, gcid, "Mixed Concurrent GC");
+}
+
+void ShenandoahMmuTracker::record_degenerated(ShenandoahGeneration* generation,
+                                              uint gcid, bool is_old_bootstrap, bool is_mixed_done) {
+  if ((gcid == _most_recent_gcid) && _most_recent_is_full) {
+    // Do nothing.  This is a redundant recording for the full gc that just completed.
+  } else if (is_old_bootstrap) {
+    help_record_concurrent(generation, gcid, "Degenerated Bootstrap Old GC");
+    if (!is_mixed_done) {
+      _doing_mixed_evacuations = true;
+    }
+  } else {
+    help_record_concurrent(generation, gcid, "Degenerated Young GC");
+  }
+}
+
+void ShenandoahMmuTracker::record_full(ShenandoahGeneration* generation, uint gcid) {
+  help_record_concurrent(generation, gcid, "Full GC");
+  _most_recent_is_full = true;
+  _doing_mixed_evacuations = false;
 }
 
 void ShenandoahMmuTracker::report() {
   // This is only called by the periodic thread.
-  double process_time_s = process_time_seconds();
-  double elapsed_process_time_s = process_time_s - _process_reference_time_s;
-  if (elapsed_process_time_s <= 0.01) {
-    // No cpu time for this interval?
-    return;
-  }
+  double current = os::elapsedTime();
+  double time_delta = current - _most_recent_periodic_time_stamp;
+  _most_recent_periodic_time_stamp = current;
 
-  _process_reference_time_s = process_time_s;
-  double collector_time_s = gc_thread_time_seconds();
-  double elapsed_collector_time_s = collector_time_s - _collector_reference_time_s;
-  _collector_reference_time_s = collector_time_s;
-  double minimum_mutator_utilization = ((elapsed_process_time_s - elapsed_collector_time_s) / elapsed_process_time_s) * 100;
-  _mmu_average.add(minimum_mutator_utilization);
-  log_info(gc)("Average MMU = %.3f", _mmu_average.davg());
+  double gc_time, mutator_time;
+  fetch_cpu_times(gc_time, mutator_time);
+
+  double gc_delta = gc_time - _most_recent_periodic_gc_time;
+  _most_recent_periodic_gc_time = gc_time;
+
+  double mutator_delta = mutator_time - _most_recent_periodic_mutator_time;
+  _most_recent_periodic_mutator_time = mutator_time;
+
+  double mu = mutator_delta / (_active_processors * time_delta);
+  double gcu = gc_delta / (_active_processors * time_delta);
+  log_info(gc)("Periodic Sample: Average GCU = %.3f%%, Average MU = %.3f%%", gcu * 100, mu * 100);
 }
 
 void ShenandoahMmuTracker::initialize() {
-  _process_reference_time_s = process_time_seconds();
-  _generational_reference_time_s = gc_thread_time_seconds();
-  _collector_reference_time_s = _generational_reference_time_s;
+  double mutator_time_do_not_care;
+  // initialize static data
+  _active_processors = os::initial_active_processor_count();
+
+  double _most_recent_periodic_time_stamp = os::elapsedTime();
+  fetch_cpu_times(_most_recent_periodic_gc_time, _most_recent_periodic_mutator_time);
   _mmu_periodic_task->enroll();
 }
 
@@ -160,12 +245,12 @@ ShenandoahGenerationSizer::ShenandoahGenerationSizer(ShenandoahMmuTracker* mmu_t
 
 size_t ShenandoahGenerationSizer::calculate_min_young_regions(size_t heap_region_count) {
   size_t min_young_regions = (heap_region_count * ShenandoahMinYoungPercentage) / 100;
-  return MAX2(uint(min_young_regions), 1U);
+  return MAX2(min_young_regions, (size_t) 1U);
 }
 
 size_t ShenandoahGenerationSizer::calculate_max_young_regions(size_t heap_region_count) {
   size_t max_young_regions = (heap_region_count * ShenandoahMaxYoungPercentage) / 100;
-  return MAX2(uint(max_young_regions), 1U);
+  return MAX2(max_young_regions, (size_t) 1U);
 }
 
 void ShenandoahGenerationSizer::recalculate_min_max_young_length(size_t heap_region_count) {
@@ -198,114 +283,76 @@ void ShenandoahGenerationSizer::recalculate_min_max_young_length(size_t heap_reg
   assert(_min_desired_young_regions <= _max_desired_young_regions, "Invalid min/max young gen size values");
 }
 
+// TODO: this is not hooked anywhere.
 void ShenandoahGenerationSizer::heap_size_changed(size_t heap_size) {
   recalculate_min_max_young_length(heap_size / ShenandoahHeapRegion::region_size_bytes());
 }
 
-bool ShenandoahGenerationSizer::adjust_generation_sizes() const {
-  shenandoah_assert_generational();
-  if (!use_adaptive_sizing()) {
-    return false;
-  }
-
-  if (_mmu_tracker->average() >= double(GCTimeRatio)) {
-    return false;
-  }
-
+// Returns true iff transfer is successful
+bool ShenandoahGenerationSizer::transfer_to_old(size_t regions) const {
   ShenandoahHeap* heap = ShenandoahHeap::heap();
-  ShenandoahOldGeneration *old = heap->old_generation();
-  ShenandoahYoungGeneration *young = heap->young_generation();
-  ShenandoahGeneration *global = heap->global_generation();
-  double old_time_s = old->reset_collection_time();
-  double young_time_s = young->reset_collection_time();
-  double global_time_s = global->reset_collection_time();
+  ShenandoahGeneration* old_gen = heap->old_generation();
+  ShenandoahGeneration* young_gen = heap->young_generation();
+  size_t region_size_bytes = ShenandoahHeapRegion::region_size_bytes();
+  size_t bytes_to_transfer = regions * region_size_bytes;
 
-  const double transfer_threshold = 3.0;
-  double delta = young_time_s - old_time_s;
-
-  log_info(gc)("Thread Usr+Sys YOUNG = %.3f, OLD = %.3f, GLOBAL = %.3f", young_time_s, old_time_s, global_time_s);
-
-  if (abs(delta) <= transfer_threshold) {
-    log_info(gc, ergo)("Difference (%.3f) for thread utilization for each generation is under threshold (%.3f)", abs(delta), transfer_threshold);
+  if (young_gen->free_unaffiliated_regions() < regions) {
     return false;
-  }
-
-  if (delta > 0) {
-    // young is busier than old, increase size of young to raise MMU
-    return transfer_capacity(old, young);
-  } else {
-    // old is busier than young, increase size of old to raise MMU
-    return transfer_capacity(young, old);
-  }
-}
-
-bool ShenandoahGenerationSizer::transfer_capacity(ShenandoahGeneration* target) const {
-  ShenandoahHeapLocker locker(ShenandoahHeap::heap()->lock());
-  if (target->is_young()) {
-    return transfer_capacity(ShenandoahHeap::heap()->old_generation(), target);
-  } else {
-    assert(target->is_old(), "Expected old generation, if not young.");
-    return transfer_capacity(ShenandoahHeap::heap()->young_generation(), target);
-  }
-}
-
-bool ShenandoahGenerationSizer::transfer_capacity(ShenandoahGeneration* from, ShenandoahGeneration* to) const {
-  shenandoah_assert_heaplocked_or_safepoint();
-
-  size_t available_regions = from->free_unaffiliated_regions();
-  if (available_regions <= 0) {
-    log_info(gc)("%s has no regions available for transfer to %s", from->name(), to->name());
+  } else if (old_gen->max_capacity() + bytes_to_transfer > heap->max_size_for(old_gen)) {
     return false;
-  }
-
-  size_t regions_to_transfer = MAX2(1u, uint(double(available_regions) * _resize_increment));
-  if (from->generation_mode() == YOUNG) {
-    regions_to_transfer = adjust_transfer_from_young(from, regions_to_transfer);
-  } else {
-    regions_to_transfer = adjust_transfer_to_young(to, regions_to_transfer);
-  }
-
-  if (regions_to_transfer == 0) {
-    log_info(gc)("No capacity available to transfer from: %s (" SIZE_FORMAT "%s) to: %s (" SIZE_FORMAT "%s)",
-                  from->name(), byte_size_in_proper_unit(from->max_capacity()), proper_unit_for_byte_size(from->max_capacity()),
-                  to->name(), byte_size_in_proper_unit(to->max_capacity()), proper_unit_for_byte_size(to->max_capacity()));
+  } else if (young_gen->max_capacity() - bytes_to_transfer < heap->min_size_for(young_gen)) {
     return false;
+  } else {
+    young_gen->decrease_capacity(bytes_to_transfer);
+    old_gen->increase_capacity(bytes_to_transfer);
+    size_t new_size = old_gen->max_capacity();
+    log_info(gc)("Transfer " SIZE_FORMAT " region(s) from %s to %s, yielding increased size: " SIZE_FORMAT "%s",
+                 regions, young_gen->name(), old_gen->name(),
+                 byte_size_in_proper_unit(new_size), proper_unit_for_byte_size(new_size));
+    return true;
   }
-
-  log_info(gc)("Transfer " SIZE_FORMAT " region(s) from %s to %s", regions_to_transfer, from->name(), to->name());
-  from->decrease_capacity(regions_to_transfer * ShenandoahHeapRegion::region_size_bytes());
-  to->increase_capacity(regions_to_transfer * ShenandoahHeapRegion::region_size_bytes());
-  return true;
 }
 
-size_t ShenandoahGenerationSizer::adjust_transfer_from_young(ShenandoahGeneration* from, size_t regions_to_transfer) const {
-  assert(from->generation_mode() == YOUNG, "Expect to transfer from young");
-  size_t young_capacity_regions = from->max_capacity() / ShenandoahHeapRegion::region_size_bytes();
-  size_t new_young_regions = young_capacity_regions - regions_to_transfer;
-  size_t minimum_young_regions = min_young_regions();
-  // Check that we are not going to violate the minimum size constraint.
-  if (new_young_regions < minimum_young_regions) {
-    assert(minimum_young_regions <= young_capacity_regions, "Young is under minimum capacity.");
-    // If the transfer violates the minimum size and there is still some capacity to transfer,
-    // adjust the transfer to take the size to the minimum. Note that this may be zero.
-    regions_to_transfer = young_capacity_regions - minimum_young_regions;
-  }
-  return regions_to_transfer;
+// This is used when promoting humongous or highly utilized regular regions in place.  It is not required in this situation
+// that the transferred regions be unaffiliated.  In fact, we are transferring regions that already have high utilization.
+void ShenandoahGenerationSizer::force_transfer_to_old(size_t regions) const {
+  ShenandoahHeap* heap = ShenandoahHeap::heap();
+  ShenandoahGeneration* old_gen = heap->old_generation();
+  ShenandoahGeneration* young_gen = heap->young_generation();
+  size_t region_size_bytes = ShenandoahHeapRegion::region_size_bytes();
+  size_t bytes_to_transfer = regions * region_size_bytes;
+
+  young_gen->decrease_capacity(bytes_to_transfer);
+  old_gen->increase_capacity(bytes_to_transfer);
+  size_t new_size = old_gen->max_capacity();
+  log_info(gc)("Forcing transfer of " SIZE_FORMAT " region(s) from %s to %s, yielding increased size: " SIZE_FORMAT "%s",
+               regions, young_gen->name(), old_gen->name(),
+               byte_size_in_proper_unit(new_size), proper_unit_for_byte_size(new_size));
 }
 
-size_t ShenandoahGenerationSizer::adjust_transfer_to_young(ShenandoahGeneration* to, size_t regions_to_transfer) const {
-  assert(to->generation_mode() == YOUNG, "Can only transfer between young and old.");
-  size_t young_capacity_regions = to->max_capacity() / ShenandoahHeapRegion::region_size_bytes();
-  size_t new_young_regions = young_capacity_regions + regions_to_transfer;
-  size_t maximum_young_regions = max_young_regions();
-  // Check that we are not going to violate the maximum size constraint.
-  if (new_young_regions > maximum_young_regions) {
-    assert(maximum_young_regions >= young_capacity_regions, "Young is over maximum capacity");
-    // If the transfer violates the maximum size and there is still some capacity to transfer,
-    // adjust the transfer to take the size to the maximum. Note that this may be zero.
-    regions_to_transfer = maximum_young_regions - young_capacity_regions;
+
+bool ShenandoahGenerationSizer::transfer_to_young(size_t regions) const {
+  ShenandoahHeap* heap = ShenandoahHeap::heap();
+  ShenandoahGeneration* old_gen = heap->old_generation();
+  ShenandoahGeneration* young_gen = heap->young_generation();
+  size_t region_size_bytes = ShenandoahHeapRegion::region_size_bytes();
+  size_t bytes_to_transfer = regions * region_size_bytes;
+
+  if (old_gen->free_unaffiliated_regions() < regions) {
+    return false;
+  } else if (young_gen->max_capacity() + bytes_to_transfer > heap->max_size_for(young_gen)) {
+    return false;
+  } else if (old_gen->max_capacity() - bytes_to_transfer < heap->min_size_for(old_gen)) {
+    return false;
+  } else {
+    old_gen->decrease_capacity(bytes_to_transfer);
+    young_gen->increase_capacity(bytes_to_transfer);
+    size_t new_size = young_gen->max_capacity();
+    log_info(gc)("Transfer " SIZE_FORMAT " region(s) from %s to %s, yielding increased size: " SIZE_FORMAT "%s",
+                 regions, old_gen->name(), young_gen->name(),
+                 byte_size_in_proper_unit(new_size), proper_unit_for_byte_size(new_size));
+    return true;
   }
-  return regions_to_transfer;
 }
 
 size_t ShenandoahGenerationSizer::min_young_size() const {

--- a/src/hotspot/share/gc/shenandoah/shenandoahMmuTracker.hpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahMmuTracker.hpp
@@ -50,16 +50,31 @@ class ShenandoahMmuTask;
  * MMU.
  */
 class ShenandoahMmuTracker {
+private:
+  // For reporting utilization during most recent GC cycle
+  double _most_recent_timestamp;
+  double _most_recent_gc_time;
+  double _most_recent_gcu;
+  double _most_recent_mutator_time;
+  double _most_recent_mu;
 
-  double _generational_reference_time_s;
-  double _process_reference_time_s;
-  double _collector_reference_time_s;
+  // For periodic MU/GCU reports
+  double _most_recent_periodic_time_stamp;
+  double _most_recent_periodic_gc_time;
+  double _most_recent_periodic_mutator_time;
+
+  uint _most_recent_gcid;
+  uint _active_processors;
+
+  bool _most_recent_is_full;
+  bool _doing_mixed_evacuations;
 
   ShenandoahMmuTask* _mmu_periodic_task;
   TruncatedSeq _mmu_average;
 
-  static double gc_thread_time_seconds();
+  void help_record_concurrent(ShenandoahGeneration* generation, uint gcid, const char* msg);
   static double process_time_seconds();
+  static void fetch_cpu_times(double &gc_time, double &mutator_time);
 
 public:
   explicit ShenandoahMmuTracker();
@@ -68,22 +83,22 @@ public:
   // This enrolls the periodic task after everything is initialized.
   void initialize();
 
-  // This is called at the start and end of a GC cycle. The GC thread times
-  // will be accumulated in this generation. Note that the bootstrap cycle
-  // for an old collection should be counted against the old generation.
-  // When the collector is idle, it still runs a regulator and a control.
-  // The times for these threads are attributed to the global generation.
-  void record(ShenandoahGeneration* generation);
+  // At completion of each GC cycle (not including interrupted cycles), we invoke one of the following to record the
+  // GC utilization during this cycle.
+  //
+  // We may redundantly record degen and full, in which case the gcid will repeat.  We log these as FULL.
+  // Full gets reported first.
+  void record_young(ShenandoahGeneration* generation, uint gcid);
+  void record_bootstrap(ShenandoahGeneration* generation, uint gcid, bool has_old_candidates);
+  void record_old_marking_increment(ShenandoahGeneration* generation, uint gcid, bool old_marking_done, bool has_old_candidates);
+  void record_mixed(ShenandoahGeneration* generation, uint gcid, bool is_mixed_done);
+  void record_full(ShenandoahGeneration* generation, uint gcid);
+  void record_degenerated(ShenandoahGeneration* generation, uint gcid, bool is_old_boostrap, bool is_mixed_done);
 
   // This is called by the periodic task timer. The interval is defined by
   // GCPauseIntervalMillis and defaults to 5 seconds. This method computes
   // the MMU over the elapsed interval and records it in a running average.
-  // This method also logs the average MMU.
   void report();
-
-  double average() {
-    return _mmu_average.davg();
-  }
 };
 
 class ShenandoahGenerationSizer {
@@ -114,14 +129,6 @@ private:
   // given the number of heap regions depending on the kind of sizing algorithm.
   void recalculate_min_max_young_length(size_t heap_region_count);
 
-  // These two methods are responsible for enforcing the minimum and maximum
-  // constraints for the size of the generations.
-  size_t adjust_transfer_from_young(ShenandoahGeneration* from, size_t regions_to_transfer) const;
-  size_t adjust_transfer_to_young(ShenandoahGeneration* to, size_t regions_to_transfer) const;
-
-  // This will attempt to transfer capacity from one generation to the other. It
-  // returns true if a transfer is made, false otherwise.
-  bool transfer_capacity(ShenandoahGeneration* from, ShenandoahGeneration* to) const;
 public:
   explicit ShenandoahGenerationSizer(ShenandoahMmuTracker* mmu_tracker);
 
@@ -145,19 +152,11 @@ public:
     return _use_adaptive_sizing;
   }
 
-  // This is invoked at the end of a collection. This happens on a safepoint
-  // to avoid any races with allocators (and to avoid interfering with
-  // allocators by taking the heap lock). The amount of capacity to move
-  // from one generation to another is controlled by YoungGenerationSizeIncrement
-  // and defaults to 20% of the available capacity of the donor generation.
-  // The minimum and maximum sizes of the young generation are controlled by
-  // ShenandoahMinYoungPercentage and ShenandoahMaxYoungPercentage, respectively.
-  // The method returns true when an adjustment is made, false otherwise.
-  bool adjust_generation_sizes() const;
-
-  // This may be invoked by a heuristic (from regulator thread) before it
-  // decides to run a collection.
-  bool transfer_capacity(ShenandoahGeneration* target) const;
+  bool transfer_to_young(size_t regions) const;
+  bool transfer_to_old(size_t regions) const;
+  
+  // force transfer is used when we promote humongous objects.  May violate min/max limits on generation sizes
+  void force_transfer_to_old(size_t regions) const;
 };
 
 #endif //SHARE_GC_SHENANDOAH_SHENANDOAHMMUTRACKER_HPP

--- a/src/hotspot/share/gc/shenandoah/shenandoahOldGC.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahOldGC.cpp
@@ -30,6 +30,7 @@
 #include "gc/shenandoah/shenandoahOldGC.hpp"
 #include "gc/shenandoah/shenandoahOopClosures.inline.hpp"
 #include "gc/shenandoah/shenandoahGeneration.hpp"
+#include "gc/shenandoah/shenandoahOldGeneration.hpp"
 #include "gc/shenandoah/shenandoahYoungGeneration.hpp"
 #include "prims/jvmtiTagMap.hpp"
 #include "utilities/events.hpp"
@@ -146,5 +147,56 @@ bool ShenandoahOldGC::collect(GCCause::Cause cause) {
   // collection.
   vmop_entry_final_roots(false);
 
+  // We do not rebuild_free following increments of old marking because memory has not been reclaimed..  However, we may
+  // need to transfer memory to OLD in order to efficiently support the mixed evacuations that might immediately follow.
+#undef KELVIN_PREP_4_MIXED
+#ifdef KELVIN_PREP_4_MIXED
+  log_info(gc, ergo)("KELVIN SEES ADJUST FOR MIXED RIGHT HERE");
+#endif
+  size_t evac_slack = heap->young_generation()->heuristics()->evac_slack(0);
+  heap->adjust_generation_sizes_for_next_cycle(evac_slack, 0, 0);
+#ifdef KELVIN_PREP_4_MIXED
+  log_info(gc, ergo)("After adjusting generation sizes, old_deficit: " SIZE_FORMAT ", old surplus: " SIZE_FORMAT,
+                     heap->get_old_region_deficit(), heap->get_old_region_surplus());
+#endif
+
+  bool success;
+  size_t region_xfer;
+  const char* region_destination;
+  ShenandoahYoungGeneration* young_gen = heap->young_generation();
+  ShenandoahGeneration* old_gen = heap->old_generation();
+  {
+    ShenandoahHeapLocker locker(heap->lock());
+
+    size_t old_region_surplus = heap->get_old_region_surplus();
+    size_t old_region_deficit = heap->get_old_region_deficit();
+    if (old_region_surplus) {
+      success = heap->generation_sizer()->transfer_to_young(old_region_surplus);
+      region_destination = "young";
+      region_xfer = old_region_surplus;
+    } else if (old_region_deficit) {
+      success = heap->generation_sizer()->transfer_to_old(old_region_deficit);
+      region_destination = "old";
+      region_xfer = old_region_deficit;
+      if (!success) {
+        ((ShenandoahOldHeuristics *) old_gen->heuristics())->trigger_cannot_expand();
+      }
+    } else {
+      region_destination = "none";
+      region_xfer = 0;
+      success = true;
+    }
+    heap->set_old_region_surplus(0);
+    heap->set_old_region_deficit(0);
+  }
+
+  // Report outside the heap lock
+  size_t young_available = young_gen->available();
+  size_t old_available = old_gen->available();
+  log_info(gc, ergo)("After old marking finished, %s " SIZE_FORMAT " regions to %s to prepare for next gc, old available: "
+                     SIZE_FORMAT "%s, young_available: " SIZE_FORMAT "%s",
+                     success? "successfully transferred": "failed to transfer", region_xfer, region_destination,
+                     byte_size_in_proper_unit(old_available), proper_unit_for_byte_size(old_available),
+                     byte_size_in_proper_unit(young_available), proper_unit_for_byte_size(young_available));
   return true;
 }

--- a/src/hotspot/share/gc/shenandoah/shenandoahOldGeneration.hpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahOldGeneration.hpp
@@ -95,17 +95,31 @@ class ShenandoahOldGeneration : public ShenandoahGeneration {
     return _state;
   }
 
+  size_t get_live_bytes_after_last_mark() const;
+  void set_live_bytes_after_last_mark(size_t new_live);
+
+  size_t usage_trigger_threshold() const;
+
   bool can_start_gc() {
     return _state == IDLE || _state == WAITING_FOR_FILL;
   }
 
  private:
+  static const size_t FRACTIONAL_DENOMINATOR = 64536;
+  static const size_t INITIAL_GROWTH_BEFORE_COMPACTION = FRACTIONAL_DENOMINATOR / 2;          //  50.0%
+  static const size_t MINIMUM_GROWTH_BEFORE_COMPACTION = FRACTIONAL_DENOMINATOR / 8;          //  12.5%
+
+  // First old-collection trigger is at 4.6875% of heap size: i.e. 50% grown beyond 3.125%
+  static const uint16_t INITIAL_LIVE_FRACTION = FRACTIONAL_DENOMINATOR / 32;                    //   3.125%
+
   bool entry_coalesce_and_fill();
   bool coalesce_and_fill();
 
   ShenandoahHeapRegion** _coalesce_and_fill_region_array;
   ShenandoahOldHeuristics* _old_heuristics;
   State _state;
+  size_t _live_bytes_after_last_mark;
+  size_t _growth_before_compaction; // How much growth in usage before we trigger old collection, per 65_536
 };
 
 

--- a/src/hotspot/share/gc/shenandoah/shenandoahPhaseTimings.hpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahPhaseTimings.hpp
@@ -189,6 +189,7 @@ class outputStream;
   f(pacing,                                         "Pacing")                          \
                                                                                        \
   f(heap_iteration_roots,                           "Heap Iteration")                  \
+  f(thread_iteration_roots,                         "Java Thread Iteration")           \
   SHENANDOAH_PAR_PHASE_DO(heap_iteration_roots_,    "  HI: ", f)                       \
   // end
 

--- a/src/hotspot/share/gc/shenandoah/shenandoahRegulatorThread.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahRegulatorThread.cpp
@@ -140,7 +140,8 @@ void ShenandoahRegulatorThread::regulator_sleep() {
 }
 
 bool ShenandoahRegulatorThread::start_old_cycle() {
-  return _old_heuristics->should_start_gc() && _control_thread->request_concurrent_gc(OLD);
+  return !ShenandoahHeap::heap()->doing_mixed_evacuations() && !ShenandoahHeap::heap()->collection_set()->has_old_regions() &&
+    _old_heuristics->should_start_gc() && _control_thread->request_concurrent_gc(OLD);
 }
 
 bool ShenandoahRegulatorThread::start_young_cycle() {

--- a/src/hotspot/share/gc/shenandoah/shenandoahVMOperations.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahVMOperations.cpp
@@ -80,6 +80,10 @@ void VM_ShenandoahFinalUpdateRefs::doit() {
 
 void VM_ShenandoahFinalRoots::doit() {
   ShenandoahGCPauseMark mark(_gc_id, SvcGCMarker::CONCURRENT);
+#undef KELVIN_VERBOSE
+#ifdef KELVIN_VERBOSE
+  log_info(gc, ergo)("VM_ShenandoahFinalRoots::doit() will increment region ages if %d is non-zero\n", _incr_region_ages);
+#endif
   if (_incr_region_ages) {
     // TODO: Do we even care about this?  Do we want to parallelize it?
     ShenandoahHeap* heap = ShenandoahHeap::heap();

--- a/src/hotspot/share/gc/shenandoah/shenandoahVerifier.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahVerifier.cpp
@@ -356,6 +356,14 @@ public:
     _garbage += r->garbage();
     _committed += r->is_committed() ? ShenandoahHeapRegion::region_size_bytes() : 0;
     _regions++;
+#undef KELVIN_STATS
+#ifdef KELVIN_STATS
+    log_info(gc, ergo)("ShenandoahCalculateRegionStatsClosure added " SIZE_FORMAT " for %s %s %s Region " SIZE_FORMAT
+                       ", yielding usage: " SIZE_FORMAT ", garbage: " SIZE_FORMAT ", committed: " SIZE_FORMAT
+                       ", regions: " SIZE_FORMAT,
+                       r->used(), affiliation_name(r->affiliation()), r->is_cset()? "cset": "retained",
+                       r->is_humongous()? "humongous": "regular", r->index(), _used, _garbage, _committed, _regions);
+#endif
   }
 
   size_t used() { return _used; }
@@ -378,11 +386,21 @@ class ShenandoahGenerationStatsClosure : public ShenandoahHeapRegionClosure {
       default:
         ShouldNotReachHere();
         return;
-      case FREE: return;
+      case FREE:
+#ifdef KELVIN_STATS
+        log_info(gc, ergo)("Ignoring FREE region " SIZE_FORMAT, r->index());
+#endif
+        return;
       case YOUNG_GENERATION:
+#ifdef KELVIN_STATS
+        log_info(gc, ergo)("Accumulating region " SIZE_FORMAT " as young", r->index());
+#endif
         young.heap_region_do(r);
         break;
       case OLD_GENERATION:
+#ifdef KELVIN_STATS
+        log_info(gc, ergo)("Accumulating region " SIZE_FORMAT " as old", r->index());
+#endif
         old.heap_region_do(r);
         break;
     }
@@ -396,24 +414,98 @@ class ShenandoahGenerationStatsClosure : public ShenandoahHeapRegionClosure {
                   byte_size_in_proper_unit(stats.used()), proper_unit_for_byte_size(stats.used()));
   }
 
-  static void validate_usage(const char* label, ShenandoahGeneration* generation, ShenandoahCalculateRegionStatsClosure& stats) {
+  static void validate_usage(const bool adjust_for_padding, const bool adjust_for_deferred_accounting,
+			     const char* label, ShenandoahGeneration* generation, ShenandoahCalculateRegionStatsClosure& stats) {
     size_t generation_used = generation->used();
+    size_t generation_used_regions = generation->used_regions();
+#undef KELVIN_VERIFY
+#ifdef KELVIN_VERIFY
+    log_info(gc, ergo)("%s: validate_usage(label: %s, pad adjust: %d, accounting adjust: %d)",
+                       generation->name(), label, adjust_for_padding, adjust_for_deferred_accounting);
+#endif
+    if (adjust_for_deferred_accounting) {
+      ShenandoahHeap* heap = ShenandoahHeap::heap();
+      ShenandoahGeneration* young_generation = heap->young_generation();
+      size_t humongous_regions_promoted = heap->get_promotable_humongous_regions();
+      size_t humongous_bytes_promoted = heap->get_promotable_humongous_usage();
+#ifdef KELVIN_DEPRECATE
+      size_t regular_regions_promoted_in_place = heap->get_regular_regions_promoted_in_place();
+      size_t total_regions_promoted = humongous_regions_promoted + regular_regions_promoted_in_place;
+#else
+      size_t total_regions_promoted = humongous_regions_promoted;
+#endif
+      size_t bytes_promoted_in_place = 0;
+      if (total_regions_promoted > 0) {
+#ifdef KELVIN_DEPRECATE
+	size_t regular_bytes_promoted_in_place = heap->get_regular_usage_promoted_in_place();
+	bytes_promoted_in_place = humongous_bytes_promoted + regular_bytes_promoted_in_place;
+#else
+	bytes_promoted_in_place = humongous_bytes_promoted;
+#endif
+
+#ifdef KELVIN_VERIFY
+	log_info(gc, ergo)("bytes_promoted_in_place: " SIZE_FORMAT
+                           " computed from humongous_bytes_promoted: " SIZE_FORMAT
+                           " plus regular_bytes_promoted: " SIZE_FORMAT,
+			   bytes_promoted_in_place, humongous_bytes_promoted, regular_bytes_promoted_in_place);
+#endif
+      }
+      if (generation->is_young()) {
+	generation_used -= bytes_promoted_in_place;
+	generation_used_regions -= total_regions_promoted;
+#ifdef KELVIN_VERIFY
+	log_info(gc, ergo)("validate_usage subtracting " SIZE_FORMAT " from young used to obtain " SIZE_FORMAT,
+			   bytes_promoted_in_place, generation_used);
+	log_info(gc, ergo)("  subtracting " SIZE_FORMAT " from young regions used to obtain " SIZE_FORMAT,
+			   total_regions_promoted, generation_used_regions);
+#endif
+      } else if (generation->is_old()) {
+	generation_used += bytes_promoted_in_place;
+	generation_used_regions += total_regions_promoted;
+#ifdef KELVIN_VERIFY
+	log_info(gc, ergo)("validate_usage adding " SIZE_FORMAT " to old used to obtain " SIZE_FORMAT,
+			   bytes_promoted_in_place, generation_used);
+	log_info(gc, ergo)("  adding " SIZE_FORMAT " to old regions used to obtain " SIZE_FORMAT,
+			   total_regions_promoted, generation_used_regions);
+#endif
+      }
+      // else, global validation doesn't care where the promoted-in-place data is tallied.
+    }
+    if (adjust_for_padding && (generation->is_young() || generation->is_global())) {
+      size_t pad = ShenandoahHeap::heap()->get_pad_for_promote_in_place();
+      generation_used += pad;
+#ifdef KELVIN_VERIFY
+      log_info(gc, ergo)("validate_usage adding pad " SIZE_FORMAT " from YOUNG usage to get " SIZE_FORMAT,
+                         pad, generation_used);
+#endif
+    }
+
     guarantee(stats.used() == generation_used,
               "%s: generation (%s) used size must be consistent: generation-used = " SIZE_FORMAT "%s, regions-used = " SIZE_FORMAT "%s",
               label, generation->name(),
               byte_size_in_proper_unit(generation_used), proper_unit_for_byte_size(generation_used),
               byte_size_in_proper_unit(stats.used()), proper_unit_for_byte_size(stats.used()));
 
-    guarantee(stats.regions() == generation->used_regions(),
+    guarantee(stats.regions() == generation_used_regions,
               "%s: generation (%s) used regions (" SIZE_FORMAT ") must equal regions that are in use (" SIZE_FORMAT ")",
               label, generation->name(), generation->used_regions(), stats.regions());
 
-    size_t capacity = generation->adjusted_capacity();
-    guarantee(stats.span() <= capacity,
+    size_t generation_capacity = generation->adjusted_capacity();
+    if (adjust_for_deferred_accounting) {
+      ShenandoahHeap* heap = ShenandoahHeap::heap();
+      size_t humongous_regions_promoted = heap->get_promotable_humongous_regions();
+#ifdef KELVIN_DEPRECATED
+      size_t regular_regions_promoted_in_place = heap->get_regular_regions_promoted_in_place();
+      size_t transferred_regions = humongous_regions_promoted + regular_regions_promoted_in_place;
+#else
+      size_t transferred_regions = humongous_regions_promoted;
+#endif
+      generation_capacity += transferred_regions * ShenandoahHeapRegion::region_size_bytes();
+    }
+    guarantee(stats.span() <= generation_capacity,
               "%s: generation (%s) size spanned by regions (" SIZE_FORMAT ") must not exceed current capacity (" SIZE_FORMAT "%s)",
               label, generation->name(), stats.regions(),
-              byte_size_in_proper_unit(capacity), proper_unit_for_byte_size(capacity));
-
+              byte_size_in_proper_unit(generation_capacity), proper_unit_for_byte_size(generation_capacity));
   }
 };
 
@@ -710,7 +802,7 @@ private:
 public:
   VerifyThreadGCState(const char* label, char expected) : _label(label), _expected(expected) {}
   void do_thread(Thread* t) {
-    char actual = ShenandoahThreadLocalData::gc_state(t);
+    char actual = ShenandoahThreadLocalData::gc_state(t) & ~ShenandoahHeap::MIXED_EVACUATIONS_ENABLED;
     if (actual != _expected && !(actual & ShenandoahHeap::OLD_MARKING)) {
       fatal("%s: Thread %s: expected gc-state %d, actual %d", _label, t->name(), _expected, actual);
     }
@@ -722,6 +814,7 @@ void ShenandoahVerifier::verify_at_safepoint(const char* label,
                                              VerifyForwarded forwarded, VerifyMarked marked,
                                              VerifyCollectionSet cset,
                                              VerifyLiveness liveness, VerifyRegions regions,
+					     VerifySize sizeness,
                                              VerifyGCState gcstate) {
   guarantee(ShenandoahSafepoint::is_at_shenandoah_safepoint(), "only when nothing else happens");
   guarantee(ShenandoahVerify, "only when enabled, and bitmap is initialized in ShenandoahHeap::initialize");
@@ -773,7 +866,7 @@ void ShenandoahVerifier::verify_at_safepoint(const char* label,
     }
 
     if (enabled) {
-      char actual = _heap->gc_state();
+      char actual = _heap->gc_state() & ~ShenandoahHeap::MIXED_EVACUATIONS_ENABLED;
       // Old generation marking is allowed in all states.
       if (actual != expected && !(actual & ShenandoahHeap::OLD_MARKING)) {
         fatal("%s: Global gc-state: expected %d, actual %d", label, expected, actual);
@@ -793,13 +886,25 @@ void ShenandoahVerifier::verify_at_safepoint(const char* label,
 
     ShenandoahCalculateRegionStatsClosure cl;
     _heap->heap_region_iterate(&cl);
-    size_t heap_used = _heap->used();
-    guarantee(cl.used() == heap_used,
-              "%s: heap used size must be consistent: heap-used = " SIZE_FORMAT "%s, regions-used = " SIZE_FORMAT "%s",
-              label,
-              byte_size_in_proper_unit(heap_used), proper_unit_for_byte_size(heap_used),
-              byte_size_in_proper_unit(cl.used()), proper_unit_for_byte_size(cl.used()));
-
+    size_t heap_used;
+    if (_heap->mode()->is_generational() && (sizeness == _verify_size_adjusted_for_padding)) {
+      // Prior to evacuation, regular regions that are to be evacuated in place are padded to prevent further allocations
+      heap_used = _heap->used() + _heap->get_pad_for_promote_in_place();
+#undef KELVIN_VERIFY
+#ifdef KELVIN_VERIFY
+      log_info(gc, ergo)("added " SIZE_FORMAT " to _heap->used(), yielding: " SIZE_FORMAT ", cl.used: " SIZE_FORMAT,
+			 _heap->get_pad_for_promote_in_place(), heap_used, cl.used());
+#endif
+    } else if (sizeness != _verify_size_disable) {
+      heap_used = _heap->used();
+    }
+    if (sizeness != _verify_size_disable) {
+      guarantee(cl.used() == heap_used,
+                "%s: heap used size must be consistent: heap-used = " SIZE_FORMAT "%s, regions-used = " SIZE_FORMAT "%s",
+                label,
+                byte_size_in_proper_unit(heap_used), proper_unit_for_byte_size(heap_used),
+                byte_size_in_proper_unit(cl.used()), proper_unit_for_byte_size(cl.used()));
+    }
     size_t heap_committed = _heap->committed();
     guarantee(cl.committed() == heap_committed,
               "%s: heap committed size must be consistent: heap-committed = " SIZE_FORMAT "%s, regions-committed = " SIZE_FORMAT "%s",
@@ -846,9 +951,36 @@ void ShenandoahVerifier::verify_at_safepoint(const char* label,
       ShenandoahGenerationStatsClosure::log_usage(_heap->global_generation(), cl.global);
     }
 
-    ShenandoahGenerationStatsClosure::validate_usage(label, _heap->old_generation(), cl.old);
-    ShenandoahGenerationStatsClosure::validate_usage(label, _heap->young_generation(), cl.young);
-    ShenandoahGenerationStatsClosure::validate_usage(label, _heap->global_generation(), cl.global);
+    if (sizeness == _verify_size_adjusted_for_deferred_accounting) {
+#ifdef KELVIN_VERIFY
+      log_info(gc, ergo)("_sizeness is verify_size_adjusted_for_deferred_accounting");
+#endif
+      ShenandoahGenerationStatsClosure::validate_usage(false, true, label, _heap->old_generation(), cl.old);
+      ShenandoahGenerationStatsClosure::validate_usage(false, true, label, _heap->young_generation(), cl.young);
+      ShenandoahGenerationStatsClosure::validate_usage(false, false, label, _heap->global_generation(), cl.global);
+    } else if  (sizeness == _verify_size_adjusted_for_padding) {
+#ifdef KELVIN_VERIFY
+      log_info(gc, ergo)("_sizeness is verify_size_adjusted_for_padding");
+#endif
+      ShenandoahGenerationStatsClosure::validate_usage(false, false, label, _heap->old_generation(), cl.old);
+      ShenandoahGenerationStatsClosure::validate_usage(true, false, label, _heap->young_generation(), cl.young);
+      ShenandoahGenerationStatsClosure::validate_usage(true, false, label, _heap->global_generation(), cl.global);
+    }
+    else if (sizeness == _verify_size_exact) {
+#ifdef KELVIN_VERIFY
+      log_info(gc, ergo)("_sizeness is verify_size_exact");
+#endif
+      ShenandoahGenerationStatsClosure::validate_usage(false, false, label, _heap->old_generation(), cl.old);
+      ShenandoahGenerationStatsClosure::validate_usage(false, false, label, _heap->young_generation(), cl.young);
+      ShenandoahGenerationStatsClosure::validate_usage(false, false, label, _heap->global_generation(), cl.global);
+    }
+    // else: sizeness must equal _verify_size_disable
+#ifdef KELVIN_VERIFY
+    else {
+      log_info(gc, ergo)("_sizeness is verify_size_disable");
+    }
+#endif
+
   }
 
   log_debug(gc)("Safepoint verification finished remembered set verification");
@@ -960,6 +1092,7 @@ void ShenandoahVerifier::verify_generic(VerifyOption vo) {
           _verify_cset_disable,        // cset may be inconsistent
           _verify_liveness_disable,    // no reliable liveness data
           _verify_regions_disable,     // no reliable region data
+	  _verify_size_exact,          // expect generation and heap sizes to match exactly
           _verify_gcstate_disable      // no data about gcstate
   );
 }
@@ -973,6 +1106,7 @@ void ShenandoahVerifier::verify_before_concmark() {
           _verify_cset_none,           // UR should have fixed this
           _verify_liveness_disable,    // no reliable liveness data
           _verify_regions_notrash,     // no trash regions
+	  _verify_size_exact,          // expect generation and heap sizes to match exactly
           _verify_gcstate_stable       // there are no forwarded objects
   );
 }
@@ -986,6 +1120,7 @@ void ShenandoahVerifier::verify_after_concmark() {
           _verify_cset_none,           // no references to cset anymore
           _verify_liveness_complete,   // liveness data must be complete here
           _verify_regions_disable,     // trash regions not yet recycled
+	  _verify_size_exact,          // expect generation and heap sizes to match exactly
           _verify_gcstate_stable_weakroots  // heap is still stable, weakroots are in progress
   );
 }
@@ -999,6 +1134,8 @@ void ShenandoahVerifier::verify_before_evacuation() {
           _verify_cset_disable,                      // non-forwarded references to cset expected
           _verify_liveness_complete,                 // liveness data must be complete here
           _verify_regions_disable,                   // trash regions not yet recycled
+	  _verify_size_adjusted_for_padding,         // expect generation and heap sizes to match after adjustments
+	                                             //  for promote in place padding
           _verify_gcstate_stable_weakroots           // heap is still stable, weakroots are in progress
   );
 }
@@ -1012,6 +1149,7 @@ void ShenandoahVerifier::verify_during_evacuation() {
           _verify_cset_disable,       // some cset references are not forwarded yet
           _verify_liveness_disable,   // liveness data might be already stale after pre-evacs
           _verify_regions_disable,    // trash regions not yet recycled
+	  _verify_size_disable,       // we don't know how much of promote-in-place work has been completed
           _verify_gcstate_evacuation  // evacuation is in progress
   );
 }
@@ -1025,6 +1163,8 @@ void ShenandoahVerifier::verify_after_evacuation() {
           _verify_cset_forwarded,      // all cset refs are fully forwarded
           _verify_liveness_disable,    // no reliable liveness data anymore
           _verify_regions_notrash,     // trash regions have been recycled already
+	  _verify_size_adjusted_for_deferred_accounting,
+	                               // expect generation and heap sizes to match after adjustments for promote in place
           _verify_gcstate_forwarded    // evacuation produced some forwarded objects
   );
 }
@@ -1038,10 +1178,14 @@ void ShenandoahVerifier::verify_before_updaterefs() {
           _verify_cset_forwarded,                      // all cset refs are fully forwarded
           _verify_liveness_disable,                    // no reliable liveness data anymore
           _verify_regions_notrash,                     // trash regions have been recycled already
+	  _verify_size_adjusted_for_deferred_accounting,
+	                                               // expect generation and heap sizes to match after adjustments
+	                                               //  for promote in place
           _verify_gcstate_updating                     // evacuation should have produced some forwarded objects
   );
 }
 
+// We have not yet cleanup (reclaimed) the collection set
 void ShenandoahVerifier::verify_after_updaterefs() {
   verify_at_safepoint(
           "After Updating References",
@@ -1051,6 +1195,8 @@ void ShenandoahVerifier::verify_after_updaterefs() {
           _verify_cset_none,           // no cset references, all updated
           _verify_liveness_disable,    // no reliable liveness data anymore
           _verify_regions_nocset,      // no cset regions, trash regions have appeared
+	  _verify_size_adjusted_for_deferred_accounting,
+                                       // expect generation and heap sizes to match after adjustments for promote in place
           _verify_gcstate_stable       // update refs had cleaned up forwarded objects
   );
 }
@@ -1064,6 +1210,7 @@ void ShenandoahVerifier::verify_after_degenerated() {
           _verify_cset_none,           // no cset references
           _verify_liveness_disable,    // no reliable liveness data anymore
           _verify_regions_notrash_nocset, // no trash, no cset
+	  _verify_size_exact,           // expect generation and heap sizes to match exactly
           _verify_gcstate_stable       // degenerated refs had cleaned up forwarded objects
   );
 }
@@ -1077,6 +1224,7 @@ void ShenandoahVerifier::verify_before_fullgc() {
           _verify_cset_disable,        // cset might be foobared
           _verify_liveness_disable,    // no reliable liveness data anymore
           _verify_regions_disable,     // no reliable region data here
+	  _verify_size_exact,           // expect generation and heap sizes to match exactly
           _verify_gcstate_disable      // no reliable gcstate data
   );
 }
@@ -1090,6 +1238,7 @@ void ShenandoahVerifier::verify_after_generational_fullgc() {
           _verify_cset_none,           // no cset references
           _verify_liveness_disable,    // no reliable liveness data anymore
           _verify_regions_notrash_nocset, // no trash, no cset
+	  _verify_size_exact,           // expect generation and heap sizes to match exactly
           _verify_gcstate_stable       // full gc cleaned up everything
   );
 }
@@ -1103,6 +1252,7 @@ void ShenandoahVerifier::verify_after_fullgc() {
           _verify_cset_none,           // no cset references
           _verify_liveness_disable,    // no reliable liveness data anymore
           _verify_regions_notrash_nocset, // no trash, no cset
+	  _verify_size_exact,           // expect generation and heap sizes to match exactly
           _verify_gcstate_stable        // full gc cleaned up everything
   );
 }

--- a/src/hotspot/share/gc/shenandoah/shenandoahVerifier.hpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahVerifier.hpp
@@ -142,6 +142,20 @@ public:
   } VerifyRegions;
 
   typedef enum {
+    // Disable size verification
+    _verify_size_disable,
+
+    // Enforce exact consistency
+    _verify_size_exact,
+
+    // Expect promote-in-place adjustments: padding inserted to temporarily prevent further allocation in regular regions
+    _verify_size_adjusted_for_padding,
+
+    // Expect promote-in-place adjustments: usage within regions promoted in place is transferred at end of update refs
+    _verify_size_adjusted_for_deferred_accounting
+  } VerifySize;
+
+  typedef enum {
     // Disable gc-state verification
     _verify_gcstate_disable,
 
@@ -189,6 +203,7 @@ private:
                            VerifyCollectionSet cset,
                            VerifyLiveness liveness,
                            VerifyRegions regions,
+			   VerifySize sizeness,
                            VerifyGCState gcstate);
 
 public:

--- a/src/hotspot/share/gc/shenandoah/shenandoah_globals.hpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoah_globals.hpp
@@ -97,7 +97,7 @@
           "collector accepts. In percents of heap region size.")            \
           range(0,100)                                                      \
                                                                             \
-  product(uintx, ShenandoahOldGarbageThreshold, 10, EXPERIMENTAL,           \
+  product(uintx, ShenandoahOldGarbageThreshold, 15, EXPERIMENTAL,           \
           "How much garbage an old region has to contain before it would "  \
           "be taken for collection.")                                       \
           range(0,100)                                                      \
@@ -126,13 +126,6 @@
           "collection independent of other triggers. Provides a safety "    \
           "margin for many heuristics. In percents of (soft) max heap "     \
           "size.")                                                          \
-          range(0,100)                                                      \
-                                                                            \
-  product(uintx, ShenandoahOldMinFreeThreshold, 5, EXPERIMENTAL,            \
-          "Percentage of free old generation heap memory below which most " \
-          "heuristics trigger collection independent of other triggers. "   \
-          "Provides a safety margin for many heuristics. In percents of "   \
-          "(soft) max heap size.")                                          \
           range(0,100)                                                      \
                                                                             \
   product(uintx, ShenandoahAllocationThreshold, 0, EXPERIMENTAL,            \
@@ -210,7 +203,7 @@
           "Heuristics may trigger collections more frequently. Time is in " \
           "milliseconds. Setting this to 0 disables the feature.")          \
                                                                             \
-  product(uintx, ShenandoahGuaranteedYoungGCInterval, 5*60*1000,  EXPERIMENTAL,  \
+  product(uintx, ShenandoahGuaranteedYoungGCInterval, 15*1000,  EXPERIMENTAL,  \
           "Run a collection of the young generation at least this often. "    \
           "Heuristics may trigger collections more frequently. Time is in " \
           "milliseconds. Setting this to 0 disables the feature.")          \
@@ -299,17 +292,20 @@
           "failures, which will trigger stop-the-world Full GC passes.")    \
           range(1.0,100.0)                                                  \
                                                                             \
-  product(double, ShenandoahGenerationalEvacWaste, 2.0, EXPERIMENTAL,       \
-          "For generational mode, how much waste evacuations produce "      \
-          "within the reserved space.  Larger values make evacuations "     \
-          "more resilient against evacuation conflicts, at expense of "     \
-          "evacuating less on each GC cycle.  Smaller values increase "     \
-          "the risk of evacuation failures, which will trigger "            \
-          "stop-the-world Full GC passes.  The default value for "          \
-          "generational mode is 2.0.  The reason for the higher default "   \
-          "value in generational mode is because generational mode "        \
-          "enforces the evacuation budget, triggering degenerated GC "      \
-          "which upgrades to full GC whenever the budget is exceeded.")     \
+  product(double, ShenandoahOldEvacWaste, 1.6, EXPERIMENTAL,                \
+          "How much waste evacuations produce within the reserved space. "  \
+          "Larger values make evacuations more resilient against "          \
+          "evacuation conflicts, at expense of evacuating less on each "    \
+          "GC cycle.  Smaller values increase the risk of evacuation "      \
+          "failures, which will trigger stop-the-world Full GC passes.")    \
+          range(1.0,100.0)                                                  \
+                                                                            \
+  product(double, ShenandoahPromoEvacWaste, 1.2, EXPERIMENTAL,              \
+          "How much waste evacuations produce within the reserved space. "  \
+          "Larger values make evacuations more resilient against "          \
+          "evacuation conflicts, at expense of evacuating less on each "    \
+          "GC cycle.  Smaller values increase the risk of evacuation "      \
+          "failures, which will trigger stop-the-world Full GC passes.")    \
           range(1.0,100.0)                                                  \
                                                                             \
   product(uintx, ShenandoahMaxEvacLABRatio, 0, EXPERIMENTAL,                \
@@ -338,26 +334,16 @@
           "reserve/waste is incorrect, at the risk that application "       \
           "runs out of memory too early.")                                  \
                                                                             \
-  product(uintx, ShenandoahOldEvacReserve, 2, EXPERIMENTAL,                 \
-          "How much of old-generation heap to reserve for old-generation "  \
-          "evacuations.  Larger values allow GC to evacuate more live "     \
-          "old-generation objects on every cycle, while potentially "       \
-          "creating greater impact on the cadence at which the young- "     \
-          "generation allocation pool is replenished.  During mixed "       \
-          "evacuations, the bound on amount of old-generation heap "        \
-          "regions included in the collecdtion set is the smaller "         \
-          "of the quantities specified by this parameter and the "          \
-          "size of ShenandoahEvacReserve as adjusted by the value of "      \
-          "ShenandoahOldEvacRatioPercent.  In percents of total "           \
-          "old-generation heap size.")                                      \
-          range(1,100)                                                      \
-                                                                            \
-  product(uintx, ShenandoahOldEvacRatioPercent, 12, EXPERIMENTAL,           \
+  product(uintx, ShenandoahOldEvacRatioPercent, 75, EXPERIMENTAL,           \
           "The maximum proportion of evacuation from old-gen memory, as "   \
-          "a percent ratio.  The default value 12 denotes that no more "    \
-          "than one eighth (12%) of the collection set evacuation "         \
-          "workload may be comprised of old-gen heap regions.  A larger "   \
-          "value allows a smaller number of mixed evacuations to process "  \
+          "a percent ratio.  The default value 75 denotes that no more "    \
+          "than 75% of the collection set evacuation "                      \
+          "workload may be evacuate to old-gen heap regions.  This limits " \
+          "both the promotion of aged regions and the compaction of "       \
+          "existing old regions.  A value of 75 denotes that the normal "   \
+          "young-gen evacuation is increased by up to four fold. "          \
+          "A larger value allows quicker promotion and allows"              \
+          "a smaller number of mixed evacuations to process "               \
           "the entire list of old-gen collection candidates at the cost "   \
           "of an increased disruption of the normal cadence of young-gen "  \
           "collections.  A value of 100 allows a mixed evacuation to "      \
@@ -371,13 +357,13 @@
           "events.")                                                        \
           range(0,100)                                                      \
                                                                             \
-  product(uintx, ShenandoahMinYoungPercentage, 20,                                \
+  product(uintx, ShenandoahMinYoungPercentage, 20,                          \
           "The minimum percentage of the heap to use for the young "        \
           "generation. Heuristics will not adjust the young generation "    \
           "to be less than this.")                                          \
           range(0, 100)                                                     \
                                                                             \
-  product(uintx, ShenandoahMaxYoungPercentage, 80,                                \
+  product(uintx, ShenandoahMaxYoungPercentage, 100,                         \
           "The maximum percentage of the heap to use for the young "        \
           "generation. Heuristics will not adjust the young generation "    \
           "to be more than this.")                                          \
@@ -516,20 +502,6 @@
   product(bool, ShenandoahSelfFixing, true, DIAGNOSTIC,                     \
           "Fix references with load reference barrier. Disabling this "     \
           "might degrade performance.")                                     \
-                                                                            \
-  product(uintx, ShenandoahBorrowPercent, 30, EXPERIMENTAL,                 \
-          "During evacuation and reference updating in generational "       \
-          "mode, new allocations are allowed to borrow from old-gen "       \
-          "memory up to ShenandoahBorrowPercent / 100 amount of the "       \
-          "young-generation content of the current collection set.  "       \
-          "Any memory borrowed from old-gen during evacuation and "         \
-          "update-references phases of GC will be repaid from the "         \
-          "abundance of young-gen memory produced when the collection "     \
-          "set is recycled at the end of updating references.  The "        \
-          "default value of 30 reserves 70% of the to-be-reclaimed "        \
-          "young collection set memory to be allocated during the "         \
-          "subsequent concurrent mark phase of GC.")                        \
-          range(0, 100)                                                     \
                                                                             \
   product(uintx, ShenandoahOldCompactionReserve, 8, EXPERIMENTAL,           \
           "During generational GC, prevent promotions from filling "        \

--- a/test/hotspot/gtest/gc/shenandoah/test_shenandoahOldHeuristic.cpp
+++ b/test/hotspot/gtest/gc/shenandoah/test_shenandoahOldHeuristic.cpp
@@ -62,7 +62,7 @@ class ShenandoahResetRegions : public ShenandoahHeapRegionClosure {
       region->make_trash();
       region->make_empty();
     }
-    region->set_affiliation(FREE);
+    region->set_affiliation(FREE, false);
     region->clear_live_data();
     region->set_top(region->bottom());
   }


### PR DESCRIPTION
This PR describes several proposed changes to dynamically adjust the sizes of old-gen and young-gen.  In general, the objective is to keep old-gen as small as possible so that there is an abundance of memory available for the young-gen allocation runway.

As currently drafted, there are regression failures.  This DRAFT PR is published for the purpose of facilitating a careful code review.