### PR TITLE
Remove redundant initialization code

### DIFF
--- a/src/hotspot/share/gc/shenandoah/shenandoahFreeSet.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahFreeSet.cpp
@@ -566,18 +566,7 @@ HeapWord* ShenandoahFreeSet::allocate_contiguous(ShenandoahAllocRequest& req) {
 
     r->set_affiliation(req.affiliation());
     r->set_update_watermark(r->bottom());
-    r->set_top(r->bottom());    // Set top to bottom so we can capture TAMS
-    ctx->capture_top_at_mark_start(r);
-    r->set_top(r->bottom() + used_words); // Then change top to reflect allocation of humongous object.
-    assert(ctx->top_at_mark_start(r) == r->bottom(), "Newly established allocation region starts with TAMS equal to bottom");
-    assert(ctx->is_bitmap_clear_range(ctx->top_bitmap(r), r->end()), "Bitmap above top_bitmap() must be clear");
-
-    // Leave top_bitmap alone.  The first time a heap region is put into service, top_bitmap should equal end.
-    // Thereafter, it should represent the upper bound on parts of the bitmap that need to be cleared.
-    // ctx->clear_bitmap(r);
-    log_debug(gc, free)("NOT clearing bitmap for Humongous region [" PTR_FORMAT ", " PTR_FORMAT "], top_bitmap: "
-                        PTR_FORMAT " at transition from FREE to %s",
-                        p2i(r->bottom()), p2i(r->end()), p2i(ctx->top_bitmap(r)), req.affiliation_name());
+    r->set_top(r->bottom() + used_words);
 
     // While individual regions report their true use, all humongous regions are marked used in the free set.
     _mutator_free_bitmap.clear_bit(r->index());


### PR DESCRIPTION
This code and the assertions that acompany it are subject to races with certain GC worker threads which are also capturing top_at_mark_start() and may capture it at a different position than this thread does.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed (1 review required, with at least 1 [Committer](https://openjdk.org/bylaws#committer))

### Reviewers
 * [Aleksey Shipilev](https://openjdk.org/census#shade) (@shipilev - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/shenandoah.git pull/267/head:pull/267` \
`$ git checkout pull/267`

Update a local copy of the PR: \
`$ git checkout pull/267` \
`$ git pull https://git.openjdk.org/shenandoah.git pull/267/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 267`

View PR using the GUI difftool: \
`$ git pr show -t 267`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/shenandoah/pull/267.diff">https://git.openjdk.org/shenandoah/pull/267.diff</a>

</details>
