### PR TITLE
Make generational mode experimental

### DIFF
--- a/src/hotspot/share/gc/shenandoah/mode/shenandoahGenerationalMode.hpp
+++ b/src/hotspot/share/gc/shenandoah/mode/shenandoahGenerationalMode.hpp
@@ -33,7 +33,7 @@ public:
   virtual ShenandoahHeuristics* initialize_heuristics(ShenandoahGeneration* generation) const;
   virtual const char* name()     { return "Generational"; }
   virtual bool is_diagnostic()   { return false; }
-  virtual bool is_experimental() { return false; }
+  virtual bool is_experimental() { return true; }
   virtual bool is_generational() { return true; }
 };
 

--- a/test/hotspot/jtreg/gc/shenandoah/generational/TestCLIModeGenerational.java
+++ b/test/hotspot/jtreg/gc/shenandoah/generational/TestCLIModeGenerational.java
@@ -35,6 +35,7 @@ import jdk.test.whitebox.WhiteBox;
  * @run main/othervm -Xbootclasspath/a:.
  *      -XX:+IgnoreUnrecognizedVMOptions
  *      -XX:+UnlockDiagnosticVMOptions -XX:+WhiteBoxAPI
+ *      -XX:+UnlockExperimentalVMOptions
  *      -XX:+UseShenandoahGC -XX:ShenandoahGCMode=generational
  *      gc.shenandoah.generational.TestCLIModeGenerational
  */

--- a/test/hotspot/jtreg/gc/shenandoah/generational/TestSimpleGenerational.java
+++ b/test/hotspot/jtreg/gc/shenandoah/generational/TestSimpleGenerational.java
@@ -37,6 +37,7 @@ import java.util.Random;
  * @run main/othervm -Xbootclasspath/a:.
  *      -XX:+IgnoreUnrecognizedVMOptions
  *      -XX:+UnlockDiagnosticVMOptions -XX:+WhiteBoxAPI
+ *      -XX:+UnlockExperimentalVMOptions
  *      -XX:+UseShenandoahGC -XX:ShenandoahGCMode=generational
  *      gc.shenandoah.generational.TestSimpleGenerational
  */

--- a/test/hotspot/jtreg/gc/shenandoah/options/TestModeUnlock.java
+++ b/test/hotspot/jtreg/gc/shenandoah/options/TestModeUnlock.java
@@ -45,10 +45,10 @@ public class TestModeUnlock {
     }
 
     public static void main(String[] args) throws Exception {
-        testWith("-XX:ShenandoahGCMode=satb",    Mode.PRODUCT);
-        testWith("-XX:ShenandoahGCMode=iu",      Mode.EXPERIMENTAL);
-        testWith("-XX:ShenandoahGCMode=passive", Mode.DIAGNOSTIC);
-        testWith("-XX:ShenandoahGCMode=generational", Mode.PRODUCT);
+        testWith("-XX:ShenandoahGCMode=satb",         Mode.PRODUCT);
+        testWith("-XX:ShenandoahGCMode=iu",           Mode.EXPERIMENTAL);
+        testWith("-XX:ShenandoahGCMode=passive",      Mode.DIAGNOSTIC);
+        testWith("-XX:ShenandoahGCMode=generational", Mode.EXPERIMENTAL);
     }
 
     private static void testWith(String h, Mode mode) throws Exception {


### PR DESCRIPTION
Setting `-XX:ShenandoahGCMode=generational` now requires `XX:+UnlockExperimentalVMOptions`.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed (1 review required, with at least 1 [Committer](https://openjdk.org/bylaws#committer))

### Reviewers
 * [Kelvin Nilsen](https://openjdk.org/census#kdnilsen) (@kdnilsen - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/shenandoah.git pull/283/head:pull/283` \
`$ git checkout pull/283`

Update a local copy of the PR: \
`$ git checkout pull/283` \
`$ git pull https://git.openjdk.org/shenandoah.git pull/283/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 283`

View PR using the GUI difftool: \
`$ git pr show -t 283`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/shenandoah/pull/283.diff">https://git.openjdk.org/shenandoah/pull/283.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/shenandoah/pull/283#issuecomment-1561646355)