### PR TITLE
8312610: GenShen: Old generation available is unintentionally restricted by mutator's available memory

### DIFF
--- a/src/hotspot/share/gc/shenandoah/shenandoahGeneration.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahGeneration.cpp
@@ -885,17 +885,7 @@ size_t ShenandoahGeneration::soft_available() const {
 
 size_t ShenandoahGeneration::available(size_t capacity) const {
   size_t in_use = used() + get_humongous_waste();
-  size_t available = in_use > capacity ? 0 : capacity - in_use;
-  // The collector reserve may eat into what the mutator is allowed to use. Make sure we are looking
-  // at what is available to the mutator when deciding whether to start a GC.
-  size_t usable = ShenandoahHeap::heap()->free_set()->available();
-  if (usable < available) {
-    log_debug(gc)("Usable (" SIZE_FORMAT "%s) is less than available (" SIZE_FORMAT "%s)",
-                  byte_size_in_proper_unit(usable), proper_unit_for_byte_size(usable),
-                  byte_size_in_proper_unit(available), proper_unit_for_byte_size(available));
-    available = usable;
-  }
-  return available;
+  return in_use > capacity ? 0 : capacity - in_use;
 }
 
 void ShenandoahGeneration::increase_capacity(size_t increment) {

--- a/src/hotspot/share/gc/shenandoah/shenandoahGlobalGeneration.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahGlobalGeneration.cpp
@@ -58,6 +58,14 @@ size_t ShenandoahGlobalGeneration::available() const {
   return ShenandoahHeap::heap()->free_set()->available();
 }
 
+size_t ShenandoahGlobalGeneration::soft_available() const {
+  size_t available = this->available();
+
+  // Make sure the code below treats available without the soft tail.
+  size_t soft_tail = max_capacity() - soft_max_capacity();
+  return (available > soft_tail) ? (available - soft_tail) : 0;
+}
+
 void ShenandoahGlobalGeneration::set_concurrent_mark_in_progress(bool in_progress) {
   ShenandoahHeap* heap = ShenandoahHeap::heap();
   if (in_progress && heap->mode()->is_generational()) {

--- a/src/hotspot/share/gc/shenandoah/shenandoahGlobalGeneration.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahGlobalGeneration.cpp
@@ -62,6 +62,7 @@ size_t ShenandoahGlobalGeneration::soft_available() const {
   size_t available = this->available();
 
   // Make sure the code below treats available without the soft tail.
+  assert(max_capacity() >= soft_max_capacity(), "Max capacity must be greater than soft max capacity.");
   size_t soft_tail = max_capacity() - soft_max_capacity();
   return (available > soft_tail) ? (available - soft_tail) : 0;
 }

--- a/src/hotspot/share/gc/shenandoah/shenandoahGlobalGeneration.hpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahGlobalGeneration.hpp
@@ -43,6 +43,7 @@ public:
   virtual size_t used_regions() const override;
   virtual size_t used_regions_size() const override;
   virtual size_t available() const override;
+  virtual size_t soft_available() const override;
 
   virtual void set_concurrent_mark_in_progress(bool in_progress) override;
 

--- a/src/hotspot/share/gc/shenandoah/shenandoahYoungGeneration.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahYoungGeneration.cpp
@@ -104,6 +104,6 @@ size_t ShenandoahYoungGeneration::available() const {
 }
 
 size_t ShenandoahYoungGeneration::soft_available() const {
-  size_t available = this->ShenandoahGeneration::available();
+  size_t available = this->ShenandoahGeneration::soft_available();
   return MIN2(available, ShenandoahHeap::heap()->free_set()->available());
 }

--- a/src/hotspot/share/gc/shenandoah/shenandoahYoungGeneration.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahYoungGeneration.cpp
@@ -98,7 +98,7 @@ void ShenandoahYoungGeneration::add_collection_time(double time_seconds) {
 
 size_t ShenandoahYoungGeneration::available() const {
   // The collector reserve may eat into what the mutator is allowed to use. Make sure we are looking
-  // at what is available to the mutator when reporting how much memory is avilable.
+  // at what is available to the mutator when reporting how much memory is available.
   size_t available = this->ShenandoahGeneration::available();
   return MIN2(available, ShenandoahHeap::heap()->free_set()->available());
 }

--- a/src/hotspot/share/gc/shenandoah/shenandoahYoungGeneration.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahYoungGeneration.cpp
@@ -95,3 +95,15 @@ void ShenandoahYoungGeneration::add_collection_time(double time_seconds) {
     ShenandoahGeneration::add_collection_time(time_seconds);
   }
 }
+
+size_t ShenandoahYoungGeneration::available() const {
+  // The collector reserve may eat into what the mutator is allowed to use. Make sure we are looking
+  // at what is available to the mutator when reporting how much memory is avilable.
+  size_t available = this->ShenandoahGeneration::available();
+  return MIN2(available, ShenandoahHeap::heap()->free_set()->available());
+}
+
+size_t ShenandoahYoungGeneration::soft_available() const {
+  size_t available = this->ShenandoahGeneration::available();
+  return MIN2(available, ShenandoahHeap::heap()->free_set()->available());
+}

--- a/src/hotspot/share/gc/shenandoah/shenandoahYoungGeneration.hpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahYoungGeneration.hpp
@@ -64,6 +64,9 @@ public:
   }
 
   virtual void add_collection_time(double time_seconds) override;
+
+  size_t available() const override;
+  size_t soft_available() const override;
 };
 
 #endif // SHARE_VM_GC_SHENANDOAH_SHENANDOAHYOUNGGENERATION_HPP


### PR DESCRIPTION
Only young gen allocations should be restricted to memory in the mutator's view of the freeset.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed (1 review required, with at least 1 [Committer](https://openjdk.org/bylaws#committer))

### Issue
 * [JDK-8312610](https://bugs.openjdk.org/browse/JDK-8312610): GenShen: Old generation available is unintentionally restricted by mutator's available memory (**Bug** - P4)


### Reviewers
 * [Kelvin Nilsen](https://openjdk.org/census#kdnilsen) (@kdnilsen - Committer) ⚠️ Review applies to [0df69803](https://git.openjdk.org/shenandoah/pull/301/files/0df698036c053244bbeb9ab2fa38b3c386e332ed)
 * [Y. Srinivas Ramakrishna](https://openjdk.org/census#ysr) (@ysramakrishna - Committer) ⚠️ Review applies to [0df69803](https://git.openjdk.org/shenandoah/pull/301/files/0df698036c053244bbeb9ab2fa38b3c386e332ed)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/shenandoah.git pull/301/head:pull/301` \
`$ git checkout pull/301`

Update a local copy of the PR: \
`$ git checkout pull/301` \
`$ git pull https://git.openjdk.org/shenandoah.git pull/301/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 301`

View PR using the GUI difftool: \
`$ git pr show -t 301`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/shenandoah/pull/301.diff">https://git.openjdk.org/shenandoah/pull/301.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/shenandoah/pull/301#issuecomment-1648120101)