### PR TITLE
Use distinct "end of cycle" message for each Shenandoah pause

### DIFF
--- a/src/hotspot/share/gc/shenandoah/shenandoahConcurrentGC.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahConcurrentGC.cpp
@@ -346,7 +346,6 @@ void ShenandoahConcurrentGC::entry_final_roots() {
 
   ShenandoahHeap* heap = ShenandoahHeap::heap();
   if (heap->is_aging_cycle()) {
-    // TODO: Do we even care about this?  Do we want to parallelize it?
     ShenandoahMarkingContext* ctx = heap->complete_marking_context();
 
     for (size_t i = 0; i < heap->num_regions(); i++) {
@@ -356,8 +355,7 @@ void ShenandoahConcurrentGC::entry_final_roots() {
         HeapWord* top = r->top();
         if (top > tams) {
           r->reset_age();
-        } else if (heap->is_aging_cycle()) {
-          // TODO: Does _incr_region_ages imply heap->is_aging_cycle()?
+        } else {
           r->increment_age();
         }
       }

--- a/src/hotspot/share/gc/shenandoah/shenandoahConcurrentGC.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahConcurrentGC.cpp
@@ -213,7 +213,7 @@ bool ShenandoahConcurrentGC::collect(GCCause::Cause cause) {
     entry_cleanup_complete();
   } else {
     // We chose not to evacuate because we found sufficient immediate garbage.
-    vmop_entry_final_roots(heap->is_aging_cycle());
+    vmop_entry_final_roots();
     _abbreviated = true;
   }
 
@@ -283,14 +283,14 @@ void ShenandoahConcurrentGC::vmop_entry_final_updaterefs() {
   VMThread::execute(&op);
 }
 
-void ShenandoahConcurrentGC::vmop_entry_final_roots(bool increment_region_ages) {
+void ShenandoahConcurrentGC::vmop_entry_final_roots() {
   ShenandoahHeap* const heap = ShenandoahHeap::heap();
   TraceCollectorStats tcs(heap->monitoring_support()->stw_collection_counters());
   ShenandoahTimingsTracker timing(ShenandoahPhaseTimings::final_roots_gross);
 
   // This phase does not use workers, no need for setup
   heap->try_inject_alloc_failure();
-  VM_ShenandoahFinalRoots op(this, increment_region_ages);
+  VM_ShenandoahFinalRoots op(this);
   VMThread::execute(&op);
 }
 
@@ -343,6 +343,26 @@ void ShenandoahConcurrentGC::entry_final_roots() {
   static const char* msg = "Pause Final Roots";
   ShenandoahPausePhase gc_phase(msg, ShenandoahPhaseTimings::final_roots);
   EventMark em("%s", msg);
+
+  ShenandoahHeap* heap = ShenandoahHeap::heap();
+  if (heap->is_aging_cycle()) {
+    // TODO: Do we even care about this?  Do we want to parallelize it?
+    ShenandoahMarkingContext* ctx = heap->complete_marking_context();
+
+    for (size_t i = 0; i < heap->num_regions(); i++) {
+      ShenandoahHeapRegion *r = heap->get_region(i);
+      if (r->is_active() && r->is_young()) {
+        HeapWord* tams = ctx->top_at_mark_start(r);
+        HeapWord* top = r->top();
+        if (top > tams) {
+          r->reset_age();
+        } else if (heap->is_aging_cycle()) {
+          // TODO: Does _incr_region_ages imply heap->is_aging_cycle()?
+          r->increment_age();
+        }
+      }
+    }
+  }
 
   op_final_roots();
 }

--- a/src/hotspot/share/gc/shenandoah/shenandoahConcurrentGC.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahConcurrentGC.cpp
@@ -344,24 +344,6 @@ void ShenandoahConcurrentGC::entry_final_roots() {
   ShenandoahPausePhase gc_phase(msg, ShenandoahPhaseTimings::final_roots);
   EventMark em("%s", msg);
 
-  ShenandoahHeap* heap = ShenandoahHeap::heap();
-  if (heap->is_aging_cycle()) {
-    ShenandoahMarkingContext* ctx = heap->complete_marking_context();
-
-    for (size_t i = 0; i < heap->num_regions(); i++) {
-      ShenandoahHeapRegion *r = heap->get_region(i);
-      if (r->is_active() && r->is_young()) {
-        HeapWord* tams = ctx->top_at_mark_start(r);
-        HeapWord* top = r->top();
-        if (top > tams) {
-          r->reset_age();
-        } else {
-          r->increment_age();
-        }
-      }
-    }
-  }
-
   op_final_roots();
 }
 
@@ -1222,6 +1204,25 @@ void ShenandoahConcurrentGC::op_final_updaterefs() {
 }
 
 void ShenandoahConcurrentGC::op_final_roots() {
+
+  ShenandoahHeap* heap = ShenandoahHeap::heap();
+  if (heap->is_aging_cycle()) {
+    ShenandoahMarkingContext* ctx = heap->complete_marking_context();
+
+    for (size_t i = 0; i < heap->num_regions(); i++) {
+      ShenandoahHeapRegion *r = heap->get_region(i);
+      if (r->is_active() && r->is_young()) {
+        HeapWord* tams = ctx->top_at_mark_start(r);
+        HeapWord* top = r->top();
+        if (top > tams) {
+          r->reset_age();
+        } else {
+          r->increment_age();
+        }
+      }
+    }
+  }
+
   ShenandoahHeap::heap()->set_concurrent_weak_root_in_progress(false);
 }
 

--- a/src/hotspot/share/gc/shenandoah/shenandoahConcurrentGC.hpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahConcurrentGC.hpp
@@ -69,7 +69,7 @@ private:
 
 protected:
   void vmop_entry_final_mark();
-  void vmop_entry_final_roots(bool incr_region_ages);
+  void vmop_entry_final_roots();
 
 private:
   void vmop_entry_init_updaterefs();

--- a/src/hotspot/share/gc/shenandoah/shenandoahOldGC.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahOldGC.cpp
@@ -144,7 +144,7 @@ bool ShenandoahOldGC::collect(GCCause::Cause cause) {
   // return from here with weak roots in progress. This is not a valid gc state
   // for any young collections (or allocation failures) that interrupt the old
   // collection.
-  vmop_entry_final_roots(false);
+  vmop_entry_final_roots();
 
   return true;
 }

--- a/src/hotspot/share/gc/shenandoah/shenandoahUtils.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahUtils.cpp
@@ -76,7 +76,7 @@ ShenandoahGCSession::~ShenandoahGCSession() {
 
 }
 
-ShenandoahGCPauseMark::ShenandoahGCPauseMark(uint gc_id, SvcGCMarker::reason_type type) :
+ShenandoahGCPauseMark::ShenandoahGCPauseMark(uint gc_id, const char* notification_message, SvcGCMarker::reason_type type) :
   _heap(ShenandoahHeap::heap()), _gc_id_mark(gc_id), _svc_gc_mark(type), _is_gc_active_mark() {
   _trace_pause.initialize(_heap->stw_memory_manager(), _heap->gc_cause(),
           /* allMemoryPoolsAffected */    true,
@@ -86,7 +86,8 @@ ShenandoahGCPauseMark::ShenandoahGCPauseMark(uint gc_id, SvcGCMarker::reason_typ
           /* recordPostGCUsage = */       false,
           /* recordAccumulatedGCTime = */ true,
           /* recordGCEndTime = */         true,
-          /* countCollection = */         true
+          /* countCollection = */         true,
+          /* notificationMessage = */     notification_message
   );
 }
 

--- a/src/hotspot/share/gc/shenandoah/shenandoahUtils.hpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahUtils.hpp
@@ -154,7 +154,7 @@ private:
   TraceMemoryManagerStats       _trace_pause;
 
 public:
-  ShenandoahGCPauseMark(uint gc_id, SvcGCMarker::reason_type type);
+  ShenandoahGCPauseMark(uint gc_id, const char* notification_action, SvcGCMarker::reason_type type);
 };
 
 class ShenandoahSafepoint : public AllStatic {

--- a/src/hotspot/share/gc/shenandoah/shenandoahVMOperations.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahVMOperations.cpp
@@ -49,55 +49,36 @@ void VM_ShenandoahReferenceOperation::doit_epilogue() {
 }
 
 void VM_ShenandoahInitMark::doit() {
-  ShenandoahGCPauseMark mark(_gc_id, SvcGCMarker::CONCURRENT);
+  ShenandoahGCPauseMark mark(_gc_id, "Init Mark", SvcGCMarker::CONCURRENT);
   _gc->entry_init_mark();
 }
 
 void VM_ShenandoahFinalMarkStartEvac::doit() {
-  ShenandoahGCPauseMark mark(_gc_id, SvcGCMarker::CONCURRENT);
+  ShenandoahGCPauseMark mark(_gc_id, "Final Mark", SvcGCMarker::CONCURRENT);
   _gc->entry_final_mark();
 }
 
 void VM_ShenandoahFullGC::doit() {
-  ShenandoahGCPauseMark mark(_gc_id, SvcGCMarker::FULL);
+  ShenandoahGCPauseMark mark(_gc_id, "Full GC", SvcGCMarker::FULL);
   _full_gc->entry_full(_gc_cause);
 }
 
 void VM_ShenandoahDegeneratedGC::doit() {
-  ShenandoahGCPauseMark mark(_gc_id, SvcGCMarker::CONCURRENT);
+  ShenandoahGCPauseMark mark(_gc_id, "Degenerated GC", SvcGCMarker::CONCURRENT);
   _gc->entry_degenerated();
 }
 
 void VM_ShenandoahInitUpdateRefs::doit() {
-  ShenandoahGCPauseMark mark(_gc_id, SvcGCMarker::CONCURRENT);
+  ShenandoahGCPauseMark mark(_gc_id, "Init Update Refs", SvcGCMarker::CONCURRENT);
   _gc->entry_init_updaterefs();
 }
 
 void VM_ShenandoahFinalUpdateRefs::doit() {
-  ShenandoahGCPauseMark mark(_gc_id, SvcGCMarker::CONCURRENT);
+  ShenandoahGCPauseMark mark(_gc_id, "Final Update Refs", SvcGCMarker::CONCURRENT);
   _gc->entry_final_updaterefs();
 }
 
 void VM_ShenandoahFinalRoots::doit() {
-  ShenandoahGCPauseMark mark(_gc_id, SvcGCMarker::CONCURRENT);
-  if (_incr_region_ages) {
-    // TODO: Do we even care about this?  Do we want to parallelize it?
-    ShenandoahHeap* heap = ShenandoahHeap::heap();
-    ShenandoahMarkingContext* ctx = heap->complete_marking_context();
-
-    for (size_t i = 0; i < heap->num_regions(); i++) {
-      ShenandoahHeapRegion *r = heap->get_region(i);
-      if (r->is_active() && r->is_young()) {
-        HeapWord* tams = ctx->top_at_mark_start(r);
-        HeapWord* top = r->top();
-        if (top > tams) {
-          r->reset_age();
-        } else if (heap->is_aging_cycle()) {
-          // TODO: Does _incr_region_ages imply heap->is_aging_cycle()?
-          r->increment_age();
-        }
-      }
-    }
-  }
+  ShenandoahGCPauseMark mark(_gc_id, "Final Roots", SvcGCMarker::CONCURRENT);
   _gc->entry_final_roots();
 }

--- a/src/hotspot/share/gc/shenandoah/shenandoahVMOperations.hpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahVMOperations.hpp
@@ -133,12 +133,10 @@ public:
 
 class VM_ShenandoahFinalRoots: public VM_ShenandoahOperation {
   ShenandoahConcurrentGC* const _gc;
-  const bool _incr_region_ages;
 public:
-  VM_ShenandoahFinalRoots(ShenandoahConcurrentGC* gc, bool incr_region_ages) :
+  VM_ShenandoahFinalRoots(ShenandoahConcurrentGC* gc) :
     VM_ShenandoahOperation(),
-    _gc(gc),
-    _incr_region_ages(incr_region_ages) {};
+    _gc(gc) {};
   VM_Operation::VMOp_Type type() const { return VMOp_ShenandoahFinalRoots; }
   const char* name()             const { return "Shenandoah Final Roots"; }
   virtual void doit();

--- a/src/hotspot/share/services/memoryManager.cpp
+++ b/src/hotspot/share/services/memoryManager.cpp
@@ -243,7 +243,7 @@ void GCMemoryManager::gc_end(bool recordPostGCUsage,
                              bool recordAccumulatedGCTime,
                              bool recordGCEndTime, bool countCollection,
                              GCCause::Cause cause,
-                             bool allMemoryPoolsAffected) {
+                             bool allMemoryPoolsAffected, const char* notificationMessage) {
   if (recordAccumulatedGCTime) {
     _accumulated_timer.stop();
   }
@@ -293,7 +293,8 @@ void GCMemoryManager::gc_end(bool recordPostGCUsage,
     }
 
     if (is_notification_enabled()) {
-      GCNotifier::pushNotification(this, _gc_end_message, GCCause::to_string(cause));
+      const char* message = notificationMessage != nullptr ? notificationMessage : _gc_end_message;
+      GCNotifier::pushNotification(this, message, GCCause::to_string(cause));
     }
   }
 }

--- a/src/hotspot/share/services/memoryManager.hpp
+++ b/src/hotspot/share/services/memoryManager.hpp
@@ -167,7 +167,7 @@ public:
                   bool recordAccumulatedGCTime);
   void   gc_end(bool recordPostGCUsage, bool recordAccumulatedGCTime,
                 bool recordGCEndTime, bool countCollection, GCCause::Cause cause,
-                bool allMemoryPoolsAffected);
+                bool allMemoryPoolsAffected, const char* notificationMessage = nullptr);
 
   void        reset_gc_stat()   { _num_collections = 0; _accumulated_timer.reset(); }
 

--- a/src/hotspot/share/services/memoryService.cpp
+++ b/src/hotspot/share/services/memoryService.cpp
@@ -183,10 +183,10 @@ void MemoryService::gc_end(GCMemoryManager* manager, bool recordPostGCUsage,
                            bool recordAccumulatedGCTime,
                            bool recordGCEndTime, bool countCollection,
                            GCCause::Cause cause,
-                           bool allMemoryPoolsAffected) {
+                           bool allMemoryPoolsAffected, const char* notificationMessage) {
   // register the GC end statistics and memory usage
   manager->gc_end(recordPostGCUsage, recordAccumulatedGCTime, recordGCEndTime,
-                  countCollection, cause, allMemoryPoolsAffected);
+                  countCollection, cause, allMemoryPoolsAffected, notificationMessage);
 }
 
 bool MemoryService::set_verbose(bool verbose) {
@@ -227,11 +227,12 @@ TraceMemoryManagerStats::TraceMemoryManagerStats(GCMemoryManager* gc_memory_mana
                                                  bool recordPostGCUsage,
                                                  bool recordAccumulatedGCTime,
                                                  bool recordGCEndTime,
-                                                 bool countCollection) {
+                                                 bool countCollection,
+                                                 const char* notificationMessage) {
   initialize(gc_memory_manager, cause, allMemoryPoolsAffected,
              recordGCBeginTime, recordPreGCUsage, recordPeakUsage,
              recordPostGCUsage, recordAccumulatedGCTime, recordGCEndTime,
-             countCollection);
+             countCollection, notificationMessage);
 }
 
 // for a subclass to create then initialize an instance before invoking
@@ -245,7 +246,8 @@ void TraceMemoryManagerStats::initialize(GCMemoryManager* gc_memory_manager,
                                          bool recordPostGCUsage,
                                          bool recordAccumulatedGCTime,
                                          bool recordGCEndTime,
-                                         bool countCollection) {
+                                         bool countCollection,
+                                         const char* notificationMessage) {
   _gc_memory_manager = gc_memory_manager;
   _allMemoryPoolsAffected = allMemoryPoolsAffected;
   _recordGCBeginTime = recordGCBeginTime;
@@ -256,6 +258,7 @@ void TraceMemoryManagerStats::initialize(GCMemoryManager* gc_memory_manager,
   _recordGCEndTime = recordGCEndTime;
   _countCollection = countCollection;
   _cause = cause;
+  _notificationMessage = notificationMessage;
 
   MemoryService::gc_begin(_gc_memory_manager, _recordGCBeginTime, _recordAccumulatedGCTime,
                           _recordPreGCUsage, _recordPeakUsage);
@@ -263,5 +266,6 @@ void TraceMemoryManagerStats::initialize(GCMemoryManager* gc_memory_manager,
 
 TraceMemoryManagerStats::~TraceMemoryManagerStats() {
   MemoryService::gc_end(_gc_memory_manager, _recordPostGCUsage, _recordAccumulatedGCTime,
-                        _recordGCEndTime, _countCollection, _cause, _allMemoryPoolsAffected);
+                        _recordGCEndTime, _countCollection, _cause, _allMemoryPoolsAffected,
+                        _notificationMessage);
 }

--- a/src/hotspot/share/services/memoryService.hpp
+++ b/src/hotspot/share/services/memoryService.hpp
@@ -104,7 +104,7 @@ public:
                      bool recordAccumulatedGCTime,
                      bool recordGCEndTime, bool countCollection,
                      GCCause::Cause cause,
-                     bool allMemoryPoolsAffected);
+                     bool allMemoryPoolsAffected, const char* notificationMessage = nullptr);
 
   static bool get_verbose() { return log_is_enabled(Info, gc); }
   static bool set_verbose(bool verbose);
@@ -125,6 +125,7 @@ private:
   bool         _recordGCEndTime;
   bool         _countCollection;
   GCCause::Cause _cause;
+  const char*  _notificationMessage;
 public:
   TraceMemoryManagerStats() {}
   TraceMemoryManagerStats(GCMemoryManager* gc_memory_manager,
@@ -136,7 +137,8 @@ public:
                           bool recordPostGCUsage = true,
                           bool recordAccumulatedGCTime = true,
                           bool recordGCEndTime = true,
-                          bool countCollection = true);
+                          bool countCollection = true,
+                          const char* notificationMessage = nullptr);
 
   void initialize(GCMemoryManager* gc_memory_manager,
                   GCCause::Cause cause,
@@ -147,7 +149,8 @@ public:
                   bool recordPostGCUsage,
                   bool recordAccumulatedGCTime,
                   bool recordGCEndTime,
-                  bool countCollection);
+                  bool countCollection,
+                  const char* notificationMessage = nullptr);
 
   ~TraceMemoryManagerStats();
 };

--- a/test/hotspot/jtreg/gc/shenandoah/mxbeans/TestPauseNotifications.java
+++ b/test/hotspot/jtreg/gc/shenandoah/mxbeans/TestPauseNotifications.java
@@ -127,6 +127,12 @@ public class TestPauseNotifications {
 
     static volatile Object sink;
 
+    private static boolean isExpectedPauseAction(String action) {
+        return "Init Mark".equals(action) || "Final Mark".equals(action) || "Full GC".equals(action)
+            || "Degenerated GC".equals(action) || "Init Update Refs".equals(action)
+            || "Final Update Refs".equals(action) || "Final Roots".equals(action);
+    }
+
     public static void main(String[] args) throws Exception {
         final long startTime = System.currentTimeMillis();
 
@@ -141,7 +147,8 @@ public class TestPauseNotifications {
                 if (n.getType().equals(GarbageCollectionNotificationInfo.GARBAGE_COLLECTION_NOTIFICATION)) {
                     GarbageCollectionNotificationInfo info = GarbageCollectionNotificationInfo.from((CompositeData) n.getUserData());
 
-                    System.out.println("Received: " + info.getGcName());
+                    System.out.println("Received: " + info.getGcName() + "/" + info.getGcAction());
+
 
                     long d = info.getGcInfo().getDuration();
 
@@ -150,6 +157,9 @@ public class TestPauseNotifications {
                         if (name.equals("Shenandoah Pauses")) {
                             pausesCount.incrementAndGet();
                             pausesDuration.addAndGet(d);
+                            if (!isExpectedPauseAction(info.getGcAction())) {
+                                throw new IllegalStateException("Unknown action: " + info.getGcAction());
+                            }
                         } else if (name.equals("Shenandoah Cycles")) {
                             cyclesCount.incrementAndGet();
                             cyclesDuration.addAndGet(d);


### PR DESCRIPTION
This change allows the `GarbageCollectionNotificationInfo::gcAction` to be overridden. Shenandoah now uses this to distinguish the notification raised for each of the pauses during the concurrent cycle. This will make it easier for monitoring software to identify which phases may be having longer than expected pauses.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed (1 review required, with at least 1 [Committer](https://openjdk.org/bylaws#committer))

### Reviewers
 * [Kelvin Nilsen](https://openjdk.org/census#kdnilsen) (@kdnilsen - Committer)
 * [Y. Srinivas Ramakrishna](https://openjdk.org/census#ysr) (@ysramakrishna - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/shenandoah.git pull/270/head:pull/270` \
`$ git checkout pull/270`

Update a local copy of the PR: \
`$ git checkout pull/270` \
`$ git pull https://git.openjdk.org/shenandoah.git pull/270/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 270`

View PR using the GUI difftool: \
`$ git pr show -t 270`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/shenandoah/pull/270.diff">https://git.openjdk.org/shenandoah/pull/270.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/shenandoah/pull/270#issuecomment-1532258497)