### PR TITLE
Restore event descriptions immortality

### DIFF
--- a/src/hotspot/share/gc/shenandoah/shenandoahConcurrentGC.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahConcurrentGC.cpp
@@ -295,8 +295,7 @@ void ShenandoahConcurrentGC::vmop_entry_final_roots(bool increment_region_ages) 
 }
 
 void ShenandoahConcurrentGC::entry_init_mark() {
-  char msg[1024];
-  init_mark_event_message(msg, sizeof(msg));
+  const char* msg = init_mark_event_message();
   ShenandoahPausePhase gc_phase(msg, ShenandoahPhaseTimings::init_mark);
   EventMark em("%s", msg);
 
@@ -308,8 +307,7 @@ void ShenandoahConcurrentGC::entry_init_mark() {
 }
 
 void ShenandoahConcurrentGC::entry_final_mark() {
-  char msg[1024];
-  final_mark_event_message(msg, sizeof(msg));
+  const char* msg = final_mark_event_message();
   ShenandoahPausePhase gc_phase(msg, ShenandoahPhaseTimings::final_mark);
   EventMark em("%s", msg);
 
@@ -397,10 +395,9 @@ void ShenandoahConcurrentGC::entry_mark_roots() {
 }
 
 void ShenandoahConcurrentGC::entry_mark() {
-  char msg[1024];
   ShenandoahHeap* const heap = ShenandoahHeap::heap();
   TraceCollectorStats tcs(heap->monitoring_support()->concurrent_collection_counters());
-  conc_mark_event_message(msg, sizeof(msg));
+  const char* msg = conc_mark_event_message();
   ShenandoahConcurrentPhase gc_phase(msg, ShenandoahPhaseTimings::conc_mark);
   EventMark em("%s", msg);
 
@@ -1226,34 +1223,35 @@ bool ShenandoahConcurrentGC::check_cancellation_and_abort(ShenandoahDegenPoint p
   return false;
 }
 
-void ShenandoahConcurrentGC::init_mark_event_message(char* buf, size_t len) const {
+const char* ShenandoahConcurrentGC::init_mark_event_message() const {
   ShenandoahHeap* const heap = ShenandoahHeap::heap();
   assert(!heap->has_forwarded_objects(), "Should not have forwarded objects here");
   if (heap->unload_classes()) {
-    jio_snprintf(buf, len, "Pause Init Mark (%s) (unload classes)", _generation->name());
+    SHENANDOAH_RETURN_EVENT_MESSAGE(_generation->type(), "Pause Init Mark", "(unload classes)");
   } else {
-    jio_snprintf(buf, len, "Pause Init Mark (%s)", _generation->name());
+    SHENANDOAH_RETURN_EVENT_MESSAGE(_generation->type(), "Pause Init Mark", "");
   }
 }
 
-void ShenandoahConcurrentGC::final_mark_event_message(char* buf, size_t len) const {
+const char* ShenandoahConcurrentGC::final_mark_event_message() const {
   ShenandoahHeap* const heap = ShenandoahHeap::heap();
   assert(!heap->has_forwarded_objects() || heap->is_concurrent_old_mark_in_progress(),
          "Should not have forwarded objects during final mark, unless old gen concurrent mark is running");
+
   if (heap->unload_classes()) {
-    jio_snprintf(buf, len, "Pause Final Mark (%s) (unload classes)", _generation->name());
+    SHENANDOAH_RETURN_EVENT_MESSAGE(_generation->type(), "Pause Final Mark", "(unload classes)");
   } else {
-    jio_snprintf(buf, len, "Pause Final Mark (%s)", _generation->name());
+    SHENANDOAH_RETURN_EVENT_MESSAGE(_generation->type(), "Pause Final Mark", "");
   }
 }
 
-void ShenandoahConcurrentGC::conc_mark_event_message(char* buf, size_t len) const {
+const char* ShenandoahConcurrentGC::conc_mark_event_message() const {
   ShenandoahHeap* const heap = ShenandoahHeap::heap();
   assert(!heap->has_forwarded_objects() || heap->is_concurrent_old_mark_in_progress(),
          "Should not have forwarded objects concurrent mark, unless old gen concurrent mark is running");
   if (heap->unload_classes()) {
-    jio_snprintf(buf, len, "Concurrent marking (%s) (unload classes)", _generation->name());
+    SHENANDOAH_RETURN_EVENT_MESSAGE(_generation->type(), "Concurrent marking", "(unload classes)");
   } else {
-    jio_snprintf(buf, len, "Concurrent marking (%s)", _generation->name());
+    SHENANDOAH_RETURN_EVENT_MESSAGE(_generation->type(), "Concurrent marking", "");
   }
 }

--- a/src/hotspot/share/gc/shenandoah/shenandoahConcurrentGC.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahConcurrentGC.cpp
@@ -1227,9 +1227,9 @@ const char* ShenandoahConcurrentGC::init_mark_event_message() const {
   ShenandoahHeap* const heap = ShenandoahHeap::heap();
   assert(!heap->has_forwarded_objects(), "Should not have forwarded objects here");
   if (heap->unload_classes()) {
-    SHENANDOAH_RETURN_EVENT_MESSAGE(_generation->type(), "Pause Init Mark", " (unload classes)");
+    SHENANDOAH_RETURN_EVENT_MESSAGE(heap, _generation->type(), "Pause Init Mark", " (unload classes)");
   } else {
-    SHENANDOAH_RETURN_EVENT_MESSAGE(_generation->type(), "Pause Init Mark", "");
+    SHENANDOAH_RETURN_EVENT_MESSAGE(heap, _generation->type(), "Pause Init Mark", "");
   }
 }
 
@@ -1239,9 +1239,9 @@ const char* ShenandoahConcurrentGC::final_mark_event_message() const {
          "Should not have forwarded objects during final mark, unless old gen concurrent mark is running");
 
   if (heap->unload_classes()) {
-    SHENANDOAH_RETURN_EVENT_MESSAGE(_generation->type(), "Pause Final Mark", " (unload classes)");
+    SHENANDOAH_RETURN_EVENT_MESSAGE(heap, _generation->type(), "Pause Final Mark", " (unload classes)");
   } else {
-    SHENANDOAH_RETURN_EVENT_MESSAGE(_generation->type(), "Pause Final Mark", "");
+    SHENANDOAH_RETURN_EVENT_MESSAGE(heap, _generation->type(), "Pause Final Mark", "");
   }
 }
 
@@ -1250,8 +1250,8 @@ const char* ShenandoahConcurrentGC::conc_mark_event_message() const {
   assert(!heap->has_forwarded_objects() || heap->is_concurrent_old_mark_in_progress(),
          "Should not have forwarded objects concurrent mark, unless old gen concurrent mark is running");
   if (heap->unload_classes()) {
-    SHENANDOAH_RETURN_EVENT_MESSAGE(_generation->type(), "Concurrent marking", " (unload classes)");
+    SHENANDOAH_RETURN_EVENT_MESSAGE(heap, _generation->type(), "Concurrent marking", " (unload classes)");
   } else {
-    SHENANDOAH_RETURN_EVENT_MESSAGE(_generation->type(), "Concurrent marking", "");
+    SHENANDOAH_RETURN_EVENT_MESSAGE(heap, _generation->type(), "Concurrent marking", "");
   }
 }

--- a/src/hotspot/share/gc/shenandoah/shenandoahConcurrentGC.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahConcurrentGC.cpp
@@ -1227,7 +1227,7 @@ const char* ShenandoahConcurrentGC::init_mark_event_message() const {
   ShenandoahHeap* const heap = ShenandoahHeap::heap();
   assert(!heap->has_forwarded_objects(), "Should not have forwarded objects here");
   if (heap->unload_classes()) {
-    SHENANDOAH_RETURN_EVENT_MESSAGE(_generation->type(), "Pause Init Mark", "(unload classes)");
+    SHENANDOAH_RETURN_EVENT_MESSAGE(_generation->type(), "Pause Init Mark", " (unload classes)");
   } else {
     SHENANDOAH_RETURN_EVENT_MESSAGE(_generation->type(), "Pause Init Mark", "");
   }
@@ -1239,7 +1239,7 @@ const char* ShenandoahConcurrentGC::final_mark_event_message() const {
          "Should not have forwarded objects during final mark, unless old gen concurrent mark is running");
 
   if (heap->unload_classes()) {
-    SHENANDOAH_RETURN_EVENT_MESSAGE(_generation->type(), "Pause Final Mark", "(unload classes)");
+    SHENANDOAH_RETURN_EVENT_MESSAGE(_generation->type(), "Pause Final Mark", " (unload classes)");
   } else {
     SHENANDOAH_RETURN_EVENT_MESSAGE(_generation->type(), "Pause Final Mark", "");
   }
@@ -1250,7 +1250,7 @@ const char* ShenandoahConcurrentGC::conc_mark_event_message() const {
   assert(!heap->has_forwarded_objects() || heap->is_concurrent_old_mark_in_progress(),
          "Should not have forwarded objects concurrent mark, unless old gen concurrent mark is running");
   if (heap->unload_classes()) {
-    SHENANDOAH_RETURN_EVENT_MESSAGE(_generation->type(), "Concurrent marking", "(unload classes)");
+    SHENANDOAH_RETURN_EVENT_MESSAGE(_generation->type(), "Concurrent marking", " (unload classes)");
   } else {
     SHENANDOAH_RETURN_EVENT_MESSAGE(_generation->type(), "Concurrent marking", "");
   }

--- a/src/hotspot/share/gc/shenandoah/shenandoahConcurrentGC.hpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahConcurrentGC.hpp
@@ -130,10 +130,11 @@ protected:
 private:
   void start_mark();
 
-  // Messages for GC trace events
-  void init_mark_event_message(char* buf, size_t len) const;
-  void final_mark_event_message(char* buf, size_t len) const;
-  void conc_mark_event_message(char* buf, size_t len) const;
+  // Messages for GC trace events, they have to be immortal for
+  // passing around the logging/tracing systems
+  const char* init_mark_event_message() const;
+  const char* final_mark_event_message() const;
+  const char* conc_mark_event_message() const;
 
 protected:
   // Check GC cancellation and abort concurrent GC

--- a/src/hotspot/share/gc/shenandoah/shenandoahDegeneratedGC.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahDegeneratedGC.cpp
@@ -70,8 +70,7 @@ void ShenandoahDegenGC::vmop_degenerated() {
 }
 
 void ShenandoahDegenGC::entry_degenerated() {
-  char msg[1024];
-  degen_event_message(_degen_point, msg, sizeof(msg));
+  const char* msg = degen_event_message(_degen_point);
   ShenandoahPausePhase gc_phase(msg, ShenandoahPhaseTimings::degen_gc, true /* log_heap_usage */);
   EventMark em("%s", msg);
   ShenandoahHeap* const heap = ShenandoahHeap::heap();
@@ -442,8 +441,24 @@ void ShenandoahDegenGC::op_degenerated_futile() {
   full_gc.op_full(GCCause::_shenandoah_upgrade_to_full_gc);
 }
 
-void ShenandoahDegenGC::degen_event_message(ShenandoahDegenPoint point, char* buf, size_t len) const {
-  jio_snprintf(buf, len, "Pause Degenerated %s GC (%s)", _generation->name(), ShenandoahGC::degen_point_to_string(point));
+const char* ShenandoahDegenGC::degen_event_message(ShenandoahDegenPoint point) const {
+  switch (point) {
+    case _degenerated_unset:
+      SHENANDOAH_RETURN_EVENT_MESSAGE(_generation->type(), "Pause Degenerated GC", " (<UNSET>)");
+    case _degenerated_outside_cycle:
+      SHENANDOAH_RETURN_EVENT_MESSAGE(_generation->type(), "Pause Degenerated GC", " (Outside of Cycle)");
+    case _degenerated_roots:
+      SHENANDOAH_RETURN_EVENT_MESSAGE(_generation->type(), "Pause Degenerated GC", " (Roots)");
+    case _degenerated_mark:
+      SHENANDOAH_RETURN_EVENT_MESSAGE(_generation->type(), "Pause Degenerated GC", " (Mark)");
+    case _degenerated_evac:
+      SHENANDOAH_RETURN_EVENT_MESSAGE(_generation->type(), "Pause Degenerated GC", " (Evacuation)");
+    case _degenerated_updaterefs:
+      SHENANDOAH_RETURN_EVENT_MESSAGE(_generation->type(), "Pause Degenerated GC", " (Update Refs)");
+    default:
+      ShouldNotReachHere();
+      SHENANDOAH_RETURN_EVENT_MESSAGE(_generation->type(), "Pause Degenerated GC", " (?)");
+  }
 }
 
 void ShenandoahDegenGC::upgrade_to_full() {

--- a/src/hotspot/share/gc/shenandoah/shenandoahDegeneratedGC.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahDegeneratedGC.cpp
@@ -442,22 +442,23 @@ void ShenandoahDegenGC::op_degenerated_futile() {
 }
 
 const char* ShenandoahDegenGC::degen_event_message(ShenandoahDegenPoint point) const {
+  const ShenandoahHeap* heap = ShenandoahHeap::heap();
   switch (point) {
     case _degenerated_unset:
-      SHENANDOAH_RETURN_EVENT_MESSAGE(_generation->type(), "Pause Degenerated GC", " (<UNSET>)");
+      SHENANDOAH_RETURN_EVENT_MESSAGE(heap, _generation->type(), "Pause Degenerated GC", " (<UNSET>)");
     case _degenerated_outside_cycle:
-      SHENANDOAH_RETURN_EVENT_MESSAGE(_generation->type(), "Pause Degenerated GC", " (Outside of Cycle)");
+      SHENANDOAH_RETURN_EVENT_MESSAGE(heap, _generation->type(), "Pause Degenerated GC", " (Outside of Cycle)");
     case _degenerated_roots:
-      SHENANDOAH_RETURN_EVENT_MESSAGE(_generation->type(), "Pause Degenerated GC", " (Roots)");
+      SHENANDOAH_RETURN_EVENT_MESSAGE(heap, _generation->type(), "Pause Degenerated GC", " (Roots)");
     case _degenerated_mark:
-      SHENANDOAH_RETURN_EVENT_MESSAGE(_generation->type(), "Pause Degenerated GC", " (Mark)");
+      SHENANDOAH_RETURN_EVENT_MESSAGE(heap, _generation->type(), "Pause Degenerated GC", " (Mark)");
     case _degenerated_evac:
-      SHENANDOAH_RETURN_EVENT_MESSAGE(_generation->type(), "Pause Degenerated GC", " (Evacuation)");
+      SHENANDOAH_RETURN_EVENT_MESSAGE(heap, _generation->type(), "Pause Degenerated GC", " (Evacuation)");
     case _degenerated_updaterefs:
-      SHENANDOAH_RETURN_EVENT_MESSAGE(_generation->type(), "Pause Degenerated GC", " (Update Refs)");
+      SHENANDOAH_RETURN_EVENT_MESSAGE(heap, _generation->type(), "Pause Degenerated GC", " (Update Refs)");
     default:
       ShouldNotReachHere();
-      SHENANDOAH_RETURN_EVENT_MESSAGE(_generation->type(), "Pause Degenerated GC", " (?)");
+      SHENANDOAH_RETURN_EVENT_MESSAGE(heap, _generation->type(), "Pause Degenerated GC", " (?)");
   }
 }
 

--- a/src/hotspot/share/gc/shenandoah/shenandoahDegeneratedGC.hpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahDegeneratedGC.hpp
@@ -64,8 +64,9 @@ private:
   void op_degenerated_futile();
   void op_degenerated_fail();
 
-  void degen_event_message(ShenandoahDegenPoint point, char* buf, size_t len) const;
   void upgrade_to_full();
+
+  const char* degen_event_message(ShenandoahDegenPoint point) const;
 };
 
 #endif // SHARE_GC_SHENANDOAH_SHENANDOAHDEGENERATEDGC_HPP

--- a/src/hotspot/share/gc/shenandoah/shenandoahUtils.hpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahUtils.hpp
@@ -44,18 +44,21 @@
 class GCTimer;
 class ShenandoahGeneration;
 
-#define SHENANDOAH_RETURN_EVENT_MESSAGE(generation_type, prefix, postfix) \
-  switch (generation_type) {                                              \
-    case GLOBAL:                                                          \
-      return prefix " (GLOBAL)" postfix;                                  \
-    case YOUNG:                                                           \
-      return prefix " (YOUNG)" postfix;                                   \
-    case OLD:                                                             \
-      return prefix " (OLD)" postfix;                                     \
-    default:                                                              \
-      ShouldNotReachHere();                                               \
-      return prefix " (?)" postfix;                                       \
-  }                                                                       \
+#define SHENANDOAH_RETURN_EVENT_MESSAGE(heap, generation_type, prefix, postfix) \
+  if (!heap->mode()->is_generational()) {                                       \
+    return prefix "" postfix;                                                   \
+  }                                                                             \
+  switch (generation_type) {                                                    \
+    case GLOBAL:                                                                \
+      return prefix " (GLOBAL)" postfix;                                        \
+    case YOUNG:                                                                 \
+      return prefix " (YOUNG)" postfix;                                         \
+    case OLD:                                                                   \
+      return prefix " (OLD)" postfix;                                           \
+    default:                                                                    \
+      ShouldNotReachHere();                                                     \
+      return prefix " (?)" postfix;                                             \
+  }                                                                             \
 
 class ShenandoahGCSession : public StackObj {
 private:

--- a/src/hotspot/share/gc/shenandoah/shenandoahUtils.hpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahUtils.hpp
@@ -47,7 +47,7 @@ class ShenandoahGeneration;
 #define SHENANDOAH_RETURN_EVENT_MESSAGE(generation_type, prefix, postfix) \
   switch (generation_type) {                                              \
     case GLOBAL:                                                          \
-      return prefix " " postfix;                                          \
+      return prefix "" postfix;                                           \
     case YOUNG:                                                           \
       return prefix " (YOUNG)" postfix;                                   \
     case OLD:                                                             \

--- a/src/hotspot/share/gc/shenandoah/shenandoahUtils.hpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahUtils.hpp
@@ -44,6 +44,19 @@
 class GCTimer;
 class ShenandoahGeneration;
 
+#define SHENANDOAH_RETURN_EVENT_MESSAGE(generation_type, prefix, postfix) \
+  switch (generation_type) {                                              \
+    case GLOBAL:                                                          \
+      return prefix " " postfix;                                          \
+    case YOUNG:                                                           \
+      return prefix " (YOUNG)" postfix;                                   \
+    case OLD:                                                             \
+      return prefix " (OLD)" postfix;                                     \
+    default:                                                              \
+      ShouldNotReachHere();                                               \
+      return prefix " (?)" postfix;                                       \
+  }                                                                       \
+
 class ShenandoahGCSession : public StackObj {
 private:
   ShenandoahHeap* const _heap;

--- a/src/hotspot/share/gc/shenandoah/shenandoahUtils.hpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahUtils.hpp
@@ -47,7 +47,7 @@ class ShenandoahGeneration;
 #define SHENANDOAH_RETURN_EVENT_MESSAGE(generation_type, prefix, postfix) \
   switch (generation_type) {                                              \
     case GLOBAL:                                                          \
-      return prefix "" postfix;                                           \
+      return prefix " (GLOBAL)" postfix;                                  \
     case YOUNG:                                                           \
       return prefix " (YOUNG)" postfix;                                   \
     case OLD:                                                             \


### PR DESCRIPTION
Upstream code has event descriptions as immortal strings for a reason: they are passed inside the logging classes, and so the references to them may outlive the scope of the current method. We have seen logs corruption because of that before, e.g. in hs_err-s `Events` section. This PR restores the immortality of event descriptions, producing const strings with macros.

This also stops emitting "(GLOBAL)" for global collections, which I think is what non-generational Shenandoah mode prints. Please tell me if we still need to print "(GLOBAL)" in generational mode.

Tangentially, this also improves performance for compilers that choose to initialize the automatic storage for `char msg[1024]`, see https://isocpp.org/files/papers/P2723R0.html.

Additional testing:
 - [x] Eyeballing the GC logs

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed (1 review required, with at least 1 [Committer](https://openjdk.org/bylaws#committer))

### Reviewers
 * [Kelvin Nilsen](https://openjdk.org/census#kdnilsen) (@kdnilsen - Committer) ⚠️ Review applies to [a550586e](https://git.openjdk.org/shenandoah/pull/253/files/a550586e06296608fedd11e9bbda0ab61fe5aaeb)
 * [Y. Srinivas Ramakrishna](https://openjdk.org/census#ysr) (@ysramakrishna - Author)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/shenandoah.git pull/253/head:pull/253` \
`$ git checkout pull/253`

Update a local copy of the PR: \
`$ git checkout pull/253` \
`$ git pull https://git.openjdk.org/shenandoah.git pull/253/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 253`

View PR using the GUI difftool: \
`$ git pr show -t 253`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/shenandoah/pull/253.diff">https://git.openjdk.org/shenandoah/pull/253.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/shenandoah/pull/253#issuecomment-1505048182)