### PR TITLE
8310075: Revert accidental change to jcheck configuration for shenandoah project

### DIFF
--- a/.jcheck/conf
+++ b/.jcheck/conf
@@ -22,7 +22,7 @@ ignore-tabs=.*\.gmk|Makefile
 message=Merge
 
 [checks "reviewers"]
-reviewers=1
+committers=1
 ignore=duke
 
 [checks "committer"]

--- a/.jcheck/conf
+++ b/.jcheck/conf
@@ -1,7 +1,7 @@
 [general]
-project=jdk
+project=shenandoah
 jbs=JDK
-version=21
+version=22
 
 [checks]
 error=author,committer,reviewers,merge,issues,executable,symlink,message,hg-tag,whitespace,problemlists


### PR DESCRIPTION
This bit of the configuration was clobbered with https://github.com/openjdk/shenandoah/pull/285.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8310075](https://bugs.openjdk.org/browse/JDK-8310075): Revert accidental change to jcheck configuration for shenandoah project (**Task** - P4)


### Reviewers
 * [Y. Srinivas Ramakrishna](https://openjdk.org/census#ysr) (@ysramakrishna - **Reviewer**) ⚠️ Review applies to [2e9756b1](https://git.openjdk.org/shenandoah/pull/288/files/2e9756b16e79a4dcd120bd9d38b80629c9b79abf)
 * [Kelvin Nilsen](https://openjdk.org/census#kdnilsen) (@kdnilsen - no project role) ⚠️ Review applies to [2e9756b1](https://git.openjdk.org/shenandoah/pull/288/files/2e9756b16e79a4dcd120bd9d38b80629c9b79abf)
 * [Aleksey Shipilev](https://openjdk.org/census#shade) (@shipilev - **Reviewer**) ⚠️ Review applies to [2e9756b1](https://git.openjdk.org/shenandoah/pull/288/files/2e9756b16e79a4dcd120bd9d38b80629c9b79abf)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/shenandoah.git pull/288/head:pull/288` \
`$ git checkout pull/288`

Update a local copy of the PR: \
`$ git checkout pull/288` \
`$ git pull https://git.openjdk.org/shenandoah.git pull/288/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 288`

View PR using the GUI difftool: \
`$ git pr show -t 288`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/shenandoah/pull/288.diff">https://git.openjdk.org/shenandoah/pull/288.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/shenandoah/pull/288#issuecomment-1592129713)