### PR TITLE
Disable failing tests while fixes are in progress

### DIFF
--- a/test/hotspot/jtreg/ProblemList.txt
+++ b/test/hotspot/jtreg/ProblemList.txt
@@ -85,7 +85,11 @@ gc/stress/TestStressG1Humongous.java 8286554 windows-x64
 
 gc/shenandoah/TestDynamicSoftMaxHeapSize.java#generational 8306024 generic-all
 gc/shenandoah/oom/TestThreadFailure.java 8306024 generic-all
+gc/shenandoah/oom/TestClassLoaderLeak 8306024 generic-all
+gc/shenandoah/mxbeans/TestChurnNotifications#generational 8306024 generic-all
 gc/stress/gcold/TestGCOldWithShenandoah.java#generational 8306024 generic-all
+gc/TestAllocHumongousFragment#generational 8306024 generic-all
+java/lang/Thread/virtual/TraceVirtualThreadLocals 8306024 generic-all
 
 #############################################################################
 

--- a/test/hotspot/jtreg/ProblemList.txt
+++ b/test/hotspot/jtreg/ProblemList.txt
@@ -84,6 +84,7 @@ gc/stress/TestJNIBlockFullGC/TestJNIBlockFullGC.java 8192647 generic-all
 gc/stress/TestStressG1Humongous.java 8286554 windows-x64
 
 gc/shenandoah/TestDynamicSoftMaxHeapSize.java#generational 8306024 generic-all
+gc/shenandoah/TestArrayCopyStress.java#generational 8306024 generic-all
 gc/shenandoah/oom/TestThreadFailure.java 8306024 generic-all
 gc/shenandoah/oom/TestClassLoaderLeak 8306024 generic-all
 gc/shenandoah/mxbeans/TestChurnNotifications#generational 8306024 generic-all

--- a/test/hotspot/jtreg/ProblemList.txt
+++ b/test/hotspot/jtreg/ProblemList.txt
@@ -88,6 +88,8 @@ gc/shenandoah/oom/TestThreadFailure.java 8306024 generic-all
 gc/shenandoah/oom/TestClassLoaderLeak 8306024 generic-all
 gc/shenandoah/mxbeans/TestChurnNotifications#generational 8306024 generic-all
 gc/stress/gcold/TestGCOldWithShenandoah.java#generational 8306024 generic-all
+gc/stress/systemgc/TestSystemGCWithShenandoah.java#generational 8306024 generic-all
+gc/stress/gclocker/TestGCLockerWithShenandoah.java#generational 8306024 generic-all
 gc/TestAllocHumongousFragment#generational 8306024 generic-all
 java/lang/Thread/virtual/TraceVirtualThreadLocals 8306024 generic-all
 

--- a/test/hotspot/jtreg/ProblemList.txt
+++ b/test/hotspot/jtreg/ProblemList.txt
@@ -83,6 +83,10 @@ gc/stress/gclocker/TestGCLockerWithG1.java 8180622 generic-all
 gc/stress/TestJNIBlockFullGC/TestJNIBlockFullGC.java 8192647 generic-all
 gc/stress/TestStressG1Humongous.java 8286554 windows-x64
 
+gc/shenandoah/TestDynamicSoftMaxHeapSize.java#generational 8306024 generic-all
+gc/shenandoah/oom/TestThreadFailure.java 8306024 generic-all
+gc/stress/gcold/TestGCOldWithShenandoah.java#generational 8306024 generic-all
+
 #############################################################################
 
 # :hotspot_runtime


### PR DESCRIPTION
These tests related to the `borrow-from-old` and `generation-resizing-v1` features are being disabled while improvements are made.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed (1 review required, with at least 1 [Committer](https://openjdk.org/bylaws#committer))

### Reviewers
 * [Y. Srinivas Ramakrishna](https://openjdk.org/census#ysr) (@ysramakrishna - Author) ⚠️ Review applies to [e003c2b8](https://git.openjdk.org/shenandoah/pull/259/files/e003c2b8a1c22600695b61c2b34465a1fef9b067)
 * [Aleksey Shipilev](https://openjdk.org/census#shade) (@shipilev - Committer) ⚠️ Review applies to [e003c2b8](https://git.openjdk.org/shenandoah/pull/259/files/e003c2b8a1c22600695b61c2b34465a1fef9b067)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/shenandoah.git pull/259/head:pull/259` \
`$ git checkout pull/259`

Update a local copy of the PR: \
`$ git checkout pull/259` \
`$ git pull https://git.openjdk.org/shenandoah.git pull/259/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 259`

View PR using the GUI difftool: \
`$ git pr show -t 259`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/shenandoah/pull/259.diff">https://git.openjdk.org/shenandoah/pull/259.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/shenandoah/pull/259#issuecomment-1509349697)