### PR TITLE
Use state of mark context itself to track stability of old mark bitmap

### DIFF
--- a/src/hotspot/share/gc/shenandoah/shenandoahHeap.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahHeap.cpp
@@ -688,9 +688,7 @@ bool ShenandoahHeap::doing_mixed_evacuations() {
 }
 
 bool ShenandoahHeap::is_old_bitmap_stable() const {
-  ShenandoahOldGeneration::State state = _old_generation->state();
-  return state != ShenandoahOldGeneration::MARKING
-      && state != ShenandoahOldGeneration::BOOTSTRAPPING;
+  return _old_generation->is_mark_complete();
 }
 
 bool ShenandoahHeap::is_gc_generation_young() const {


### PR DESCRIPTION
Rely on the state of the bitmap itself, rather than the state of the GC for knowing when it is safe to use the old generation bitmap.