### PR TITLE
Use soft max capacity only for trigger calculations

### DIFF
--- a/src/hotspot/share/gc/shenandoah/heuristics/shenandoahAdaptiveHeuristics.cpp
+++ b/src/hotspot/share/gc/shenandoah/heuristics/shenandoahAdaptiveHeuristics.cpp
@@ -325,14 +325,13 @@ static double saturate(double value, double min, double max) {
 }
 
 bool ShenandoahAdaptiveHeuristics::should_start_gc() {
-  size_t max_capacity = _generation->max_capacity();
   size_t capacity = _generation->soft_max_capacity();
-  size_t available = _generation->available();
+  size_t available = _generation->soft_available();
   size_t allocated = _generation->bytes_allocated_since_gc_start();
 
   log_debug(gc)("should_start_gc (%s)? available: " SIZE_FORMAT ", soft_max_capacity: " SIZE_FORMAT
-                ", max_capacity: " SIZE_FORMAT ", allocated: " SIZE_FORMAT,
-                _generation->name(), available, capacity, max_capacity, allocated);
+                ", allocated: " SIZE_FORMAT,
+                _generation->name(), available, capacity, allocated);
 
   // The collector reserve may eat into what the mutator is allowed to use. Make sure we are looking
   // at what is available to the mutator when deciding whether to start a GC.
@@ -378,7 +377,7 @@ bool ShenandoahAdaptiveHeuristics::should_start_gc() {
   //    1. At certain phase changes, we may discard large amounts of data and replace it with large numbers of newly
   //       allocated objects.  This "spike" looks more like a phase change.  We were in steady state at M bytes/sec
   //       allocation rate and now we're in a "reinitialization phase" that looks like N bytes/sec.  We need the "spike"
-  //       accomodation to give us enough runway to recalibrate our "average allocation rate".
+  //       accommodation to give us enough runway to recalibrate our "average allocation rate".
   //
   //   2. The typical workload changes.  "Suddenly", our typical workload of N TPS increases to N+delta TPS.  This means
   //       our average allocation rate needs to be adjusted.  Once again, we need the "spike" accomodation to give us

--- a/src/hotspot/share/gc/shenandoah/shenandoahGeneration.hpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahGeneration.hpp
@@ -111,21 +111,23 @@ private:
   virtual size_t used() const { return _used; }
   virtual size_t available() const;
 
+  size_t soft_available() const;
+
   // During evacuation and update-refs, some memory may be shifted between generations.  In particular, memory
   // may be loaned by old-gen to young-gen based on the promise the loan will be promptly repaid from the memory reclaimed
   // when the current collection set is recycled.  The capacity adjustment also takes into consideration memory that is
   // set aside within each generation to hold the results of evacuation, but not promotion, into that region.  Promotions
   // into old-gen are bounded by adjusted_available() whereas evacuations into old-gen are pre-committed.
-  virtual size_t adjusted_available() const;
-  virtual size_t adjusted_capacity() const;
+  size_t adjusted_available() const;
+  size_t adjusted_capacity() const;
 
   // This is the number of FREE regions that are eligible to be affiliated with this generation according to the current
   // adjusted capacity.
-  virtual size_t adjusted_unaffiliated_regions() const;
+  size_t adjusted_unaffiliated_regions() const;
 
   // Both of following return new value of available
-  virtual size_t adjust_available(intptr_t adjustment);
-  virtual size_t unadjust_available();
+  size_t adjust_available(intptr_t adjustment);
+  size_t unadjust_available();
 
   size_t bytes_allocated_since_gc_start();
   void reset_bytes_allocated_since_gc_start();

--- a/src/hotspot/share/gc/shenandoah/shenandoahGeneration.hpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahGeneration.hpp
@@ -111,6 +111,10 @@ private:
   virtual size_t used() const { return _used; }
   virtual size_t available() const;
 
+  // Returns the memory available based on the _soft_ max heap capacity (soft_max_heap - used).
+  // The soft max heap size may be adjusted lower than the max heap size to cause the trigger
+  // to believe it has less memory available than is _really_ available. Lowering the soft
+  // max heap size will cause the adaptive heuristic to run more frequent cycles.
   size_t soft_available() const;
 
   // During evacuation and update-refs, some memory may be shifted between generations.  In particular, memory

--- a/src/hotspot/share/gc/shenandoah/shenandoahHeap.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahHeap.cpp
@@ -511,7 +511,7 @@ void ShenandoahHeap::initialize_heuristics_generations() {
   // for old would be total heap - minimum capacity of young. This means the sum of the maximum
   // allowed for old and young could exceed the total heap size. It remains the case that the
   // _actual_ capacity of young + old = total.
-  _generation_sizer.heap_size_changed(soft_max_capacity());
+  _generation_sizer.heap_size_changed(max_capacity());
   size_t initial_capacity_young = _generation_sizer.max_young_size();
   size_t max_capacity_young = _generation_sizer.max_young_size();
   size_t initial_capacity_old = max_capacity() - max_capacity_young;
@@ -820,11 +820,10 @@ void ShenandoahHeap::set_soft_max_capacity(size_t v) {
   Atomic::store(&_soft_max_size, v);
 
   if (mode()->is_generational()) {
-    _generation_sizer.heap_size_changed(_soft_max_size);
-    size_t soft_max_capacity_young = _generation_sizer.max_young_size();
-    size_t soft_max_capacity_old = _soft_max_size - soft_max_capacity_young;
-    _young_generation->set_soft_max_capacity(soft_max_capacity_young);
-    _old_generation->set_soft_max_capacity(soft_max_capacity_old);
+    size_t max_capacity_young = _generation_sizer.max_young_size();
+    size_t min_capacity_young = _generation_sizer.min_young_size();
+    size_t new_capacity_young = clamp(v, min_capacity_young, max_capacity_young);
+    _young_generation->set_soft_max_capacity(new_capacity_young);
   }
 }
 

--- a/test/hotspot/jtreg/ProblemList.txt
+++ b/test/hotspot/jtreg/ProblemList.txt
@@ -86,6 +86,7 @@ gc/stress/TestStressG1Humongous.java 8286554 windows-x64
 gc/shenandoah/oom/TestThreadFailure.java 8306335 generic-all
 gc/shenandoah/oom/TestClassLoaderLeak.java 8306336 generic-all
 gc/stress/gclocker/TestGCLockerWithShenandoah.java#generational 8306341 generic-all
+gc/TestAllocHumongousFragment.java#generational 8306342 generic-all
 
 #############################################################################
 

--- a/test/hotspot/jtreg/ProblemList.txt
+++ b/test/hotspot/jtreg/ProblemList.txt
@@ -85,9 +85,7 @@ gc/stress/TestStressG1Humongous.java 8286554 windows-x64
 
 gc/shenandoah/oom/TestThreadFailure.java 8306335 generic-all
 gc/shenandoah/oom/TestClassLoaderLeak.java 8306336 generic-all
-gc/shenandoah/TestDynamicSoftMaxHeapSize.java#generational 8306333 generic-all
 gc/stress/gclocker/TestGCLockerWithShenandoah.java#generational 8306341 generic-all
-
 
 #############################################################################
 


### PR DESCRIPTION
Use the soft max heap capacity only for the trigger's availability calculations. Our current generation sizing calculations cannot tolerate arbitrary changes to capacity. This use of soft max heap is consistent with original non-generational behavior. Here, the soft max heap capacity is applied directly as the heuristics view of the capacity of the young generation.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed (1 review required, with at least 1 [Committer](https://openjdk.org/bylaws#committer))

### Reviewers
 * [Kelvin Nilsen](https://openjdk.org/census#kdnilsen) (@kdnilsen - Committer) ⚠️ Review applies to [6eb01c0f](https://git.openjdk.org/shenandoah/pull/280/files/6eb01c0f41975ebbbf5391e345ede800673c9632)
 * [Y. Srinivas Ramakrishna](https://openjdk.org/census#ysr) (@ysramakrishna - Committer) ⚠️ Review applies to [6eb01c0f](https://git.openjdk.org/shenandoah/pull/280/files/6eb01c0f41975ebbbf5391e345ede800673c9632)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/shenandoah.git pull/280/head:pull/280` \
`$ git checkout pull/280`

Update a local copy of the PR: \
`$ git checkout pull/280` \
`$ git pull https://git.openjdk.org/shenandoah.git pull/280/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 280`

View PR using the GUI difftool: \
`$ git pr show -t 280`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/shenandoah/pull/280.diff">https://git.openjdk.org/shenandoah/pull/280.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/shenandoah/pull/280#issuecomment-1551840484)