### PR TITLE
Cleanup NumberSeq additions

### DIFF
--- a/src/hotspot/share/gc/shenandoah/shenandoahNumberSeq.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahNumberSeq.cpp
@@ -149,8 +149,10 @@ void HdrSeq::add(HdrSeq& other) {
 void HdrSeq::clear() {
   for (int mag = 0; mag < MagBuckets; mag++) {
     int* bucket = _hdr[mag];
-    for (int c = 0; c < ValBuckets; c++) {
-      bucket[c] = 0;
+    if (bucket != nullptr) {
+      for (int c = 0; c < ValBuckets; c++) {
+        bucket[c] = 0;
+      }
     }
   }
 }

--- a/src/hotspot/share/gc/shenandoah/shenandoahNumberSeq.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahNumberSeq.cpp
@@ -121,7 +121,7 @@ double HdrSeq::percentile(double level) const {
   return maximum();
 }
 
-void HdrSeq::add(HdrSeq& other) {
+void HdrSeq::add(const HdrSeq& other) {
   if (other.num() == 0) {
     // Other sequence is empty, return
     return;

--- a/src/hotspot/share/gc/shenandoah/shenandoahNumberSeq.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahNumberSeq.cpp
@@ -165,6 +165,7 @@ void HdrSeq::add(HdrSeq& other) {
 }
 
 void HdrSeq::clear() {
+  // Clear the storage
   for (int mag = 0; mag < MagBuckets; mag++) {
     int* bucket = _hdr[mag];
     if (bucket != nullptr) {
@@ -173,6 +174,15 @@ void HdrSeq::clear() {
       }
     }
   }
+
+  // Clear other fields too
+  _last = 0;
+  _maximum = 0;
+  _sum = 0;
+  _sum_of_squares = 0;
+  _num = 0;
+  _davg = 0;
+  _dvariance = 0;
 }
 
 BinaryMagnitudeSeq::BinaryMagnitudeSeq() {

--- a/src/hotspot/share/gc/shenandoah/shenandoahNumberSeq.hpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahNumberSeq.hpp
@@ -50,10 +50,9 @@ public:
   ~HdrSeq();
 
   virtual void add(double val);
+  void add(HdrSeq& other);
   double percentile(double level) const;
-
-  // Merge this HdrSeq into hdr2, optionally clearing this HdrSeq
-  void merge(HdrSeq& hdr2, bool clear_this = true);
+  void clear();
 };
 
 // Binary magnitude sequence stores the power-of-two histogram.

--- a/src/hotspot/share/gc/shenandoah/shenandoahNumberSeq.hpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahNumberSeq.hpp
@@ -50,7 +50,7 @@ public:
   ~HdrSeq();
 
   virtual void add(double val);
-  void add(HdrSeq& other);
+  void add(const HdrSeq& other);
   double percentile(double level) const;
   void clear();
 };

--- a/src/hotspot/share/gc/shenandoah/shenandoahScanRemembered.hpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahScanRemembered.hpp
@@ -927,14 +927,14 @@ public:
   // Log stats related to card/RS stats for given phase t
   void log_card_stats(uint nworkers, CardStatLogType t) PRODUCT_RETURN;
 private:
-  // Log stats for given worker id related into given cumulative card/RS stats
-  void log_worker_card_stats(uint worker_id, HdrSeq* cum_stats) PRODUCT_RETURN;
+  // Log stats for given worker id related into given summary card/RS stats
+  void log_worker_card_stats(uint worker_id, HdrSeq* sum_stats) PRODUCT_RETURN;
 
   // Log given stats
   inline void log_card_stats(HdrSeq* stats) PRODUCT_RETURN;
 
   // Merge the stats from worked_id into the given summary stats, and clear the worker_id's stats.
-  void merge_worker_card_stats_cumulative(HdrSeq* worker_stats, HdrSeq* cum_stats) PRODUCT_RETURN;
+  void merge_worker_card_stats_cumulative(HdrSeq* worker_stats, HdrSeq* sum_stats) PRODUCT_RETURN;
 };
 
 

--- a/src/hotspot/share/gc/shenandoah/shenandoahScanRemembered.inline.hpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahScanRemembered.inline.hpp
@@ -966,7 +966,8 @@ template<typename RememberedSet>
 void ShenandoahScanRemembered<RememberedSet>::merge_worker_card_stats_cumulative(
   HdrSeq* worker_stats, HdrSeq* cum_stats) {
   for (int i = 0; i < MAX_CARD_STAT_TYPE; i++) {
-    worker_stats[i].merge(cum_stats[i]);
+    cum_stats[i].add(worker_stats[i]);
+    worker_stats[i].clear();
   }
 }
 #endif

--- a/src/hotspot/share/gc/shenandoah/shenandoahScanRemembered.inline.hpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahScanRemembered.inline.hpp
@@ -936,37 +936,37 @@ inline void ShenandoahScanRemembered<RememberedSet>::log_card_stats(HdrSeq* stat
 template<typename RememberedSet>
 void ShenandoahScanRemembered<RememberedSet>::log_card_stats(uint nworkers, CardStatLogType t) {
   assert(ShenandoahEnableCardStats, "Do not call");
-  HdrSeq* cum_stats = card_stats_for_phase(t);
+  HdrSeq* sum_stats = card_stats_for_phase(t);
   log_info(gc, remset)("%s", _card_stat_log_type[t]);
   for (uint i = 0; i < nworkers; i++) {
-    log_worker_card_stats(i, cum_stats);
+    log_worker_card_stats(i, sum_stats);
   }
 
   // Every so often, log the cumulative global stats
   if (++_card_stats_log_counter[t] >= ShenandoahCardStatsLogInterval) {
     _card_stats_log_counter[t] = 0;
     log_info(gc, remset)("Cumulative stats");
-    log_card_stats(cum_stats);
+    log_card_stats(sum_stats);
   }
 }
 
 // Log card stats for given worker_id, & clear them after merging into given cumulative stats
 template<typename RememberedSet>
-void ShenandoahScanRemembered<RememberedSet>::log_worker_card_stats(uint worker_id, HdrSeq* cum_stats) {
+void ShenandoahScanRemembered<RememberedSet>::log_worker_card_stats(uint worker_id, HdrSeq* sum_stats) {
   assert(ShenandoahEnableCardStats, "Do not call");
 
   HdrSeq* worker_card_stats = card_stats(worker_id);
   log_info(gc, remset)("Worker %u Card Stats: ", worker_id);
   log_card_stats(worker_card_stats);
   // Merge worker stats into the cumulative stats & clear worker stats
-  merge_worker_card_stats_cumulative(worker_card_stats, cum_stats);
+  merge_worker_card_stats_cumulative(worker_card_stats, sum_stats);
 }
 
 template<typename RememberedSet>
 void ShenandoahScanRemembered<RememberedSet>::merge_worker_card_stats_cumulative(
-  HdrSeq* worker_stats, HdrSeq* cum_stats) {
+  HdrSeq* worker_stats, HdrSeq* sum_stats) {
   for (int i = 0; i < MAX_CARD_STAT_TYPE; i++) {
-    cum_stats[i].add(worker_stats[i]);
+    sum_stats[i].add(worker_stats[i]);
     worker_stats[i].clear();
   }
 }

--- a/src/hotspot/share/utilities/numberSeq.cpp
+++ b/src/hotspot/share/utilities/numberSeq.cpp
@@ -54,14 +54,6 @@ void AbsSeq::add(double val) {
   }
 }
 
-void AbsSeq::add(AbsSeq& other) {
-  // Until JDK-8298902 is fixed, we taint the decaying statistics
-  if (other._davg != NAN) {
-    _davg = NAN;
-    _dvariance = NAN;
-  }
-}
-
 double AbsSeq::avg() const {
   if (_num == 0)
     return 0.0;
@@ -143,21 +135,6 @@ void NumberSeq::add(double val) {
   _sum += val;
   _sum_of_squares += val * val;
   ++_num;
-}
-
-void NumberSeq::add(NumberSeq& other) {
-  if (other.num() == 0) {
-    // Other sequence is empty, nothing to do
-    return;
-  }
-
-  _last = other._last;
-  _maximum = MAX2(_maximum, other._maximum);
-  _sum += other._sum;
-  _sum_of_squares += other._sum_of_squares;
-  _num += other._num;
-
-  AbsSeq::add(other);
 }
 
 

--- a/src/hotspot/share/utilities/numberSeq.cpp
+++ b/src/hotspot/share/utilities/numberSeq.cpp
@@ -55,8 +55,9 @@ void AbsSeq::add(double val) {
 }
 
 void AbsSeq::add(AbsSeq& other) {
+  // TODO: Prove these actually work...
   _davg = pow(_alpha, _num) * _davg + other._davg;
-  // Hm... :(
+  _dvariance = sqrt(_dvariance*_dvariance + other._dvariance*other._dvariance);
 }
 
 double AbsSeq::avg() const {

--- a/src/hotspot/share/utilities/numberSeq.cpp
+++ b/src/hotspot/share/utilities/numberSeq.cpp
@@ -55,9 +55,11 @@ void AbsSeq::add(double val) {
 }
 
 void AbsSeq::add(AbsSeq& other) {
-  // TODO: Prove these actually work...
-  _davg = pow(_alpha, _num) * _davg + other._davg;
-  _dvariance = sqrt(_dvariance*_dvariance + other._dvariance*other._dvariance);
+  // Until JDK-8298902 is fixed, we taint the decaying statistics
+  if (other._davg != NAN) {
+    _davg = NAN;
+    _dvariance = NAN;
+  }
 }
 
 double AbsSeq::avg() const {

--- a/src/hotspot/share/utilities/numberSeq.cpp
+++ b/src/hotspot/share/utilities/numberSeq.cpp
@@ -54,6 +54,11 @@ void AbsSeq::add(double val) {
   }
 }
 
+void AbsSeq::add(AbsSeq& other) {
+  _davg = pow(_alpha, _num) * _davg + other._davg;
+  // Hm... :(
+}
+
 double AbsSeq::avg() const {
   if (_num == 0)
     return 0.0;
@@ -110,32 +115,6 @@ double AbsSeq::dsd() const {
   return sqrt(var);
 }
 
-void AbsSeq::merge(AbsSeq& abs2, bool clear_this) {
-
-  if (num() == 0) return;  // nothing to do
-
-  abs2._num += _num;
-  abs2._sum += _sum;
-  abs2._sum_of_squares += _sum_of_squares;
-
-  // Decaying stats need a bit more thought
-  assert(abs2._alpha == _alpha, "Caution: merge incompatible?");
-  // Until JDK-8298902 is fixed, we taint the decaying statistics
-  if (abs2._davg != NAN) {
-    abs2._davg = NAN;
-    abs2._dvariance = NAN;
-  }
-
-  if (clear_this) {
-    _num = 0;
-    _sum = 0;
-    _sum_of_squares = 0;
-    _davg = 0;
-    _dvariance = 0;
-  }
-}
-
-
 NumberSeq::NumberSeq(double alpha) :
   AbsSeq(alpha), _last(0.0), _maximum(0.0) {
 }
@@ -163,20 +142,19 @@ void NumberSeq::add(double val) {
   ++_num;
 }
 
-void NumberSeq::merge(NumberSeq& nseq2, bool clear_this) {
-
-  if (num() == 0) return;  // nothing to do
-
-  nseq2._last = _last;   // this is newer than that
-  nseq2._maximum = MAX2(_maximum, nseq2._maximum);
-
-  AbsSeq::merge(nseq2, clear_this);
-
-  if (clear_this) {
-    _last = 0;
-    _maximum = 0;
-    assert(num() == 0, "Not cleared");
+void NumberSeq::add(NumberSeq& other) {
+  if (other.num() == 0) {
+    // Other sequence is empty, nothing to do
+    return;
   }
+
+  _last = other._last;
+  _maximum = MAX2(_maximum, other._maximum);
+  _sum += other._sum;
+  _sum_of_squares += other._sum_of_squares;
+  _num += other._num;
+
+  AbsSeq::add(other);
 }
 
 

--- a/src/hotspot/share/utilities/numberSeq.hpp
+++ b/src/hotspot/share/utilities/numberSeq.hpp
@@ -64,6 +64,7 @@ public:
 
   virtual void add(double val); // adds a new element to the sequence
   void add(unsigned val) { add((double) val); }
+  void add(AbsSeq& other);
   virtual double maximum() const = 0; // maximum element in the sequence
   virtual double last() const = 0; // last element added in the sequence
 
@@ -83,9 +84,6 @@ public:
   // Debugging/Printing
   virtual void dump();
   virtual void dump_on(outputStream* s);
-
-  // Merge this AbsSeq into seq2, optionally clearing this AbsSeq
-  void merge(AbsSeq& seq2, bool clear_this = true);
 };
 
 class NumberSeq: public AbsSeq {
@@ -100,14 +98,12 @@ public:
   NumberSeq(double alpha = DEFAULT_ALPHA_VALUE);
 
   virtual void add(double val);
+  void add(NumberSeq& other);
   virtual double maximum() const { return _maximum; }
   virtual double last() const { return _last; }
 
   // Debugging/Printing
   virtual void dump_on(outputStream* s);
-
-  // Merge this NumberSeq into seq2, optionally clearing this NumberSeq
-  void merge(NumberSeq& seq2, bool clear_this = true);
 };
 
 class TruncatedSeq: public AbsSeq {
@@ -127,6 +123,7 @@ public:
                double alpha = DEFAULT_ALPHA_VALUE);
   ~TruncatedSeq();
   virtual void add(double val);
+  // TODO: add(TruncatedSeq& other)?
   virtual double maximum() const;
   virtual double last() const; // the last value added to the sequence
 
@@ -135,9 +132,6 @@ public:
 
   // Debugging/Printing
   virtual void dump_on(outputStream* s);
-
-  // Merge this AbsSeq into seq2, optionally clearing this AbsSeq
-  void merge(AbsSeq& seq2, bool clear_this = true);
 };
 
 #endif // SHARE_UTILITIES_NUMBERSEQ_HPP

--- a/src/hotspot/share/utilities/numberSeq.hpp
+++ b/src/hotspot/share/utilities/numberSeq.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2001, 2019, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -64,7 +64,6 @@ public:
 
   virtual void add(double val); // adds a new element to the sequence
   void add(unsigned val) { add((double) val); }
-  void add(AbsSeq& other);
   virtual double maximum() const = 0; // maximum element in the sequence
   virtual double last() const = 0; // last element added in the sequence
 
@@ -98,7 +97,6 @@ public:
   NumberSeq(double alpha = DEFAULT_ALPHA_VALUE);
 
   virtual void add(double val);
-  void add(NumberSeq& other);
   virtual double maximum() const { return _maximum; }
   virtual double last() const { return _last; }
 
@@ -123,7 +121,6 @@ public:
                double alpha = DEFAULT_ALPHA_VALUE);
   ~TruncatedSeq();
   virtual void add(double val);
-  // TODO: add(TruncatedSeq& other)?
   virtual double maximum() const;
   virtual double last() const; // the last value added to the sequence
 

--- a/test/hotspot/gtest/gc/shenandoah/test_shenandoahNumberSeq.cpp
+++ b/test/hotspot/gtest/gc/shenandoah/test_shenandoahNumberSeq.cpp
@@ -118,7 +118,7 @@ TEST_VM_F(ShenandoahNumberSeqMergeTest, merge_test) {
   merged.add(seq1);
   merged.add(seq2);
 
-  EXPECT_EQ(merged.num(),  seq3.num());
+  EXPECT_EQ(merged.num(), seq3.num());
 
   EXPECT_EQ(merged.maximum(), seq3.maximum());
   EXPECT_EQ(merged.percentile(0), seq3.percentile(0));
@@ -127,7 +127,6 @@ TEST_VM_F(ShenandoahNumberSeqMergeTest, merge_test) {
   }
   EXPECT_NEAR(merged.avg(), seq3.avg(), err);
   EXPECT_NEAR(merged.sd(),  seq3.sd(),  err);
-
-  EXPECT_EQ(merged.davg(), seq3.davg());
-  EXPECT_EQ(merged.dvariance(), seq3.dvariance());
+  EXPECT_NEAR(merged.davg(), seq3.davg(), err);
+  EXPECT_NEAR(merged.dvariance(), seq3.dvariance(), err);
 }

--- a/test/hotspot/gtest/gc/shenandoah/test_shenandoahNumberSeq.cpp
+++ b/test/hotspot/gtest/gc/shenandoah/test_shenandoahNumberSeq.cpp
@@ -127,6 +127,8 @@ TEST_VM_F(ShenandoahNumberSeqMergeTest, merge_test) {
   }
   EXPECT_NEAR(merged.avg(), seq3.avg(), err);
   EXPECT_NEAR(merged.sd(),  seq3.sd(),  err);
-  EXPECT_NEAR(merged.davg(), seq3.davg(), err);
-  EXPECT_NEAR(merged.dvariance(), seq3.dvariance(), err);
+
+  // These are not implemented
+  EXPECT_TRUE(isnan(merged.davg()));
+  EXPECT_TRUE(isnan(merged.dvariance()));
 }

--- a/test/hotspot/gtest/gc/shenandoah/test_shenandoahNumberSeq.cpp
+++ b/test/hotspot/gtest/gc/shenandoah/test_shenandoahNumberSeq.cpp
@@ -112,27 +112,22 @@ TEST_VM_F(BasicShenandoahNumberSeqTest, percentile_test) {
 TEST_VM_F(ShenandoahNumberSeqMergeTest, merge_test) {
   EXPECT_EQ(seq1.num(), 80);
   EXPECT_EQ(seq2.num(), 20);
-  EXPECT_FALSE(isnan(seq2.davg()));  // Exercise the path; not a nan
-  EXPECT_FALSE(isnan(seq2.dsd()));
-  EXPECT_FALSE(isnan(seq2.dvariance()));
+  EXPECT_EQ(seq3.num(), 100);
 
-  std::cout << "Pre-merge: \n";
-  print();
-  seq1.merge(seq2);    // clears seq1, after merging into seq2
-  std::cout << "Post-merge: \n";
-  print();
+  HdrSeq merged;
+  merged.add(seq1);
+  merged.add(seq2);
 
-  EXPECT_EQ(seq1.num(), 0);
-  EXPECT_EQ(seq2.num(), 100);
-  EXPECT_EQ(seq2.num(), seq3.num());
-  EXPECT_TRUE(isnan(seq2.davg()));  // until we fix decayed stats
-  EXPECT_TRUE(isnan(seq2.dvariance()));
+  EXPECT_EQ(merged.num(),  seq3.num());
 
-  EXPECT_EQ(seq2.maximum(), seq3.maximum());
-  EXPECT_EQ(seq2.percentile(0), seq3.percentile(0));
+  EXPECT_EQ(merged.maximum(), seq3.maximum());
+  EXPECT_EQ(merged.percentile(0), seq3.percentile(0));
   for (int i = 0; i <= 100; i += 10) {
-    EXPECT_NEAR(seq2.percentile(i), seq3.percentile(i), err);
+    EXPECT_NEAR(merged.percentile(i), seq3.percentile(i), err);
   }
-  EXPECT_NEAR(seq2.avg(), seq3.avg(), err);
-  EXPECT_NEAR(seq2.sd(),  seq3.sd(),  err);
+  EXPECT_NEAR(merged.avg(), seq3.avg(), err);
+  EXPECT_NEAR(merged.sd(),  seq3.sd(),  err);
+
+  EXPECT_EQ(merged.davg(), seq3.davg());
+  EXPECT_EQ(merged.dvariance(), seq3.dvariance());
 }

--- a/test/hotspot/gtest/gc/shenandoah/test_shenandoahNumberSeq.cpp
+++ b/test/hotspot/gtest/gc/shenandoah/test_shenandoahNumberSeq.cpp
@@ -109,6 +109,35 @@ TEST_VM_F(BasicShenandoahNumberSeqTest, percentile_test) {
   EXPECT_NEAR(100, seq1.percentile(100), err);
 }
 
+TEST_VM_F(BasicShenandoahNumberSeqTest, clear_test) {
+  HdrSeq test;
+  test.add(1);
+
+  EXPECT_NE(test.num(), 0);
+  EXPECT_NE(test.sum(), 0);
+  EXPECT_NE(test.maximum(), 0);
+  EXPECT_NE(test.avg(), 0);
+  EXPECT_EQ(test.sd(), 0);
+  EXPECT_NE(test.davg(), 0);
+  EXPECT_EQ(test.dvariance(), 0);
+  for (int i = 0; i <= 100; i += 10) {
+    EXPECT_NE(test.percentile(i), 0);
+  }
+
+  test.clear();
+
+  EXPECT_EQ(test.num(), 0);
+  EXPECT_EQ(test.sum(), 0);
+  EXPECT_EQ(test.maximum(), 0);
+  EXPECT_EQ(test.avg(), 0);
+  EXPECT_EQ(test.sd(), 0);
+  EXPECT_EQ(test.davg(), 0);
+  EXPECT_EQ(test.dvariance(), 0);
+  for (int i = 0; i <= 100; i += 10) {
+    EXPECT_EQ(test.percentile(i), 0);
+  }
+}
+
 TEST_VM_F(ShenandoahNumberSeqMergeTest, merge_test) {
   EXPECT_EQ(seq1.num(), 80);
   EXPECT_EQ(seq2.num(), 20);


### PR DESCRIPTION
I have been looking into how to decrease our upstream exposure for `NumberSeq` changes, and it seems to be not solvable in an easy way. Normally, I would add `AbsSeq::add(AbsSeq& other)` methods and get to that from `HdrSeq::add(HdrSeq& other)`, and that almost works. The remaining bit is figuring out the decaying average/variance thingie. 

I spent an hour trying to come up with easily provable equations for _combining_ the decaying average/variance. The decaying average is somewhat easy, although there are boundary problems (decaying average treats 0-th element without adjustments, which requires remembering the `_last` element to compensate). Decaying variance looks remarkably scary in the few of my approaches.

If we enter with current code upstream, it would be the uphill battle to implemented decays and prove they work. So instead, I took the alternative approach of doing everything inside Shenandoah code, except the decays. This reverts `numberSeq.*` to upstream state.

Additional testing:
 - [x] Linux x86_64 fastdebug `hotspot_gc_shenandoah`
 - [x] Linux AArch64 fastdebug `hotspot_gc_shenandoah`
 - [x] GitFarm

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed (1 review required, with at least 1 [Committer](https://openjdk.org/bylaws#committer))

### Reviewers
 * [Y. Srinivas Ramakrishna](https://openjdk.org/census#ysr) (@ysramakrishna - Author)
 * [Roman Kennke](https://openjdk.org/census#rkennke) (@rkennke - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/shenandoah.git pull/268/head:pull/268` \
`$ git checkout pull/268`

Update a local copy of the PR: \
`$ git checkout pull/268` \
`$ git pull https://git.openjdk.org/shenandoah.git pull/268/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 268`

View PR using the GUI difftool: \
`$ git pr show -t 268`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/shenandoah/pull/268.diff">https://git.openjdk.org/shenandoah/pull/268.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/shenandoah/pull/268#issuecomment-1525945644)