### PR TITLE
8309874: NMethod barriers may remain armed when regions are promoted in place

### DIFF
--- a/src/hotspot/share/gc/shenandoah/shenandoahConcurrentGC.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahConcurrentGC.cpp
@@ -766,7 +766,6 @@ void ShenandoahConcurrentGC::op_final_mark() {
     heap->prepare_concurrent_roots();
 
     if (heap->mode()->is_generational()) {
-      ShenandoahGeneration* young_gen = heap->young_generation();
       size_t humongous_regions_promoted = heap->get_promotable_humongous_regions();
       size_t regular_regions_promoted_in_place = heap->get_regular_regions_promoted_in_place();
       if (!heap->collection_set()->is_empty() || (humongous_regions_promoted + regular_regions_promoted_in_place > 0)) {
@@ -795,9 +794,11 @@ void ShenandoahConcurrentGC::op_final_mark() {
           heap->verifier()->verify_during_evacuation();
         }
 
-        // Arm nmethods/stack for concurrent processing
-        ShenandoahCodeRoots::arm_nmethods();
-        ShenandoahStackWatermark::change_epoch_id();
+        if (!heap->collection_set()->is_empty()) {
+          // Arm nmethods/stack for concurrent processing
+          ShenandoahCodeRoots::arm_nmethods();
+          ShenandoahStackWatermark::change_epoch_id();
+        }
 
         if (ShenandoahPacing) {
           heap->pacer()->setup_for_evac();

--- a/src/hotspot/share/gc/shenandoah/shenandoahConcurrentGC.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahConcurrentGC.cpp
@@ -795,7 +795,9 @@ void ShenandoahConcurrentGC::op_final_mark() {
         }
 
         if (!heap->collection_set()->is_empty()) {
-          // Arm nmethods/stack for concurrent processing
+          // Iff objects will be evaluated, arm the nmethod barriers. These will be disarmed
+          // under the same condition (established in preprare_concurrent_roots) after strong
+          // root evacuation has completed (see op_strong_roots).
           ShenandoahCodeRoots::arm_nmethods();
           ShenandoahStackWatermark::change_epoch_id();
         }


### PR DESCRIPTION
Genshen runs in-place promotions during the evacuation phase. If the cycle is _only_ performing in-place promotions, it should not arm NMethod barriers. The barriers are now only armed and disarmed if the collection set is not empty.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed (1 review required, with at least 1 [Committer](https://openjdk.org/bylaws#committer))

### Issue
 * [JDK-8309874](https://bugs.openjdk.org/browse/JDK-8309874): NMethod barriers may remain armed when regions are promoted in place (**Bug** - P4)


### Reviewers
 * [Kelvin Nilsen](https://openjdk.org/census#kdnilsen) (@kdnilsen - Committer) ⚠️ Review applies to [fac642a3](https://git.openjdk.org/shenandoah/pull/286/files/fac642a3a3c72c55eecab7d17ffe820016b1d5d5)
 * [Y. Srinivas Ramakrishna](https://openjdk.org/census#ysr) (@ysramakrishna - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/shenandoah.git pull/286/head:pull/286` \
`$ git checkout pull/286`

Update a local copy of the PR: \
`$ git checkout pull/286` \
`$ git pull https://git.openjdk.org/shenandoah.git pull/286/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 286`

View PR using the GUI difftool: \
`$ git pr show -t 286`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/shenandoah/pull/286.diff">https://git.openjdk.org/shenandoah/pull/286.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/shenandoah/pull/286#issuecomment-1591945172)