### PR TITLE
Nullify top before promote when resetting regions for cycle

### DIFF
--- a/src/hotspot/share/gc/shenandoah/shenandoahGeneration.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahGeneration.cpp
@@ -56,6 +56,7 @@ class ShenandoahResetUpdateRegionStateClosure : public ShenandoahHeapRegionClosu
       // anyway to capture any updates that happened since now.
       _ctx->capture_top_at_mark_start(r);
       r->clear_live_data();
+      r->reset_top_before_promote();
     }
   }
 

--- a/src/hotspot/share/gc/shenandoah/shenandoahHeapRegion.hpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahHeapRegion.hpp
@@ -355,6 +355,10 @@ public:
   inline void save_top_before_promote();
   inline HeapWord* get_top_before_promote() const { return _top_before_promoted; }
   inline void restore_top_before_promote();
+  inline void reset_top_before_promote() {
+    _top_before_promoted = nullptr;
+  }
+
   inline size_t garbage_before_padded_for_promote() const;
 
   // Allocation (return nullptr if full)


### PR DESCRIPTION
Evacuation failures may cause stale `top_before_promote` values to be carried over from one cycle into the next. This is not something that should happen.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [ ] Commit message must refer to an issue
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Committer](https://openjdk.org/bylaws#committer))

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/shenandoah.git pull/296/head:pull/296` \
`$ git checkout pull/296`

Update a local copy of the PR: \
`$ git checkout pull/296` \
`$ git pull https://git.openjdk.org/shenandoah.git pull/296/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 296`

View PR using the GUI difftool: \
`$ git pr show -t 296`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/shenandoah/pull/296.diff">https://git.openjdk.org/shenandoah/pull/296.diff</a>

</details>
