### PR TITLE
8312321: GenShen: Remembered set scan may encounter garbage objects

### DIFF
--- a/src/hotspot/share/gc/shenandoah/shenandoahConcurrentGC.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahConcurrentGC.cpp
@@ -227,7 +227,7 @@ bool ShenandoahConcurrentGC::collect(GCCause::Cause cause) {
   } else {
     // We chose not to evacuate because we found sufficient immediate garbage. Note that we
     // do not check for cancellation here because, at this point, the cycle is effectively
-    // complete. If the cycle has been cancelled here, the control thread will detect it at
+    // complete. If the cycle has been cancelled here, the control thread will detect it 
     // on its next iteration and run a degenerated young cycle.
     vmop_entry_final_roots();
     _abbreviated = true;

--- a/src/hotspot/share/gc/shenandoah/shenandoahConcurrentGC.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahConcurrentGC.cpp
@@ -227,7 +227,7 @@ bool ShenandoahConcurrentGC::collect(GCCause::Cause cause) {
   } else {
     // We chose not to evacuate because we found sufficient immediate garbage. Note that we
     // do not check for cancellation here because, at this point, the cycle is effectively
-    // complete. If the cycle has been cancelled here, the control thread will detect it 
+    // complete. If the cycle has been cancelled here, the control thread will detect it
     // on its next iteration and run a degenerated young cycle.
     vmop_entry_final_roots();
     _abbreviated = true;

--- a/src/hotspot/share/gc/shenandoah/shenandoahConcurrentGC.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahConcurrentGC.cpp
@@ -188,9 +188,10 @@ bool ShenandoahConcurrentGC::collect(GCCause::Cause cause) {
     entry_strong_roots();
   }
 
-  // Global marking has completed. We need to fill in any unmarked objects in the old generation
-  // so that subsequent remembered set scans will not walk pointers into reclaimed memory.
-  if (!heap->cancelled_gc() && heap->mode()->is_generational() && _generation->is_global()) {
+  // Global marking has completed and we may have collected regions with no live objects.
+  // We need to fill in any unmarked objects in the old generation so that subsequent
+  // remembered set scans will not walk pointers into reclaimed memory.
+  if (heap->mode()->is_generational() && _generation->is_global()) {
     entry_global_coalesce_and_fill();
   }
 
@@ -224,7 +225,10 @@ bool ShenandoahConcurrentGC::collect(GCCause::Cause cause) {
     // Update references freed up collection set, kick the cleanup to reclaim the space.
     entry_cleanup_complete();
   } else {
-    // We chose not to evacuate because we found sufficient immediate garbage.
+    // We chose not to evacuate because we found sufficient immediate garbage. Note that we
+    // do not check for cancellation here because, at this point, the cycle is effectively
+    // complete. If the cycle has been cancelled here, the control thread will detect it at
+    // on its next iteration and run a degenerated young cycle.
     vmop_entry_final_roots();
     _abbreviated = true;
   }


### PR DESCRIPTION
During a global cycle, regions with no live objects may be reclaimed early (before evacuation). Once this happens, we _must_ coalesce and fill any dead objects in old regions because they may hold pointers into the reclaimed regions (even if the gc is cancelled before coalesce and fill). A subsequent scan of the remembered set may crash if it encounters these objects.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed (1 review required, with at least 1 [Committer](https://openjdk.org/bylaws#committer))

### Issue
 * [JDK-8312321](https://bugs.openjdk.org/browse/JDK-8312321): GenShen: Remembered set scan may encounter garbage objects (**Bug** - P4)


### Reviewers
 * [Kelvin Nilsen](https://openjdk.org/census#kdnilsen) (@kdnilsen - Committer) ⚠️ Review applies to [b819a47c](https://git.openjdk.org/shenandoah/pull/297/files/b819a47c7b2b82078a50bb306927a0b9589596aa)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/shenandoah.git pull/297/head:pull/297` \
`$ git checkout pull/297`

Update a local copy of the PR: \
`$ git checkout pull/297` \
`$ git pull https://git.openjdk.org/shenandoah.git pull/297/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 297`

View PR using the GUI difftool: \
`$ git pr show -t 297`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/shenandoah/pull/297.diff">https://git.openjdk.org/shenandoah/pull/297.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/shenandoah/pull/297#issuecomment-1641061789)