### PR TITLE
8314972: GenShen: promote_in_place needs to prepare remembered set before it enables old allocations within region

### DIFF
--- a/src/hotspot/share/gc/shenandoah/shenandoahHeapRegion.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahHeapRegion.cpp
@@ -1015,6 +1015,35 @@ void ShenandoahHeapRegion::promote_in_place() {
   ShenandoahYoungGeneration* young_gen = heap->young_generation();
   size_t region_size_bytes = ShenandoahHeapRegion::region_size_bytes();
 
+  assert(top() == tams, "Cannot promote regions in place if top has advanced beyond TAMS");
+
+  // Since this region may have served previously as OLD, it may hold obsolete object range info.
+  heap->card_scan()->reset_object_range(bottom(), end());
+  heap->card_scan()->mark_range_as_dirty(bottom(), top() - bottom());
+
+  // TODO: use an existing coalesce-and-fill function rather than
+  // replicating the code here.
+  HeapWord* obj_addr = bottom();
+  while (obj_addr < tams) {
+    oop obj = cast_to_oop(obj_addr);
+    if (marking_context->is_marked(obj)) {
+      assert(obj->klass() != NULL, "klass should not be NULL");
+      // This thread is responsible for registering all objects in this region.  No need for lock.
+      heap->card_scan()->register_object_without_lock(obj_addr);
+      obj_addr += obj->size();
+    } else {
+      HeapWord* next_marked_obj = marking_context->get_next_marked_addr(obj_addr, tams);
+      assert(next_marked_obj <= tams, "next marked object cannot exceed tams");
+      size_t fill_size = next_marked_obj - obj_addr;
+      assert(fill_size >= ShenandoahHeap::min_fill_size(), "previously allocated objects known to be larger than min_size");
+      ShenandoahHeap::fill_with_object(obj_addr, fill_size);
+      heap->card_scan()->register_object_without_lock(obj_addr);
+      obj_addr = next_marked_obj;
+    }
+  }
+  // We do not need to scan above TAMS because restored top equals tams
+  assert(obj_addr == tams, "Expect loop to terminate when obj_addr equals tams");
+
   {
     ShenandoahHeapLocker locker(heap->lock());
 
@@ -1051,36 +1080,6 @@ void ShenandoahHeapRegion::promote_in_place() {
     // add_old_collector_free_region() increases promoted_reserve() if available space exceeds PLAB::min_size()
     heap->free_set()->add_old_collector_free_region(this);
   }
-
-  assert(top() == tams, "Cannot promote regions in place if top has advanced beyond TAMS");
-
-  // Since this region may have served previously as OLD, it may hold obsolete object range info.
-  heap->card_scan()->reset_object_range(bottom(), end());
-  heap->card_scan()->mark_range_as_dirty(bottom(), top() - bottom());
-
-  // TODO: use an existing coalesce-and-fill function rather than
-  // replicating the code here.
-  HeapWord* obj_addr = bottom();
-  while (obj_addr < tams) {
-    oop obj = cast_to_oop(obj_addr);
-    if (marking_context->is_marked(obj)) {
-      assert(obj->klass() != NULL, "klass should not be NULL");
-      // This thread is responsible for registering all objects in this region.  No need for lock.
-      heap->card_scan()->register_object_without_lock(obj_addr);
-      obj_addr += obj->size();
-    } else {
-      HeapWord* next_marked_obj = marking_context->get_next_marked_addr(obj_addr, tams);
-      assert(next_marked_obj <= tams, "next marked object cannot exceed tams");
-      size_t fill_size = next_marked_obj - obj_addr;
-      assert(fill_size >= ShenandoahHeap::min_fill_size(), "previously allocated objects known to be larger than min_size");
-      ShenandoahHeap::fill_with_object(obj_addr, fill_size);
-      heap->card_scan()->register_object_without_lock(obj_addr);
-      obj_addr = next_marked_obj;
-    }
-  }
-
-  // We do not need to scan above TAMS because top equals tams
-  assert(obj_addr == tams, "Expect loop to terminate when obj_addr equals tams");
 }
 
 void ShenandoahHeapRegion::promote_humongous() {

--- a/src/hotspot/share/gc/shenandoah/shenandoahHeapRegion.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahHeapRegion.cpp
@@ -1015,11 +1015,11 @@ void ShenandoahHeapRegion::promote_in_place() {
   ShenandoahYoungGeneration* young_gen = heap->young_generation();
   size_t region_size_bytes = ShenandoahHeapRegion::region_size_bytes();
 
-  assert(top() == tams, "Cannot promote regions in place if top has advanced beyond TAMS");
+  assert(get_top_before_promote() == tams, "Cannot promote regions in place if top has advanced beyond TAMS");
 
   // Since this region may have served previously as OLD, it may hold obsolete object range info.
   heap->card_scan()->reset_object_range(bottom(), end());
-  heap->card_scan()->mark_range_as_dirty(bottom(), top() - bottom());
+  heap->card_scan()->mark_range_as_dirty(bottom(), get_top_before_promote() - bottom());
 
   // TODO: use an existing coalesce-and-fill function rather than
   // replicating the code here.


### PR DESCRIPTION
An error in the original implementation left us vulnerable to a race between a worker thread which is promoting a region in place and another worker or mutator thread who is allocating memory for old objects within the same region.

This PR prevents this race by requiring the worker thread that promotes a region in place to finish the preparation of the region's remembered set before it makes the region available to other threads for allocation of old-gen memory.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed (1 review required, with at least 1 [Committer](https://openjdk.org/bylaws#committer))

### Issue
 * [JDK-8314972](https://bugs.openjdk.org/browse/JDK-8314972): GenShen: promote_in_place needs to prepare remembered set before it enables old allocations within region (**Bug** - P2)


### Reviewers
 * [Y. Srinivas Ramakrishna](https://openjdk.org/census#ysr) (@ysramakrishna - Committer) ⚠️ Review applies to [96ca2bea](https://git.openjdk.org/shenandoah/pull/310/files/96ca2bea0cb078d66f75683c484c75e2d8f65f35)
 * [William Kemper](https://openjdk.org/census#wkemper) (@earthling-amzn - Committer) ⚠️ Review applies to [96ca2bea](https://git.openjdk.org/shenandoah/pull/310/files/96ca2bea0cb078d66f75683c484c75e2d8f65f35)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/shenandoah.git pull/310/head:pull/310` \
`$ git checkout pull/310`

Update a local copy of the PR: \
`$ git checkout pull/310` \
`$ git pull https://git.openjdk.org/shenandoah.git pull/310/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 310`

View PR using the GUI difftool: \
`$ git pr show -t 310`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/shenandoah/pull/310.diff">https://git.openjdk.org/shenandoah/pull/310.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/shenandoah/pull/310#issuecomment-1693622806)