### PR TITLE
JDK-8314777: GenShen: Alias young and old marking bits to legacy Shenandoah marking bit in gc state

### DIFF
--- a/src/hotspot/cpu/aarch64/gc/shenandoah/shenandoahBarrierSetAssembler_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/gc/shenandoah/shenandoahBarrierSetAssembler_aarch64.cpp
@@ -62,7 +62,7 @@ void ShenandoahBarrierSetAssembler::arraycopy_prologue(MacroAssembler* masm, Dec
       if (ShenandoahSATBBarrier && dest_uninitialized) {
         __ tbz(rscratch1, ShenandoahHeap::HAS_FORWARDED_BITPOS, done);
       } else {
-        __ mov(rscratch2, ShenandoahHeap::HAS_FORWARDED | ShenandoahHeap::YOUNG_MARKING | ShenandoahHeap::OLD_MARKING);
+        __ mov(rscratch2, ShenandoahHeap::HAS_FORWARDED | ShenandoahHeap::MARKING);
         __ tst(rscratch1, rscratch2);
         __ br(Assembler::EQ, done);
       }
@@ -758,13 +758,7 @@ void ShenandoahBarrierSetAssembler::generate_c1_pre_barrier_runtime_stub(StubAss
   // Is marking still active?
   Address gc_state(thread, in_bytes(ShenandoahThreadLocalData::gc_state_offset()));
   __ ldrb(tmp, gc_state);
-  if (!ShenandoahHeap::heap()->mode()->is_generational()) {
-    __ tbz(tmp, ShenandoahHeap::YOUNG_MARKING_BITPOS, done);
-  } else {
-    __ mov(rscratch2, ShenandoahHeap::YOUNG_MARKING | ShenandoahHeap::OLD_MARKING);
-    __ tst(tmp, rscratch2);
-    __ br(Assembler::EQ, done);
-  }
+  __ tbz(tmp, ShenandoahHeap::MARKING_BITPOS, done);
 
   // Can we store original value in the thread's buffer?
   __ ldr(tmp, queue_index);

--- a/src/hotspot/cpu/ppc/gc/shenandoah/shenandoahBarrierSetAssembler_ppc.cpp
+++ b/src/hotspot/cpu/ppc/gc/shenandoah/shenandoahBarrierSetAssembler_ppc.cpp
@@ -130,7 +130,7 @@ void ShenandoahBarrierSetAssembler::arraycopy_prologue(MacroAssembler *masm, Dec
   // for the garbage collector.
   const int required_states = ShenandoahSATBBarrier && dest_uninitialized
                               ? ShenandoahHeap::HAS_FORWARDED
-                              : ShenandoahHeap::HAS_FORWARDED | ShenandoahHeap::YOUNG_MARKING | ShenandoahHeap::OLD_MARKING;
+                              : ShenandoahHeap::HAS_FORWARDED | ShenandoahHeap::MARKING;
 
   __ andi_(R11_tmp, R11_tmp, required_states);
   __ beq(CCR0, skip_prologue);
@@ -230,7 +230,7 @@ void ShenandoahBarrierSetAssembler::satb_write_barrier_impl(MacroAssembler *masm
   // Check whether marking is active.
   __ lbz(tmp1, in_bytes(ShenandoahThreadLocalData::gc_state_offset()), R16_thread);
 
-  __ andi_(tmp1, tmp1, ShenandoahHeap::YOUNG_MARKING | ShenandoahHeap::OLD_MARKING);
+  __ andi_(tmp1, tmp1, ShenandoahHeap::MARKING);
   __ beq(CCR0, skip_barrier);
 
   /* ==== Determine the reference's previous value ==== */
@@ -964,7 +964,7 @@ void ShenandoahBarrierSetAssembler::generate_c1_pre_barrier_runtime_stub(StubAss
   // another check is required as a safepoint might have been reached in the meantime (JDK-8140588).
   __ lbz(R12_tmp2, in_bytes(ShenandoahThreadLocalData::gc_state_offset()), R16_thread);
 
-  __ andi_(R12_tmp2, R12_tmp2, ShenandoahHeap::YOUNG_MARKING | ShenandoahHeap::OLD_MARKING);
+  __ andi_(R12_tmp2, R12_tmp2, ShenandoahHeap::MARKING);
   __ beq(CCR0, skip_barrier);
 
   /* ==== Add previous value directly to thread-local SATB mark queue ==== */

--- a/src/hotspot/cpu/x86/gc/shenandoah/shenandoahBarrierSetAssembler_x86.cpp
+++ b/src/hotspot/cpu/x86/gc/shenandoah/shenandoahBarrierSetAssembler_x86.cpp
@@ -176,7 +176,7 @@ void ShenandoahBarrierSetAssembler::arraycopy_prologue(MacroAssembler* masm, Dec
       if (ShenandoahSATBBarrier && dest_uninitialized) {
         flags = ShenandoahHeap::HAS_FORWARDED;
       } else {
-        flags = ShenandoahHeap::HAS_FORWARDED | ShenandoahHeap::YOUNG_MARKING | ShenandoahHeap::OLD_MARKING;
+        flags = ShenandoahHeap::HAS_FORWARDED | ShenandoahHeap::MARKING;
       }
       __ testb(gc_state, flags);
       __ jcc(Assembler::zero, L_done);
@@ -278,7 +278,7 @@ void ShenandoahBarrierSetAssembler::satb_write_barrier_pre(MacroAssembler* masm,
   Address buffer(thread, in_bytes(ShenandoahThreadLocalData::satb_mark_queue_buffer_offset()));
 
   Address gc_state(thread, in_bytes(ShenandoahThreadLocalData::gc_state_offset()));
-  __ testb(gc_state, ShenandoahHeap::YOUNG_MARKING | ShenandoahHeap::OLD_MARKING);
+  __ testb(gc_state, ShenandoahHeap::MARKING);
   __ jcc(Assembler::zero, done);
 
   // Do we need to load the previous value?
@@ -1102,7 +1102,7 @@ void ShenandoahBarrierSetAssembler::generate_c1_pre_barrier_runtime_stub(StubAss
 
   // Is SATB still active?
   Address gc_state(thread, in_bytes(ShenandoahThreadLocalData::gc_state_offset()));
-  __ testb(gc_state, ShenandoahHeap::YOUNG_MARKING | ShenandoahHeap::OLD_MARKING);
+  __ testb(gc_state, ShenandoahHeap::MARKING);
   __ jcc(Assembler::zero, done);
 
   // Can we store original value in the thread's buffer?

--- a/src/hotspot/share/gc/shenandoah/c2/shenandoahBarrierSetC2.cpp
+++ b/src/hotspot/share/gc/shenandoah/c2/shenandoahBarrierSetC2.cpp
@@ -242,7 +242,7 @@ void ShenandoahBarrierSetC2::satb_write_barrier_pre(GraphKit* kit,
   Node* marking;
   Node* gc_state = __ AddP(no_base, tls, __ ConX(in_bytes(ShenandoahThreadLocalData::gc_state_offset())));
   Node* ld = __ load(__ ctrl(), gc_state, TypeInt::BYTE, T_BYTE, Compile::AliasIdxRaw);
-  marking = __ AndI(ld, __ ConI(ShenandoahHeap::YOUNG_MARKING | ShenandoahHeap::OLD_MARKING));
+  marking = __ AndI(ld, __ ConI(ShenandoahHeap::MARKING));
   assert(ShenandoahBarrierC2Support::is_gc_state_load(ld), "Should match the shape");
 
   // if (!marking)
@@ -323,7 +323,7 @@ bool ShenandoahBarrierSetC2::is_shenandoah_marking_if(PhaseValues* phase, Node* 
       cmpx->is_Cmp() && cmpx->in(2) == phase->intcon(0) &&
       is_shenandoah_state_load(cmpx->in(1)->in(1)) &&
       cmpx->in(1)->in(2)->is_Con() &&
-      cmpx->in(1)->in(2) == phase->intcon(ShenandoahHeap::YOUNG_MARKING | ShenandoahHeap::OLD_MARKING)) {
+      cmpx->in(1)->in(2) == phase->intcon(ShenandoahHeap::MARKING)) {
     return true;
   }
 
@@ -941,7 +941,8 @@ void ShenandoahBarrierSetC2::clone_at_expansion(PhaseMacroExpand* phase, ArrayCo
     Node* gc_state    = phase->transform_later(new LoadBNode(ctrl, mem, gc_state_addr, gc_state_adr_type, TypeInt::BYTE, MemNode::unordered));
     int flags = ShenandoahHeap::HAS_FORWARDED;
     if (ShenandoahIUBarrier) {
-      flags |= ShenandoahHeap::YOUNG_MARKING;
+      assert(!ShenandoahHeap::heap()->mode()->is_generational(), "Generational mode does not support IU barrier");
+      flags |= ShenandoahHeap::MARKING;
     }
     Node* stable_and  = phase->transform_later(new AndINode(gc_state, phase->igvn().intcon(flags)));
     Node* stable_cmp  = phase->transform_later(new CmpINode(stable_and, phase->igvn().zerocon(T_INT)));

--- a/src/hotspot/share/gc/shenandoah/c2/shenandoahBarrierSetC2.cpp
+++ b/src/hotspot/share/gc/shenandoah/c2/shenandoahBarrierSetC2.cpp
@@ -941,7 +941,6 @@ void ShenandoahBarrierSetC2::clone_at_expansion(PhaseMacroExpand* phase, ArrayCo
     Node* gc_state    = phase->transform_later(new LoadBNode(ctrl, mem, gc_state_addr, gc_state_adr_type, TypeInt::BYTE, MemNode::unordered));
     int flags = ShenandoahHeap::HAS_FORWARDED;
     if (ShenandoahIUBarrier) {
-      assert(!ShenandoahHeap::heap()->mode()->is_generational(), "Generational mode does not support IU barrier");
       flags |= ShenandoahHeap::MARKING;
     }
     Node* stable_and  = phase->transform_later(new AndINode(gc_state, phase->igvn().intcon(flags)));

--- a/src/hotspot/share/gc/shenandoah/c2/shenandoahSupport.cpp
+++ b/src/hotspot/share/gc/shenandoah/c2/shenandoahSupport.cpp
@@ -1484,7 +1484,7 @@ void ShenandoahBarrierC2Support::pin_and_expand(PhaseIdealLoop* phase) {
     Node* phi2 = PhiNode::make(region2, raw_mem, Type::MEMORY, TypeRawPtr::BOTTOM);
 
     // Stable path.
-    test_gc_state(ctrl, raw_mem, heap_stable_ctrl, phase, (ShenandoahHeap::YOUNG_MARKING | ShenandoahHeap::OLD_MARKING));
+    test_gc_state(ctrl, raw_mem, heap_stable_ctrl, phase, ShenandoahHeap::MARKING);
     region->init_req(_heap_stable, heap_stable_ctrl);
     phi->init_req(_heap_stable, raw_mem);
 

--- a/src/hotspot/share/gc/shenandoah/shenandoahArguments.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahArguments.cpp
@@ -136,10 +136,6 @@ void ShenandoahArguments::initialize() {
     }
   }
 #ifdef ASSERT
-  if (ShenandoahIUBarrier) {
-    assert(!ShenandoahHeap::heap()->mode()->is_generational(), "Generational mode does not support IU barrier");
-  }
-
   // C2 barrier verification is only reliable when all default barriers are enabled
   if (ShenandoahVerifyOptoBarriers &&
           (!FLAG_IS_DEFAULT(ShenandoahSATBBarrier)            ||
@@ -155,6 +151,10 @@ void ShenandoahArguments::initialize() {
   guarantee(!ShenandoahVerifyOptoBarriers, "Should be disabled");
 #endif // ASSERT
 #endif // COMPILER2
+
+  if (ShenandoahIUBarrier) {
+    assert(strcmp(ShenandoahGCMode, "generational"), "Generational mode does not support IU barrier");
+  }
 
   // Record more information about previous cycles for improved debugging pleasure
   if (FLAG_IS_DEFAULT(LogEventsBufferEntries)) {

--- a/src/hotspot/share/gc/shenandoah/shenandoahArguments.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahArguments.cpp
@@ -136,6 +136,10 @@ void ShenandoahArguments::initialize() {
     }
   }
 #ifdef ASSERT
+  if (ShenandoahIUBarrier) {
+    assert(!ShenandoahHeap::heap()->mode()->is_generational(), "Generational mode does not support IU barrier");
+  }
+
   // C2 barrier verification is only reliable when all default barriers are enabled
   if (ShenandoahVerifyOptoBarriers &&
           (!FLAG_IS_DEFAULT(ShenandoahSATBBarrier)            ||

--- a/src/hotspot/share/gc/shenandoah/shenandoahHeap.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahHeap.cpp
@@ -2455,9 +2455,9 @@ void ShenandoahHeap::set_evacuation_reserve_quantities(bool is_valid) {
 
 void ShenandoahHeap::set_concurrent_young_mark_in_progress(bool in_progress) {
   if (has_forwarded_objects()) {
-    set_gc_state_mask(YOUNG_MARKING | UPDATEREFS, in_progress);
+    set_gc_state_mask(MARKING | YOUNG_MARKING | UPDATEREFS, in_progress);
   } else {
-    set_gc_state_mask(YOUNG_MARKING, in_progress);
+    set_gc_state_mask(MARKING | YOUNG_MARKING, in_progress);
   }
 
   manage_satb_barrier(in_progress);
@@ -2465,9 +2465,9 @@ void ShenandoahHeap::set_concurrent_young_mark_in_progress(bool in_progress) {
 
 void ShenandoahHeap::set_concurrent_old_mark_in_progress(bool in_progress) {
   if (has_forwarded_objects()) {
-    set_gc_state_mask(OLD_MARKING | UPDATEREFS, in_progress);
+    set_gc_state_mask(MARKING | OLD_MARKING | UPDATEREFS, in_progress);
   } else {
-    set_gc_state_mask(OLD_MARKING, in_progress);
+    set_gc_state_mask(MARKING | OLD_MARKING, in_progress);
   }
 
   manage_satb_barrier(in_progress);

--- a/src/hotspot/share/gc/shenandoah/shenandoahHeap.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahHeap.cpp
@@ -2457,6 +2457,7 @@ void ShenandoahHeap::set_concurrent_young_mark_in_progress(bool in_progress) {
   assert(!has_forwarded_objects(), "Young marking is not concurrent with evacuation");
   if (!in_progress && is_concurrent_old_mark_in_progress()) {
     assert(mode()->is_generational(), "Only generational GC has old marking");
+    assert(_gc_state.is_set(MARKING), "concurrent_old_marking_in_progress implies MARKING");
     // If old-marking is in progress when we turn off YOUNG_MARKING, leave MARKING (and OLD_MARKING) on
     set_gc_state_mask(YOUNG_MARKING, in_progress);
   } else {
@@ -2468,6 +2469,7 @@ void ShenandoahHeap::set_concurrent_young_mark_in_progress(bool in_progress) {
 void ShenandoahHeap::set_concurrent_old_mark_in_progress(bool in_progress) {
   if (!in_progress && is_concurrent_young_mark_in_progress()) {
     // If young-marking is in progress when we turn off OLD_MARKING, leave MARKING (and YOUNG_MARKING) on
+    assert(_gc_state.is_set(MARKING), "concurrent_young_marking_in_progress implies MARKING");
     set_gc_state_mask(OLD_MARKING, in_progress);
   } else {
     set_gc_state_mask(MARKING | OLD_MARKING, in_progress);

--- a/src/hotspot/share/gc/shenandoah/shenandoahHeap.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahHeap.cpp
@@ -2462,10 +2462,13 @@ void ShenandoahHeap::set_concurrent_young_mark_in_progress(bool in_progress) {
     // If old-marking is in progress when we turn off YOUNG_MARKING, leave MARKING (and OLD_MARKING) on
     mask = YOUNG_MARKING;
   } else {
-    assert(_gc_state.is_unset(MARKING | OLD_MARKING | young_marking), "Expect all marking flags to be unset: %x", _gc_state);
+#ifdef ASSERT
+    unsigned char gc_state = (unsigned) this->gc_state();
+    assert(_gc_state.is_unset(MARKING | OLD_MARKING | YOUNG_MARKING), "Expect all marking flags to be unset: %x", gc_state);
+#endif
     mask = MARKING | YOUNG_MARKING;
   }
-  set_gc_mask(mask, in_progress);
+  set_gc_state_mask(mask, in_progress);
   manage_satb_barrier(in_progress);
 }
 
@@ -2474,7 +2477,7 @@ void ShenandoahHeap::set_concurrent_old_mark_in_progress(bool in_progress) {
   // has_forwarded_objects() iff UPDATEREFS or EVACUATION
   bool has_forwarded = has_forwarded_objects()? 1: 0;
   bool updating_or_evacuating = _gc_state.is_set(UPDATEREFS | EVACUATION)? 1: 0;
-  assert (has_forwarded_objects == updating_or_evacuating, "Has forwarded objects iff updating or evacuating");
+  assert (has_forwarded == updating_or_evacuating, "Has forwarded objects iff updating or evacuating");
 #endif
   if (!in_progress && is_concurrent_young_mark_in_progress()) {
     // If young-marking is in progress when we turn off OLD_MARKING, leave MARKING (and YOUNG_MARKING) on

--- a/src/hotspot/share/gc/shenandoah/shenandoahHeap.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahHeap.cpp
@@ -2454,22 +2454,24 @@ void ShenandoahHeap::set_evacuation_reserve_quantities(bool is_valid) {
 }
 
 void ShenandoahHeap::set_concurrent_young_mark_in_progress(bool in_progress) {
-  if (has_forwarded_objects()) {
-    set_gc_state_mask(MARKING | YOUNG_MARKING | UPDATEREFS, in_progress);
+  assert(!has_forwarded_objects(), "Young marking is not concurrent with evacuation");
+  if (!in_progress && is_concurrent_old_mark_in_progress()) {
+    assert(mode()->is_generational(), "Only generational GC has old marking");
+    // If old-marking is in progress when we turn off YOUNG_MARKING, leave MARKING (and OLD_MARKING) on
+    set_gc_state_mask(YOUNG_MARKING, in_progress);
   } else {
     set_gc_state_mask(MARKING | YOUNG_MARKING, in_progress);
   }
-
   manage_satb_barrier(in_progress);
 }
 
 void ShenandoahHeap::set_concurrent_old_mark_in_progress(bool in_progress) {
-  if (has_forwarded_objects()) {
-    set_gc_state_mask(MARKING | OLD_MARKING | UPDATEREFS, in_progress);
+  if (!in_progress && is_concurrent_young_mark_in_progress()) {
+    // If young-marking is in progress when we turn off OLD_MARKING, leave MARKING (and YOUNG_MARKING) on
+    set_gc_state_mask(OLD_MARKING, in_progress);
   } else {
     set_gc_state_mask(MARKING | OLD_MARKING, in_progress);
   }
-
   manage_satb_barrier(in_progress);
 }
 

--- a/src/hotspot/share/gc/shenandoah/shenandoahHeap.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahHeap.cpp
@@ -2462,10 +2462,6 @@ void ShenandoahHeap::set_concurrent_young_mark_in_progress(bool in_progress) {
     // If old-marking is in progress when we turn off YOUNG_MARKING, leave MARKING (and OLD_MARKING) on
     mask = YOUNG_MARKING;
   } else {
-#ifdef ASSERT
-    unsigned char gc_state = (unsigned) this->gc_state();
-    assert(_gc_state.is_unset(MARKING | OLD_MARKING | YOUNG_MARKING), "Expect all marking flags to be unset: %x", gc_state);
-#endif
     mask = MARKING | YOUNG_MARKING;
   }
   set_gc_state_mask(mask, in_progress);

--- a/src/hotspot/share/gc/shenandoah/shenandoahHeap.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahHeap.cpp
@@ -2469,8 +2469,8 @@ void ShenandoahHeap::set_concurrent_young_mark_in_progress(bool in_progress) {
 void ShenandoahHeap::set_concurrent_old_mark_in_progress(bool in_progress) {
   // if has_forarded_objects(), then we expect UPDATEREFS or EVACUATION bit of _gc_state to be set
   assert((has_forwarded_objects() && (_gc_state.is_set(UPDATEREFS) || _gc_state.is_set(EVACUATION))) ||
-	 (!has_forwarded_objects() && (_gc_state.is_unset(UPDATEREFS) && _gc_state.is_uset(EVACUATION))),
-	 "has_forwarded_objects() implies UPDATE_REFS or EVACUATION");
+         (!has_forwarded_objects() && (_gc_state.is_unset(UPDATEREFS) && _gc_state.is_uset(EVACUATION))),
+         "has_forwarded_objects() implies UPDATE_REFS or EVACUATION");
   if (!in_progress && is_concurrent_young_mark_in_progress()) {
     // If young-marking is in progress when we turn off OLD_MARKING, leave MARKING (and YOUNG_MARKING) on
     assert(_gc_state.is_set(MARKING), "concurrent_young_marking_in_progress implies MARKING");

--- a/src/hotspot/share/gc/shenandoah/shenandoahHeap.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahHeap.cpp
@@ -2467,9 +2467,9 @@ void ShenandoahHeap::set_concurrent_young_mark_in_progress(bool in_progress) {
 }
 
 void ShenandoahHeap::set_concurrent_old_mark_in_progress(bool in_progress) {
-  // if has_forarded_objects(), then we expect UPDATEREFS or EVACUATION bit of _gc_state to be set
+  // has_forwarded_objects() iff UPDATEREFS or EVACUATION
   assert((has_forwarded_objects() && (_gc_state.is_set(UPDATEREFS) || _gc_state.is_set(EVACUATION))) ||
-         (!has_forwarded_objects() && (_gc_state.is_unset(UPDATEREFS) && _gc_state.is_uset(EVACUATION))),
+         (!has_forwarded_objects() && (_gc_state.is_unset(UPDATEREFS) && _gc_state.is_unset(EVACUATION))),
          "has_forwarded_objects() implies UPDATE_REFS or EVACUATION");
   if (!in_progress && is_concurrent_young_mark_in_progress()) {
     // If young-marking is in progress when we turn off OLD_MARKING, leave MARKING (and YOUNG_MARKING) on

--- a/src/hotspot/share/gc/shenandoah/shenandoahHeap.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahHeap.cpp
@@ -2467,6 +2467,10 @@ void ShenandoahHeap::set_concurrent_young_mark_in_progress(bool in_progress) {
 }
 
 void ShenandoahHeap::set_concurrent_old_mark_in_progress(bool in_progress) {
+  // if has_forarded_objects(), then we expect UPDATEREFS or EVACUATION bit of _gc_state to be set
+  assert((has_forwarded_objects() && (_gc_state.is_set(UPDATEREFS) || _gc_state.is_set(EVACUATION))) ||
+	 (!has_forwarded_objects() && (_gc_state.is_unset(UPDATEREFS) && _gc_state.is_uset(EVACUATION))),
+	 "has_forwarded_objects() implies UPDATE_REFS or EVACUATION");
   if (!in_progress && is_concurrent_young_mark_in_progress()) {
     // If young-marking is in progress when we turn off OLD_MARKING, leave MARKING (and YOUNG_MARKING) on
     assert(_gc_state.is_set(MARKING), "concurrent_young_marking_in_progress implies MARKING");

--- a/src/hotspot/share/gc/shenandoah/shenandoahHeap.hpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahHeap.hpp
@@ -314,7 +314,8 @@ public:
     // Heap has forwarded objects: needs LRB barriers.
     HAS_FORWARDED_BITPOS   = 0,
 
-    // Young or OLD regions are under marking: needs SATB barriers.
+    // Heap is under marking: needs SATB barriers.
+    // For generational mode, it means either young or old marking, or both.
     MARKING_BITPOS    = 1,
 
     // Heap is under evacuation: needs LRB barriers. (Set together with HAS_FORWARDED)

--- a/src/hotspot/share/gc/shenandoah/shenandoahHeap.hpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahHeap.hpp
@@ -314,8 +314,8 @@ public:
     // Heap has forwarded objects: needs LRB barriers.
     HAS_FORWARDED_BITPOS   = 0,
 
-    // Young regions are under marking: needs SATB barriers.
-    YOUNG_MARKING_BITPOS    = 1,
+    // Young or OLD regions are under marking: needs SATB barriers.
+    MARKING_BITPOS    = 1,
 
     // Heap is under evacuation: needs LRB barriers. (Set together with HAS_FORWARDED)
     EVACUATION_BITPOS = 2,
@@ -326,17 +326,21 @@ public:
     // Heap is under weak-reference/roots processing: needs weak-LRB barriers.
     WEAK_ROOTS_BITPOS  = 4,
 
-    // Old regions are under marking, still need SATB barriers.
-    OLD_MARKING_BITPOS = 5
+    // Young regions are under marking, need SATB barriers.
+    YOUNG_MARKING_BITPOS = 5,
+
+    // Old regions are under marking, need SATB barriers.
+    OLD_MARKING_BITPOS = 6
   };
 
   enum GCState {
     STABLE        = 0,
     HAS_FORWARDED = 1 << HAS_FORWARDED_BITPOS,
-    YOUNG_MARKING = 1 << YOUNG_MARKING_BITPOS,
+    MARKING       = 1 << MARKING_BITPOS,
     EVACUATION    = 1 << EVACUATION_BITPOS,
     UPDATEREFS    = 1 << UPDATEREFS_BITPOS,
     WEAK_ROOTS    = 1 << WEAK_ROOTS_BITPOS,
+    YOUNG_MARKING = 1 << YOUNG_MARKING_BITPOS,
     OLD_MARKING   = 1 << OLD_MARKING_BITPOS
   };
 

--- a/src/hotspot/share/gc/shenandoah/shenandoahHeap.hpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahHeap.hpp
@@ -417,7 +417,6 @@ public:
   void set_prepare_for_old_mark_in_progress(bool cond);
   void set_aging_cycle(bool cond);
 
-
   inline bool is_stable() const;
   inline bool is_idle() const;
   inline bool has_evacuation_reserve_quantities() const;

--- a/src/hotspot/share/gc/shenandoah/shenandoahHeap.inline.hpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahHeap.inline.hpp
@@ -697,8 +697,8 @@ inline bool ShenandoahHeap::is_full_gc_in_progress() const {
 inline bool ShenandoahHeap::is_full_gc_move_in_progress() const {
   return _full_gc_move_in_progress.is_set();
 }
-
-inline bool ShenandoahHeap::is_update_refs_in_progress() const {
+	
+	inline bool ShenandoahHeap::is_update_refs_in_progress() const {
   return _gc_state.is_set(UPDATEREFS);
 }
 

--- a/src/hotspot/share/gc/shenandoah/shenandoahHeap.inline.hpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahHeap.inline.hpp
@@ -658,11 +658,6 @@ inline bool ShenandoahHeap::has_evacuation_reserve_quantities() const {
 }
 
 inline bool ShenandoahHeap::is_idle() const {
-  // if MARKING set, then either YOUNG_MARKING or OLD_MARKING is also set
-  // if MARKING unset, both YOUNG_MARKING and OLD_MARKING are unset
-  assert((_gc_state.is_unset(MARKING) && _gc_state.is_unset(YOUNG_MARKING) && _gc_state.is_unset(OLD_MARKING)) ||
-         (_gc_state.is_set(MARKING) && (_gc_state.is_set(YOUNG_MARKING) || _gc_state.is_set(OLD_MARKING))),
-         "Inconsistent gc marking state");
   return _gc_state.is_unset(MARKING | EVACUATION | UPDATEREFS);
 }
 

--- a/src/hotspot/share/gc/shenandoah/shenandoahHeap.inline.hpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahHeap.inline.hpp
@@ -661,8 +661,8 @@ inline bool ShenandoahHeap::is_idle() const {
   // if MARKING set, then either YOUNG_MARKING or OLD_MARKING is also set
   // if MARKING unset, both YOUNG_MARKING and OLD_MARKING are unset
   assert((_gc_state.is_unset(MARKING) && _gc_state.is_unset(YOUNG_MARKING) && _gc_state.is_unset(OLD_MARKING)) ||
-	 (_gc_state.is_set(MARKING) && (_gc_state.is_set(YOUNG_MARKING) || _gc_state.is_set(OLD_MARKING))),
-	 "Inconsistent gc marking state");
+         (_gc_state.is_set(MARKING) && (_gc_state.is_set(YOUNG_MARKING) || _gc_state.is_set(OLD_MARKING))),
+         "Inconsistent gc marking state");
   return _gc_state.is_unset(MARKING | EVACUATION | UPDATEREFS);
 }
 

--- a/src/hotspot/share/gc/shenandoah/shenandoahHeap.inline.hpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahHeap.inline.hpp
@@ -658,7 +658,12 @@ inline bool ShenandoahHeap::has_evacuation_reserve_quantities() const {
 }
 
 inline bool ShenandoahHeap::is_idle() const {
-  return _gc_state.is_unset(MARKING | YOUNG_MARKING | OLD_MARKING | EVACUATION | UPDATEREFS);
+  // if MARKING set, then either YOUNG_MARKING or OLD_MARKING is also set
+  // if MARKING unset, both YOUNG_MARKING and OLD_MARKING are unset
+  assert((_gc_state.is_unset(MARKING) && _gc_state.is_unset(YOUNG_MARKING) && _gc_state.is_unset(OLD_MARKING)) ||
+	 (_gc_state.is_set(MARKING) && (_gc_state.is_set(YOUNG_MARKING) || _gc_state.is_set(OLD_MARKING))),
+	 "Inconsistent gc marking state");
+  return _gc_state.is_unset(MARKING | EVACUATION | UPDATEREFS);
 }
 
 inline bool ShenandoahHeap::is_concurrent_mark_in_progress() const {

--- a/src/hotspot/share/gc/shenandoah/shenandoahHeap.inline.hpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahHeap.inline.hpp
@@ -697,8 +697,8 @@ inline bool ShenandoahHeap::is_full_gc_in_progress() const {
 inline bool ShenandoahHeap::is_full_gc_move_in_progress() const {
   return _full_gc_move_in_progress.is_set();
 }
-	
-	inline bool ShenandoahHeap::is_update_refs_in_progress() const {
+
+inline bool ShenandoahHeap::is_update_refs_in_progress() const {
   return _gc_state.is_set(UPDATEREFS);
 }
 

--- a/src/hotspot/share/gc/shenandoah/shenandoahHeap.inline.hpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahHeap.inline.hpp
@@ -658,11 +658,11 @@ inline bool ShenandoahHeap::has_evacuation_reserve_quantities() const {
 }
 
 inline bool ShenandoahHeap::is_idle() const {
-  return _gc_state.is_unset(YOUNG_MARKING | OLD_MARKING | EVACUATION | UPDATEREFS);
+  return _gc_state.is_unset(MARKING | YOUNG_MARKING | OLD_MARKING | EVACUATION | UPDATEREFS);
 }
 
 inline bool ShenandoahHeap::is_concurrent_mark_in_progress() const {
-  return _gc_state.is_set(YOUNG_MARKING | OLD_MARKING);
+  return _gc_state.is_set(MARKING);
 }
 
 inline bool ShenandoahHeap::is_concurrent_young_mark_in_progress() const {

--- a/src/hotspot/share/gc/shenandoah/shenandoahSharedVariables.hpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahSharedVariables.hpp
@@ -165,7 +165,8 @@ typedef struct ShenandoahSharedBitmap {
   // Returns true iff all bits set in mask are set in this.value.
   bool is_set_exactly(uint mask) const {
     assert (mask < (sizeof(ShenandoahSharedValue) * CHAR_MAX), "sanity");
-    return (Atomic::load_acquire(&value) & (ShenandoahSharedValue) mask) == mask;
+    uint uvalue = Atomic::load_acquire(&value);
+    return (uvalue & mask) == mask;
   }
 
   // Returns true iff all bits set in mask are unset in this.value.

--- a/src/hotspot/share/gc/shenandoah/shenandoahSharedVariables.hpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahSharedVariables.hpp
@@ -157,10 +157,18 @@ typedef struct ShenandoahSharedBitmap {
     Atomic::release_store_fence(&value, (ShenandoahSharedValue)0);
   }
 
+  // Returns true iff any bit set in mask is set in this.value.
   bool is_set(uint mask) const {
     return !is_unset(mask);
   }
 
+  // Returns true iff all bits set in mask are set in this.value.
+  bool is_set_exactly(uint mask) const {
+    assert (mask < (sizeof(ShenandoahSharedValue) * CHAR_MAX), "sanity");
+    return (Atomic::load_acquire(&value) & (ShenandoahSharedValue) mask) == mask;
+  }
+
+  // Returns true iff all bits set in mask are unset in this.value.
   bool is_unset(uint mask) const {
     assert (mask < (sizeof(ShenandoahSharedValue) * CHAR_MAX), "sanity");
     return (Atomic::load_acquire(&value) & (ShenandoahSharedValue) mask) == 0;

--- a/src/hotspot/share/gc/shenandoah/shenandoahSharedVariables.hpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahSharedVariables.hpp
@@ -121,14 +121,15 @@ typedef struct ShenandoahSharedBitmap {
     ShenandoahSharedValue mask_val = (ShenandoahSharedValue) mask;
     while (true) {
       ShenandoahSharedValue ov = Atomic::load_acquire(&value);
-      if ((ov & mask_val) != 0) {
+      // We require all bits of mask_val to be set
+      if ((ov & mask_val) == mask_val) {
         // already set
         return;
       }
 
       ShenandoahSharedValue nv = ov | mask_val;
       if (Atomic::cmpxchg(&value, ov, nv) == ov) {
-        // successfully set
+        // successfully set: if value returned from cmpxchg equals ov, then nv has overwritten value.
         return;
       }
     }

--- a/src/hotspot/share/gc/shenandoah/shenandoahVerifier.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahVerifier.cpp
@@ -765,9 +765,12 @@ public:
 
   static bool verify_gc_state(char actual, char expected) {
     // Old generation marking is allowed in all states.
-    // TODO: This actually accepts more than just OLD_MARKING.
-    // TODO: Also, only accept OLD_MARKING in generational mode.
-    return (actual == expected) || (actual & ShenandoahHeap::OLD_MARKING);
+    if (ShenandoahHeap::heap()->mode()->is_generational()) {
+      return ((actual & ~ShenandoahHeap::OLD_MARKING) == expected);
+    } else {
+      assert(actual & ShenandoahHeap::OLD_MARKING == 0, "Should not mark old in non-generational mode");
+      return (actual == expected);
+    }
   }
 };
 

--- a/src/hotspot/share/gc/shenandoah/shenandoahVerifier.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahVerifier.cpp
@@ -835,10 +835,10 @@ void ShenandoahVerifier::verify_at_safepoint(const char* label,
 
       // if MARKING set, then either YOUNG_MARKING or OLD_MARKING is also set
       // if MARKING unset, both YOUNG_MARKING and OLD_MARKING are unset
-      assert(((actual & ShenandoahHeap::MARKING == 0) &&
-              (actual & (ShenandoahHeap::YOUNG_MARKING | ShenandoahHeap::OLD_MARKING) == 0)) ||
+      assert((((actual & ShenandoahHeap::MARKING) == 0) &&
+              ((actual & (ShenandoahHeap::YOUNG_MARKING | ShenandoahHeap::OLD_MARKING)) == 0)) ||
              ((actual & ShenandoahHeap::MARKING) && (actual & (ShenandoahHeap::YOUNG_MARKING | ShenandoahHeap::OLD_MARKING))),
-             "Inconsistent gc marking state");
+             "Inconsistent gc marking state: %x", actual);
 
       // Old generation marking is allowed in all states.
       if (!VerifyThreadGCState::verify_gc_state(actual, expected)) {

--- a/src/hotspot/share/gc/shenandoah/shenandoahVerifier.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahVerifier.cpp
@@ -766,9 +766,9 @@ public:
   static bool verify_gc_state(char actual, char expected) {
     // Old generation marking is allowed in all states.
     if (ShenandoahHeap::heap()->mode()->is_generational()) {
-      return ((actual & ~ShenandoahHeap::OLD_MARKING) == expected);
+      return ((actual & ~(ShenandoahHeap::OLD_MARKING | ShenandoahHeap::MARKING)) == expected);
     } else {
-      assert(actual & ShenandoahHeap::OLD_MARKING == 0, "Should not mark old in non-generational mode");
+      assert((actual & ShenandoahHeap::OLD_MARKING) == 0, "Should not mark old in non-generational mode");
       return (actual == expected);
     }
   }

--- a/src/hotspot/share/gc/shenandoah/shenandoahVerifier.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahVerifier.cpp
@@ -832,7 +832,7 @@ void ShenandoahVerifier::verify_at_safepoint(const char* label,
 
     if (enabled) {
       char actual = _heap->gc_state();
-      
+
       bool is_marking = (actual & ShenandoahHeap::MARKING)? 1: 0;
       bool is_marking_young_or_old = (actual & (ShenandoahHeap::YOUNG_MARKING | ShenandoahHeap::OLD_MARKING))? 1: 0;
       assert(is_marking == is_marking_young_or_old, "MARKING iff (YOUNG_MARKING or OLD_MARKING), gc_state is: %x", actual);

--- a/src/hotspot/share/gc/shenandoah/shenandoahVerifier.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahVerifier.cpp
@@ -832,13 +832,10 @@ void ShenandoahVerifier::verify_at_safepoint(const char* label,
 
     if (enabled) {
       char actual = _heap->gc_state();
-
-      // if MARKING set, then either YOUNG_MARKING or OLD_MARKING is also set
-      // if MARKING unset, both YOUNG_MARKING and OLD_MARKING are unset
-      assert((((actual & ShenandoahHeap::MARKING) == 0) &&
-              ((actual & (ShenandoahHeap::YOUNG_MARKING | ShenandoahHeap::OLD_MARKING)) == 0)) ||
-             ((actual & ShenandoahHeap::MARKING) && (actual & (ShenandoahHeap::YOUNG_MARKING | ShenandoahHeap::OLD_MARKING))),
-             "Inconsistent gc marking state: %x", actual);
+      
+      bool is_marking = (actual & ShenandoahHeap::MARKING)? 1: 0;
+      bool is_marking_young_or_old = (actual & (ShenandoahHeap::YOUNG_MARKING | ShenandoahHeap::OLD_MARKING))? 1: 0;
+      assert(is_marking == is_marking_young_or_old, "MARKING iff (YOUNG_MARKING or OLD_MARKING), gc_state is: %x", actual);
 
       // Old generation marking is allowed in all states.
       if (!VerifyThreadGCState::verify_gc_state(actual, expected)) {
@@ -848,8 +845,6 @@ void ShenandoahVerifier::verify_at_safepoint(const char* label,
       VerifyThreadGCState vtgcs(label, expected);
       Threads::java_threads_do(&vtgcs);
     }
-
-
   }
 
   // Deactivate barriers temporarily: Verifier wants plain heap accesses


### PR DESCRIPTION
This change sets the MARKING bit of _gc_state whenever either Young marking or Old marking is active.  With this change, barrier code more closely resembles the code in the original single-generation Shenandoah.  The performance impact is negligible.  The primary benefit is to simplify code reviews and clarify that the addition of generational mode to Shenandoah does not negatively impact performance of single-generation Shenandoah.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed (1 review required, with at least 1 [Committer](https://openjdk.org/bylaws#committer))

### Issue
 * [JDK-8314777](https://bugs.openjdk.org/browse/JDK-8314777): GenShen: Alias young and old marking bits to legacy Shenandoah marking bit in gc state (**Bug** - P3)


### Reviewers
 * [William Kemper](https://openjdk.org/census#wkemper) (@earthling-amzn - Committer)
 * [Y. Srinivas Ramakrishna](https://openjdk.org/census#ysr) (@ysramakrishna - Committer) ⚠️ Review applies to [2aaf20b5](https://git.openjdk.org/shenandoah/pull/309/files/2aaf20b525954c367e71223cc83abc17189e595e)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/shenandoah.git pull/309/head:pull/309` \
`$ git checkout pull/309`

Update a local copy of the PR: \
`$ git checkout pull/309` \
`$ git pull https://git.openjdk.org/shenandoah.git pull/309/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 309`

View PR using the GUI difftool: \
`$ git pr show -t 309`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/shenandoah/pull/309.diff">https://git.openjdk.org/shenandoah/pull/309.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/shenandoah/pull/309#issuecomment-1688709205)