### PR TITLE
8310574 GenShen: Should not update-references for in-place-promotions

### DIFF
--- a/src/hotspot/share/gc/shenandoah/heuristics/shenandoahHeuristics.cpp
+++ b/src/hotspot/share/gc/shenandoah/heuristics/shenandoahHeuristics.cpp
@@ -389,6 +389,7 @@ void ShenandoahHeuristics::choose_collection_set(ShenandoahCollectionSet* collec
       old_heuristics->prime_collection_set(collection_set);
     } else {
       // This is a global collection and does not need to prime cset
+      assert(_generation->is_global(), "Expected global collection here");
     }
 
     // Call the subclasses to add young-gen regions into the collection set.

--- a/src/hotspot/share/gc/shenandoah/shenandoahConcurrentGC.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahConcurrentGC.cpp
@@ -127,11 +127,15 @@ bool ShenandoahConcurrentGC::collect(GCCause::Cause cause) {
 
     // Concurrent mark roots
     entry_mark_roots();
-    if (check_cancellation_and_abort(ShenandoahDegenPoint::_degenerated_roots)) return false;
+    if (check_cancellation_and_abort(ShenandoahDegenPoint::_degenerated_roots)) {
+      return false;
+    }
 
     // Continue concurrent mark
     entry_mark();
-    if (check_cancellation_and_abort(ShenandoahDegenPoint::_degenerated_mark)) return false;
+    if (check_cancellation_and_abort(ShenandoahDegenPoint::_degenerated_mark)) {
+      return false;
+    }
   }
 
   // Complete marking under STW, and start evacuation
@@ -196,18 +200,24 @@ bool ShenandoahConcurrentGC::collect(GCCause::Cause cause) {
   if (heap->is_evacuation_in_progress()) {
     // Concurrently evacuate
     entry_evacuate();
-    if (check_cancellation_and_abort(ShenandoahDegenPoint::_degenerated_evac)) return false;
+    if (check_cancellation_and_abort(ShenandoahDegenPoint::_degenerated_evac)) {
+      return false;
+    }
   }
 
   if (heap->has_forwarded_objects()) {
     // Perform update-refs phase.
     vmop_entry_init_updaterefs();
     entry_updaterefs();
-    if (check_cancellation_and_abort(ShenandoahDegenPoint::_degenerated_updaterefs)) return false;
+    if (check_cancellation_and_abort(ShenandoahDegenPoint::_degenerated_updaterefs)) {
+      return false;
+    }
 
     // Concurrent update thread roots
     entry_update_thread_roots();
-    if (check_cancellation_and_abort(ShenandoahDegenPoint::_degenerated_updaterefs)) return false;
+    if (check_cancellation_and_abort(ShenandoahDegenPoint::_degenerated_updaterefs)) {
+      return false;
+    }
 
     vmop_entry_final_updaterefs();
 

--- a/src/hotspot/share/gc/shenandoah/shenandoahDegeneratedGC.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahDegeneratedGC.cpp
@@ -257,6 +257,11 @@ void ShenandoahDegenGC::op_degenerated() {
         }
       }
 
+      // Update collector state regardless of whether or not there are forwarded objects
+      heap->set_evacuation_in_progress(false);
+      heap->set_concurrent_weak_root_in_progress(false);
+      heap->set_concurrent_strong_root_in_progress(false);
+
       // If heuristics thinks we should do the cycle, this flag would be set,
       // and we need to do update-refs. Otherwise, it would be the shortcut cycle.
       if (heap->has_forwarded_objects()) {
@@ -397,11 +402,12 @@ void ShenandoahDegenGC::op_prepare_evacuation() {
     }
 
     heap->set_evacuation_in_progress(true);
-    heap->set_has_forwarded_objects(true);
 
     if(ShenandoahVerify) {
       heap->verifier()->verify_during_evacuation();
     }
+
+    heap->set_has_forwarded_objects(!heap->collection_set()->is_empty());
   } else {
     if (ShenandoahVerify) {
       heap->verifier()->verify_after_concmark();
@@ -429,10 +435,6 @@ void ShenandoahDegenGC::op_evacuate() {
 void ShenandoahDegenGC::op_init_updaterefs() {
   // Evacuation has completed
   ShenandoahHeap* const heap = ShenandoahHeap::heap();
-  heap->set_evacuation_in_progress(false);
-  heap->set_concurrent_weak_root_in_progress(false);
-  heap->set_concurrent_strong_root_in_progress(false);
-
   heap->prepare_update_heap_references(false /*concurrent*/);
   heap->set_update_refs_in_progress(true);
 }

--- a/src/hotspot/share/gc/shenandoah/shenandoahVerifier.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahVerifier.cpp
@@ -800,7 +800,7 @@ void ShenandoahVerifier::verify_at_safepoint(const char* label,
         break;
       case _verify_gcstate_evacuation:
         enabled = true;
-        expected = ShenandoahHeap::HAS_FORWARDED | ShenandoahHeap::EVACUATION;
+        expected = ShenandoahHeap::EVACUATION;
         if (!_heap->is_stw_gc_in_progress()) {
           // Only concurrent GC sets this.
           expected |= ShenandoahHeap::WEAK_ROOTS;


### PR DESCRIPTION
When a cycle _only_ promotes regions in place, it is not necessary to update refs.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed (1 review required, with at least 1 [Committer](https://openjdk.org/bylaws#committer))

### Issue
 * [JDK-8310574](https://bugs.openjdk.org/browse/JDK-8310574): GenShen: Should not update-references for in-place-promotions (**Bug** - P4)


### Reviewers
 * [Y. Srinivas Ramakrishna](https://openjdk.org/census#ysr) (@ysramakrishna - Committer) ⚠️ Review applies to [2d0460e8](https://git.openjdk.org/shenandoah/pull/291/files/2d0460e80836916e5c8d0b69ce98e325ceb2de69)
 * [Kelvin Nilsen](https://openjdk.org/census#kdnilsen) (@kdnilsen - Committer) ⚠️ Review applies to [2d0460e8](https://git.openjdk.org/shenandoah/pull/291/files/2d0460e80836916e5c8d0b69ce98e325ceb2de69)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/shenandoah.git pull/291/head:pull/291` \
`$ git checkout pull/291`

Update a local copy of the PR: \
`$ git checkout pull/291` \
`$ git pull https://git.openjdk.org/shenandoah.git pull/291/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 291`

View PR using the GUI difftool: \
`$ git pr show -t 291`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/shenandoah/pull/291.diff">https://git.openjdk.org/shenandoah/pull/291.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/shenandoah/pull/291#issuecomment-1603445076)