### PR TITLE
8312120: GenShen: Update OLD Live at end of Previous Marking after Full GC

### DIFF
--- a/src/hotspot/share/gc/shenandoah/heuristics/shenandoahOldHeuristics.hpp
+++ b/src/hotspot/share/gc/shenandoah/heuristics/shenandoahOldHeuristics.hpp
@@ -141,8 +141,6 @@ public:
   // last_old_region_index() entries, or memory may be corrupted when this function overwrites the
   // end of the array.
   unsigned int get_coalesce_and_fill_candidates(ShenandoahHeapRegion** buffer);
-  bool has_coalesce_and_fill_candidates() const { return _last_old_region > 0; }
-  size_t coalesce_and_fill_candidates() const { return _last_old_region; }
 
   // True if there are old regions that need to be filled.
   bool has_coalesce_and_fill_candidates() const { return coalesce_and_fill_candidates_count() > 0; }

--- a/src/hotspot/share/gc/shenandoah/heuristics/shenandoahOldHeuristics.hpp
+++ b/src/hotspot/share/gc/shenandoah/heuristics/shenandoahOldHeuristics.hpp
@@ -141,7 +141,8 @@ public:
   // last_old_region_index() entries, or memory may be corrupted when this function overwrites the
   // end of the array.
   unsigned int get_coalesce_and_fill_candidates(ShenandoahHeapRegion** buffer);
-  bool has_coalesce_and_fill_candidates() { return _last_old_region > 0; }
+  bool has_coalesce_and_fill_candidates() const { return _last_old_region > 0; }
+  size_t coalesce_and_fill_candidates() const { return _last_old_region; }
 
   // True if there are old regions that need to be filled.
   bool has_coalesce_and_fill_candidates() const { return coalesce_and_fill_candidates_count() > 0; }

--- a/src/hotspot/share/gc/shenandoah/heuristics/shenandoahOldHeuristics.hpp
+++ b/src/hotspot/share/gc/shenandoah/heuristics/shenandoahOldHeuristics.hpp
@@ -141,6 +141,7 @@ public:
   // last_old_region_index() entries, or memory may be corrupted when this function overwrites the
   // end of the array.
   unsigned int get_coalesce_and_fill_candidates(ShenandoahHeapRegion** buffer);
+  bool has_coalesce_and_fill_candidates() { return _last_old_region > 0; }
 
   // True if there are old regions that need to be filled.
   bool has_coalesce_and_fill_candidates() const { return coalesce_and_fill_candidates_count() > 0; }

--- a/src/hotspot/share/gc/shenandoah/shenandoahFullGC.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahFullGC.cpp
@@ -413,6 +413,16 @@ void ShenandoahFullGC::phase1_mark_heap() {
   ShenandoahSTWMark mark(heap->global_generation(), true /*full_gc*/);
   mark.mark();
   heap->parallel_cleaning(true /* full_gc */);
+
+  size_t live_bytes_in_old = 0;
+  for (size_t i = 0; i < heap->num_regions(); i++) {
+    ShenandoahHeapRegion* r = heap->get_region(i);
+    if (r->is_old()) {
+      live_bytes_in_old += r->get_live_data_bytes();
+    }
+  }
+  log_info(gc)("Live bytes in old after STW mark: " PROPERFMT, PROPERFMTARGS(live_bytes_in_old));
+  heap->old_generation()->set_live_bytes_after_last_mark(live_bytes_in_old);
 }
 
 class ShenandoahPrepareForCompactionTask : public WorkerTask {


### PR DESCRIPTION
Record total live memory for old generation following Full GC marking phase.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed (1 review required, with at least 1 [Committer](https://openjdk.org/bylaws#committer))

### Issue
 * [JDK-8312120](https://bugs.openjdk.org/browse/JDK-8312120): GenShen: Update OLD Live at end of Previous Marking after Full GC (**Sub-task** - P4)


### Reviewers
 * [Kelvin Nilsen](https://openjdk.org/census#kdnilsen) (@kdnilsen - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/shenandoah.git pull/306/head:pull/306` \
`$ git checkout pull/306`

Update a local copy of the PR: \
`$ git checkout pull/306` \
`$ git pull https://git.openjdk.org/shenandoah.git pull/306/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 306`

View PR using the GUI difftool: \
`$ git pr show -t 306`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/shenandoah/pull/306.diff">https://git.openjdk.org/shenandoah/pull/306.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/shenandoah/pull/306#issuecomment-1680993699)