### PR TITLE
8310680: GenShen: In-place region promotions may fail

### DIFF
--- a/src/hotspot/share/gc/shenandoah/heuristics/shenandoahHeuristics.cpp
+++ b/src/hotspot/share/gc/shenandoah/heuristics/shenandoahHeuristics.cpp
@@ -41,6 +41,20 @@
 #include "runtime/globals_extension.hpp"
 #include "utilities/quickSort.hpp"
 
+inline void assert_no_in_place_promotions() {
+#ifdef ASSERT
+  class ShenandoahNoInPlacePromotions : public ShenandoahHeapRegionClosure {
+  public:
+    void heap_region_do(ShenandoahHeapRegion *r) override {
+      assert(r->get_top_before_promote() == nullptr,
+             "Region " SIZE_FORMAT " should not be ready for in-place promotion", r->index());
+    }
+  } cl;
+  ShenandoahHeap::heap()->heap_region_iterate(&cl);
+#endif
+}
+
+
 // sort by decreasing garbage (so most garbage comes first)
 int ShenandoahHeuristics::compare_by_garbage(RegionData a, RegionData b) {
   if (a._u._garbage > b._u._garbage)
@@ -125,6 +139,10 @@ static int compare_by_aged_live(AgedRegionData a, AgedRegionData b) {
 // Returns bytes of old-gen memory consumed by selected aged regions
 size_t ShenandoahHeuristics::select_aged_regions(size_t old_available, size_t num_regions,
                                                  bool candidate_regions_for_promotion_by_copy[]) {
+
+  // There should be no regions configured for subsequent in-place-promotions carried over from the previous cycle.
+  assert_no_in_place_promotions();
+
   ShenandoahHeap* heap = ShenandoahHeap::heap();
   assert(heap->mode()->is_generational(), "Only in generational mode");
   ShenandoahMarkingContext* const ctx = heap->marking_context();
@@ -153,8 +171,8 @@ size_t ShenandoahHeuristics::select_aged_regions(size_t old_available, size_t nu
       continue;
     }
     if (r->age() >= InitialTenuringThreshold) {
-      r->save_top_before_promote();
       if ((r->garbage() < old_garbage_threshold)) {
+        r->save_top_before_promote();
         HeapWord* tams = ctx->top_at_mark_start(r);
         HeapWord* original_top = r->top();
         if (tams == original_top) {
@@ -168,7 +186,7 @@ size_t ShenandoahHeuristics::select_aged_regions(size_t old_available, size_t nu
             promote_in_place_pad += remnant_size * HeapWordSize;
           } else {
             // Since the remnant is so small that it cannot be filled, we don't have to worry about any accidental
-            // allocations occuring within this region before the region is promoted in place.
+            // allocations occurring within this region before the region is promoted in place.
           }
           promote_in_place_regions++;
           promote_in_place_live += r->get_live_data_bytes();
@@ -319,7 +337,7 @@ void ShenandoahHeuristics::choose_collection_set(ShenandoahCollectionSet* collec
           // ShenandoahOldGarbageThreshold so it will be promoted in place, or because there is not sufficient room
           // in old gen to hold the evacuated copies of this region's live data.  In both cases, we choose not to
           // place this region into the collection set.
-          if (region->garbage_before_padded_for_promote() < old_garbage_threshold) {
+          if (region->get_top_before_promote() != nullptr) {
             regular_regions_promoted_in_place++;
             regular_regions_promoted_usage += region->used_before_promote();
           }

--- a/src/hotspot/share/gc/shenandoah/shenandoahConcurrentGC.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahConcurrentGC.cpp
@@ -1280,8 +1280,8 @@ void ShenandoahConcurrentGC::op_final_roots() {
     for (size_t i = 0; i < heap->num_regions(); i++) {
       ShenandoahHeapRegion *r = heap->get_region(i);
       if (r->is_active() && r->is_young()) {
-        HeapWord *tams = ctx->top_at_mark_start(r);
-        HeapWord *top = r->top();
+        HeapWord* tams = ctx->top_at_mark_start(r);
+        HeapWord* top = r->top();
         if (top > tams) {
           r->reset_age();
         } else if (heap->is_aging_cycle()) {

--- a/src/hotspot/share/gc/shenandoah/shenandoahConcurrentGC.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahConcurrentGC.cpp
@@ -1271,25 +1271,25 @@ void ShenandoahConcurrentGC::op_final_updaterefs() {
 
 void ShenandoahConcurrentGC::op_final_roots() {
 
-  ShenandoahHeap* heap = ShenandoahHeap::heap();
-  if (heap->is_aging_cycle()) {
-    ShenandoahMarkingContext* ctx = heap->complete_marking_context();
+  ShenandoahHeap *heap = ShenandoahHeap::heap();
+  heap->set_concurrent_weak_root_in_progress(false);
+
+  if (heap->mode()->is_generational()) {
+    ShenandoahMarkingContext *ctx = heap->complete_marking_context();
 
     for (size_t i = 0; i < heap->num_regions(); i++) {
       ShenandoahHeapRegion *r = heap->get_region(i);
       if (r->is_active() && r->is_young()) {
-        HeapWord* tams = ctx->top_at_mark_start(r);
-        HeapWord* top = r->top();
+        HeapWord *tams = ctx->top_at_mark_start(r);
+        HeapWord *top = r->top();
         if (top > tams) {
           r->reset_age();
-        } else {
+        } else if (heap->is_aging_cycle()) {
           r->increment_age();
         }
       }
     }
   }
-
-  ShenandoahHeap::heap()->set_concurrent_weak_root_in_progress(false);
 }
 
 void ShenandoahConcurrentGC::op_cleanup_complete() {

--- a/src/hotspot/share/gc/shenandoah/shenandoahHeap.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahHeap.cpp
@@ -1718,9 +1718,11 @@ private:
           // doing this work during a safepoint.  We cannot put humongous regions into the collection set because that
           // triggers the load-reference barrier (LRB) to copy on reference fetch.
           r->promote_humongous();
-        } else if (r->is_regular() && (r->get_top_before_promote() != nullptr)
-                  && (r->garbage_before_padded_for_promote() < old_garbage_threshold)
-                  && (r->get_top_before_promote() == tams)) {
+        } else if (r->is_regular() && (r->get_top_before_promote() != nullptr)) {
+          assert(r->garbage_before_padded_for_promote() < old_garbage_threshold,
+                 "Region " SIZE_FORMAT " has too much garbage for promotion", r->index());
+          assert(r->get_top_before_promote() == tams,
+                 "Region " SIZE_FORMAT " has been used for allocations before promotion", r->index());
           // Likewise, we cannot put promote-in-place regions into the collection set because that would also trigger
           // the LRB to copy on reference fetch.
           r->promote_in_place();

--- a/src/hotspot/share/gc/shenandoah/shenandoahHeap.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahHeap.cpp
@@ -1718,7 +1718,9 @@ private:
           // doing this work during a safepoint.  We cannot put humongous regions into the collection set because that
           // triggers the load-reference barrier (LRB) to copy on reference fetch.
           r->promote_humongous();
-        } else if (r->is_regular() && (r->garbage_before_padded_for_promote() < old_garbage_threshold) && (r->get_top_before_promote() == tams)) {
+        } else if (r->is_regular() && (r->get_top_before_promote() != nullptr)
+                  && (r->garbage_before_padded_for_promote() < old_garbage_threshold)
+                  && (r->get_top_before_promote() == tams)) {
           // Likewise, we cannot put promote-in-place regions into the collection set because that would also trigger
           // the LRB to copy on reference fetch.
           r->promote_in_place();
@@ -2996,7 +2998,7 @@ public:
     // Maintenance of region age must follow evacuation in order to account for evacuation allocations within survivor
     // regions.  We consult region age during the subsequent evacuation to determine whether certain objects need to
     // be promoted.
-    if (_is_generational && r->is_young()) {
+    if (_is_generational && r->is_young() && r->is_active()) {
       HeapWord *tams = _ctx->top_at_mark_start(r);
       HeapWord *top = r->top();
 

--- a/src/hotspot/share/gc/shenandoah/shenandoahHeapRegion.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahHeapRegion.cpp
@@ -71,6 +71,7 @@ ShenandoahHeapRegion::ShenandoahHeapRegion(HeapWord* start, size_t index, bool c
   _end(start + RegionSizeWords),
   _new_top(nullptr),
   _empty_time(os::elapsedTime()),
+  _top_before_promoted(nullptr),
   _state(committed ? _empty_committed : _empty_uncommitted),
   _top(start),
   _tlab_allocs(0),

--- a/src/hotspot/share/gc/shenandoah/shenandoahHeapRegion.inline.hpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahHeapRegion.inline.hpp
@@ -185,8 +185,8 @@ inline size_t ShenandoahHeapRegion::garbage() const {
 }
 
 inline size_t ShenandoahHeapRegion::garbage_before_padded_for_promote() const {
-  size_t used_before_promote = byte_size(bottom(), get_top_before_promote());
   assert(get_top_before_promote() != nullptr, "top before promote should not equal null");
+  size_t used_before_promote = byte_size(bottom(), get_top_before_promote());
   assert(used_before_promote >= get_live_data_bytes(),
          "Live Data must be a subset of used before promotion live: " SIZE_FORMAT " used: " SIZE_FORMAT,
          get_live_data_bytes(), used_before_promote);
@@ -251,11 +251,8 @@ inline void ShenandoahHeapRegion::save_top_before_promote() {
 
 inline void ShenandoahHeapRegion::restore_top_before_promote() {
   _top = _top_before_promoted;
-#ifdef ASSERT
   _top_before_promoted = nullptr;
-#endif
  }
-
 
 
 #endif // SHARE_GC_SHENANDOAH_SHENANDOAHHEAPREGION_INLINE_HPP


### PR DESCRIPTION
There are a few small changes here:
* In `op-update-refs-final`, only active regions are aged.
* In `op-final-roots`, a region's age may be reset outside of an aging cycle.
* When the field used to save `top` before promotion is set, it indicates the region has been chosen for in-place-promotion.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed (1 review required, with at least 1 [Committer](https://openjdk.org/bylaws#committer))

### Issue
 * [JDK-8310680](https://bugs.openjdk.org/browse/JDK-8310680): GenShen: In-place region promotions may fail (**Bug** - P4)


### Reviewers
 * [Kelvin Nilsen](https://openjdk.org/census#kdnilsen) (@kdnilsen - Committer) ⚠️ Review applies to [0c335c33](https://git.openjdk.org/shenandoah/pull/290/files/0c335c339a3e1935706b9631e204f68652fe809e)
 * [Y. Srinivas Ramakrishna](https://openjdk.org/census#ysr) (@ysramakrishna - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/shenandoah.git pull/290/head:pull/290` \
`$ git checkout pull/290`

Update a local copy of the PR: \
`$ git checkout pull/290` \
`$ git pull https://git.openjdk.org/shenandoah.git pull/290/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 290`

View PR using the GUI difftool: \
`$ git pr show -t 290`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/shenandoah/pull/290.diff">https://git.openjdk.org/shenandoah/pull/290.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/shenandoah/pull/290#issuecomment-1603419075)