### PR TITLE
8311599 GenShen: Missing card mark barrier when processing references

### DIFF
--- a/src/hotspot/share/gc/shenandoah/shenandoahReferenceProcessor.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahReferenceProcessor.cpp
@@ -472,7 +472,7 @@ void ShenandoahReferenceProcessor::process_references(ShenandoahRefProcThreadLoc
     oop head = lrb(CompressedOops::decode_not_null(*list));
     shenandoah_assert_not_in_cset_except(&head, head, ShenandoahHeap::heap()->cancelled_gc() || !ShenandoahLoadRefBarrier);
     oop prev = Atomic::xchg(&_pending_list, head);
-    RawAccess<>::oop_store(p, prev);
+    set_oop_field(p, prev);
     if (prev == nullptr) {
       // First to prepend to list, record tail
       _pending_list_tail = reinterpret_cast<void*>(p);


### PR DESCRIPTION
When reference processing threads operate on the discovered list, they may create old-to-young pointers. Such pointers need to be recorded in the remembered set.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed (1 review required, with at least 1 [Committer](https://openjdk.org/bylaws#committer))

### Issue
 * [JDK-8311599](https://bugs.openjdk.org/browse/JDK-8311599): GenShen: Missing card mark barrier when processing references (**Bug** - P4)


### Reviewers
 * [Y. Srinivas Ramakrishna](https://openjdk.org/census#ysr) (@ysramakrishna - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/shenandoah.git pull/294/head:pull/294` \
`$ git checkout pull/294`

Update a local copy of the PR: \
`$ git checkout pull/294` \
`$ git pull https://git.openjdk.org/shenandoah.git pull/294/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 294`

View PR using the GUI difftool: \
`$ git pr show -t 294`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/shenandoah/pull/294.diff">https://git.openjdk.org/shenandoah/pull/294.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/shenandoah/pull/294#issuecomment-1624274416)