### PR TITLE
8309639: GenShen: Regression in LRU cache benchmark

### DIFF
--- a/src/hotspot/share/gc/shenandoah/heuristics/shenandoahHeuristics.cpp
+++ b/src/hotspot/share/gc/shenandoah/heuristics/shenandoahHeuristics.cpp
@@ -234,13 +234,13 @@ void ShenandoahHeuristics::adjust_penalty(intx step) {
 void ShenandoahHeuristics::record_success_concurrent(bool abbreviated) {
   _degenerated_cycles_in_a_row = 0;
   _successful_cycles_in_a_row++;
-
-  if (!(abbreviated && ShenandoahAdaptiveIgnoreShortCycles)) {
-    _gc_cycle_time_history->add(elapsed_cycle_time());
-    _gc_times_learned++;
-  }
+  _gc_times_learned++;
 
   adjust_penalty(Concurrent_Adjust);
+
+  if (_gc_times_learned <= ShenandoahLearningSteps || !(abbreviated && ShenandoahAdaptiveIgnoreShortCycles)) {
+    _gc_cycle_time_history->add(elapsed_cycle_time());
+  }
 }
 
 void ShenandoahHeuristics::record_success_degenerated() {


### PR DESCRIPTION
Shenandoah's adaptive heuristic begins in a state where it is "learning" the application. In this state, it triggers collections somewhat more aggressively in an effort to "learn" the allocation rate and cycle times for the application.

Shenandoah also has the ability to "skip" evacuation phases when marking finds sufficient garbage in regions with no live objects. We call these "abbreviated" cycles. During the course of development for the generational mode, we found that such cycles tend to decrease the average cycle time tracked by the heuristic. This in turn leads to the heuristic triggering a cycle "too late" - because it expects the cycle to take less time than a normal (i.e., not abbreviated) cycle requires. To address this, we modified the heuristic to not include abbreviated cycle times in the average cycle time.

Unfortunately, this change also made the heuristic not count abbreviated cycles as "learning" cycles. Ordinarily, this is not a concern because the application will usually run plenty of "normal" cycles. However, we've discovered that the certain benchmarks and jtreg tests only run abbreviated cycles. This causes the heuristic to stay in the "learning" state for the duration of the benchmark. In this state, the GC is run more aggressively and performance suffers (15-20%).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed (1 review required, with at least 1 [Committer](https://openjdk.org/bylaws#committer))

### Issue
 * [JDK-8309639](https://bugs.openjdk.org/browse/JDK-8309639): GenShen: Regression in LRU cache benchmark (**Bug** - P4)


### Reviewers
 * [Kelvin Nilsen](https://openjdk.org/census#kdnilsen) (@kdnilsen - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/shenandoah.git pull/307/head:pull/307` \
`$ git checkout pull/307`

Update a local copy of the PR: \
`$ git checkout pull/307` \
`$ git pull https://git.openjdk.org/shenandoah.git pull/307/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 307`

View PR using the GUI difftool: \
`$ git pr show -t 307`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/shenandoah/pull/307.diff">https://git.openjdk.org/shenandoah/pull/307.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/shenandoah/pull/307#issuecomment-1681399994)