### PR TITLE
Use static assert to validate card offset encoding mask

### DIFF
--- a/src/hotspot/share/gc/shenandoah/shenandoahScanRemembered.hpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahScanRemembered.hpp
@@ -183,6 +183,7 @@
 #include "gc/shenandoah/shenandoahNumberSeq.hpp"
 #include "gc/shenandoah/shenandoahTaskqueue.hpp"
 #include "memory/iterator.hpp"
+#include "utilities/globalDefinitions.hpp"
 
 class ShenandoahReferenceProcessor;
 class ShenandoahConcurrentMark;
@@ -393,12 +394,15 @@ private:
   static const uint16_t ObjectStartsInCardRegion = 0x80;
   static const uint16_t FirstStartBits           = 0x7f;
 
+  // Check that we have enough bits to store the largest possible offset into a card for an object start
+  static const int MaxCardSize = NOT_LP64(512) LP64_ONLY(1024);
+  STATIC_ASSERT((MaxCardSize / HeapWordSize) - 1 <= FirstStartBits);
+
   crossing_info *object_starts;
 
 public:
   // If we're setting first_start, assume the card has an object.
   inline void set_first_start(size_t card_index, uint8_t value) {
-    assert(value < FirstStartBits, "Offset into card would be truncated");
     object_starts[card_index].offsets.first = ObjectStartsInCardRegion | value;
   }
 

--- a/src/hotspot/share/gc/shenandoah/shenandoahScanRemembered.hpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahScanRemembered.hpp
@@ -394,7 +394,8 @@ private:
   static const uint16_t ObjectStartsInCardRegion = 0x80;
   static const uint16_t FirstStartBits           = 0x7f;
 
-  // Check that we have enough bits to store the largest possible offset into a card for an object start
+  // Check that we have enough bits to store the largest possible offset into a card for an object start.
+  // The value for maximum card size is based on the constraints for GCCardSizeInBytes in gc_globals.hpp.
   static const int MaxCardSize = NOT_LP64(512) LP64_ONLY(1024);
   STATIC_ASSERT((MaxCardSize / HeapWordSize) - 1 <= FirstStartBits);
 


### PR DESCRIPTION
Follow up to https://github.com/openjdk/shenandoah/pull/275 - replace runtime assert with static assert.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed (1 review required, with at least 1 [Committer](https://openjdk.org/bylaws#committer))

### Reviewers
 * [Y. Srinivas Ramakrishna](https://openjdk.org/census#ysr) (@ysramakrishna - Committer) ⚠️ Review applies to [6c25a665](https://git.openjdk.org/shenandoah/pull/279/files/6c25a665b54947e0667aca7a14551b3a74db0bf1)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/shenandoah.git pull/279/head:pull/279` \
`$ git checkout pull/279`

Update a local copy of the PR: \
`$ git checkout pull/279` \
`$ git pull https://git.openjdk.org/shenandoah.git pull/279/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 279`

View PR using the GUI difftool: \
`$ git pr show -t 279`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/shenandoah/pull/279.diff">https://git.openjdk.org/shenandoah/pull/279.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/shenandoah/pull/279#issuecomment-1545985024)