### PR TITLE
8312422: GenShen: In-place region promotion state may carry over when evacuation fails

### DIFF
--- a/src/hotspot/share/gc/shenandoah/shenandoahFullGC.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahFullGC.cpp
@@ -281,6 +281,15 @@ void ShenandoahFullGC::do_it(GCCause::Cause gc_cause) {
     // f. Sync pinned region status from the CP marks
     heap->sync_pinned_region_status();
 
+    if (heap->mode()->is_generational()) {
+      for (size_t i = 0; i < heap->num_regions(); i++) {
+        ShenandoahHeapRegion* r = heap->get_region(i);
+        if (r->get_top_before_promote() != nullptr) {
+          r->restore_top_before_promote();
+        }
+      }
+    }
+
     // The rest of prologue:
     _preserved_marks->init(heap->workers()->active_workers());
 


### PR DESCRIPTION
When a full gc starts, clear any state associated with a region scheduled for in-place promotion.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed (1 review required, with at least 1 [Committer](https://openjdk.org/bylaws#committer))

### Issue
 * [JDK-8312422](https://bugs.openjdk.org/browse/JDK-8312422): GenShen: In-place region promotion state may carry over when evacuation fails (**Bug** - P4)


### Reviewers
 * [Kelvin Nilsen](https://openjdk.org/census#kdnilsen) (@kdnilsen - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/shenandoah.git pull/299/head:pull/299` \
`$ git checkout pull/299`

Update a local copy of the PR: \
`$ git checkout pull/299` \
`$ git pull https://git.openjdk.org/shenandoah.git pull/299/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 299`

View PR using the GUI difftool: \
`$ git pr show -t 299`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/shenandoah/pull/299.diff">https://git.openjdk.org/shenandoah/pull/299.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/shenandoah/pull/299#issuecomment-1642889631)