### PR TITLE
8312322: GenShen: Cancelled GCs may become stuck in self-cancellation loop

### DIFF
--- a/src/hotspot/share/gc/shenandoah/shenandoahControlThread.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahControlThread.cpp
@@ -538,29 +538,20 @@ void ShenandoahControlThread::service_concurrent_old_cycle(ShenandoahHeap* heap,
         // Coalescing threads detected the cancellation request and aborted. Stay
         // in this state so control thread may resume the coalescing work.
         assert(old_generation->state() == ShenandoahOldGeneration::FILLING, "Prepare for mark should be in progress");
-        return;
+      } else {
+        // Coalescing threads completed, it is safe to transition to the bootstrapping
+        // state now.
+        old_generation->transition_to(ShenandoahOldGeneration::BOOTSTRAPPING);
       }
 
-      // It is possible for a young generation request to preempt this nascent old
-      // collection cycle _after_ we've finished making the old regions parseable (filling),
-      // but _before_ we have unset the preemption flag. It is also possible for an
-      // allocation failure to occur after the threads have finished filling. We must
-      // check if we have been cancelled before we start a bootstrap cycle.
+      // But before bootstrapping begins, we must acknowledge any cancellation request.
+      // If the gc has not been cancelled, this does nothing. If it has been cancelled,
+      // this will clear the cancellation request and exit before starting the bootstrap
+      // phase. This will allow the young GC cycle to proceed normally.
       if (check_cancellation_or_degen(ShenandoahGC::_degenerated_outside_cycle)) {
-        if (heap->cancelled_gc()) {
-          // If this was a preemption request, the cancellation would have been cleared
-          // so that we run a concurrent young cycle. If the cancellation is still set,
-          // then this is an allocation failure and we need to run a degenerated cycle.
-          // If this is a preemption request, we're just going to fall through and run
-          // the bootstrap cycle to start the old generation cycle (the bootstrap cycle is
-          // a concurrent young cycle - which is what we're being asked to do in that case).
-          // If the cycle is cancelled for any other reason, we return from here and let
-          // the control thread return to the top of its decision loop.
-          log_info(gc)("Preparation for old generation cycle was cancelled");
-          return;
-        }
+        log_info(gc)("Preparation for old generation cycle was cancelled");
+        return;
       }
-      old_generation->transition_to(ShenandoahOldGeneration::BOOTSTRAPPING);
     }
     case ShenandoahOldGeneration::BOOTSTRAPPING: {
       // Configure the young generation's concurrent mark to put objects in


### PR DESCRIPTION
If an old GC is cancelled during its preparation phase, it may not acknowledge the cancellation. This can lead to a situation where the subsequent, interrupting young cycle observes its own cancellation request and does nothing. Which, in turn leads to another request to run a young cycle and so on, ad infinitum.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed (1 review required, with at least 1 [Committer](https://openjdk.org/bylaws#committer))

### Issue
 * [JDK-8312322](https://bugs.openjdk.org/browse/JDK-8312322): GenShen: Cancelled GCs may become stuck in self-cancellation loop (**Bug** - P4)


### Reviewers
 * [Kelvin Nilsen](https://openjdk.org/census#kdnilsen) (@kdnilsen - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/shenandoah.git pull/298/head:pull/298` \
`$ git checkout pull/298`

Update a local copy of the PR: \
`$ git checkout pull/298` \
`$ git pull https://git.openjdk.org/shenandoah.git pull/298/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 298`

View PR using the GUI difftool: \
`$ git pr show -t 298`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/shenandoah/pull/298.diff">https://git.openjdk.org/shenandoah/pull/298.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/shenandoah/pull/298#issuecomment-1641080685)