### PR TITLE
Reduce the number of new product flags

### DIFF
--- a/src/hotspot/share/gc/shenandoah/shenandoah_globals.hpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoah_globals.hpp
@@ -78,7 +78,7 @@
           " compact - run GC more frequently and with deeper targets to "   \
           "free up more memory.")                                           \
                                                                             \
-  product(ccstr, ShenandoahOldGCHeuristics, "adaptive",                     \
+  product(ccstr, ShenandoahOldGCHeuristics, "adaptive", EXPERIMENTAL,       \
           "Similar to ShenandoahGCHeuristics, but applied to the old "      \
           "generation. This configuration is only used to trigger old "     \
           "collections and does not change how regions are selected "       \
@@ -205,13 +205,13 @@
           "time from active application. Time is in milliseconds. "         \
           "Setting this to 0 disables the feature.")                        \
                                                                             \
-  product(uintx, ShenandoahGuaranteedOldGCInterval, 10*60*1000,  EXPERIMENTAL,  \
+  product(uintx, ShenandoahGuaranteedOldGCInterval, 10*60*1000, EXPERIMENTAL, \
           "Run a collection of the old generation at least this often. "    \
           "Heuristics may trigger collections more frequently. Time is in " \
           "milliseconds. Setting this to 0 disables the feature.")          \
                                                                             \
-  product(uintx, ShenandoahGuaranteedYoungGCInterval, 5*60*1000,  EXPERIMENTAL,  \
-          "Run a collection of the young generation at least this often. "    \
+  product(uintx, ShenandoahGuaranteedYoungGCInterval, 5*60*1000, EXPERIMENTAL, \
+          "Run a collection of the young generation at least this often. "  \
           "Heuristics may trigger collections more frequently. Time is in " \
           "milliseconds. Setting this to 0 disables the feature.")          \
                                                                             \
@@ -371,13 +371,13 @@
           "events.")                                                        \
           range(0,100)                                                      \
                                                                             \
-  product(uintx, ShenandoahMinYoungPercentage, 20,                                \
+  product(uintx, ShenandoahMinYoungPercentage, 20, EXPERIMENTAL,            \
           "The minimum percentage of the heap to use for the young "        \
           "generation. Heuristics will not adjust the young generation "    \
           "to be less than this.")                                          \
           range(0, 100)                                                     \
                                                                             \
-  product(uintx, ShenandoahMaxYoungPercentage, 80,                                \
+  product(uintx, ShenandoahMaxYoungPercentage, 80, EXPERIMENTAL,            \
           "The maximum percentage of the heap to use for the young "        \
           "generation. Heuristics will not adjust the young generation "    \
           "to be more than this.")                                          \


### PR DESCRIPTION
Eventual upstreaming would require a CSR for every changed product flag. Not every flag we have now needs to be product, we can reduce them to be experimental.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed (1 review required, with at least 1 [Committer](https://openjdk.org/bylaws#committer))

### Reviewers
 * [Y. Srinivas Ramakrishna](https://openjdk.org/census#ysr) (@ysramakrishna - Author)
 * [Roman Kennke](https://openjdk.org/census#rkennke) (@rkennke - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/shenandoah.git pull/251/head:pull/251` \
`$ git checkout pull/251`

Update a local copy of the PR: \
`$ git checkout pull/251` \
`$ git pull https://git.openjdk.org/shenandoah.git pull/251/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 251`

View PR using the GUI difftool: \
`$ git pr show -t 251`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/shenandoah/pull/251.diff">https://git.openjdk.org/shenandoah/pull/251.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/shenandoah/pull/251#issuecomment-1503235939)