### PR TITLE
Assert that region usage accounting is only accessed in generational mode

### DIFF
--- a/src/hotspot/share/gc/shenandoah/shenandoahGlobalGeneration.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahGlobalGeneration.cpp
@@ -30,7 +30,6 @@
 #include "gc/shenandoah/shenandoahUtils.hpp"
 #include "gc/shenandoah/shenandoahVerifier.hpp"
 #include "gc/shenandoah/shenandoahYoungGeneration.hpp"
-#include "gc/shenandoah/heuristics/shenandoahHeuristics.hpp"
 
 const char* ShenandoahGlobalGeneration::name() const {
   return "GLOBAL";
@@ -42,6 +41,7 @@ size_t ShenandoahGlobalGeneration::max_capacity() const {
 
 size_t ShenandoahGlobalGeneration::used_regions() const {
   ShenandoahHeap* heap = ShenandoahHeap::heap();
+  assert(heap->mode()->is_generational(), "Region usage account is only for generational mode");
   return heap->old_generation()->used_regions() + heap->young_generation()->used_regions();
 }
 

--- a/src/hotspot/share/gc/shenandoah/shenandoahGlobalGeneration.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahGlobalGeneration.cpp
@@ -41,7 +41,7 @@ size_t ShenandoahGlobalGeneration::max_capacity() const {
 
 size_t ShenandoahGlobalGeneration::used_regions() const {
   ShenandoahHeap* heap = ShenandoahHeap::heap();
-  assert(heap->mode()->is_generational(), "Region usage account is only for generational mode");
+  assert(heap->mode()->is_generational(), "Region usage accounting is only for generational mode");
   return heap->old_generation()->used_regions() + heap->young_generation()->used_regions();
 }
 


### PR DESCRIPTION
There was one unrelated test failure in the github actions (running G1).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed (1 review required, with at least 1 [Committer](https://openjdk.org/bylaws#committer))

### Reviewers
 * [Kelvin Nilsen](https://openjdk.org/census#kdnilsen) (@kdnilsen - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/shenandoah.git pull/278/head:pull/278` \
`$ git checkout pull/278`

Update a local copy of the PR: \
`$ git checkout pull/278` \
`$ git pull https://git.openjdk.org/shenandoah.git pull/278/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 278`

View PR using the GUI difftool: \
`$ git pr show -t 278`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/shenandoah/pull/278.diff">https://git.openjdk.org/shenandoah/pull/278.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/shenandoah/pull/278#issuecomment-1542786597)