### PR TITLE
JDK-8315478: GenShen: Tolerate round-off errors in preselected promotion budget

### DIFF
--- a/src/hotspot/share/gc/shenandoah/shenandoahGeneration.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahGeneration.cpp
@@ -394,7 +394,8 @@ void ShenandoahGeneration::adjust_evacuation_budgets(ShenandoahHeap* heap, Shena
   // and promotion reserves.  Try shrinking OLD now in case that gives us a bit more runway for mutator allocations during
   // evac and update phases.
   size_t old_consumed = old_evacuated_committed + young_advance_promoted_reserve_used;
-  assert(old_available >= old_consumed, "Cannot consume more than is available");
+  assert(old_available >= old_consumed, "Cannot consume (" SIZE_FORMAT ") more than is available (" SIZE_FORMAT ")",
+         old_consumed, old_available);
   size_t excess_old = old_available - old_consumed;
   size_t unaffiliated_old_regions = old_generation->free_unaffiliated_regions();
   size_t unaffiliated_old = unaffiliated_old_regions * region_size_bytes;
@@ -599,6 +600,8 @@ size_t ShenandoahGeneration::select_aged_regions(size_t old_available, size_t nu
   // Sort in increasing order according to live data bytes.  Note that candidates represents the number of regions
   // that qualify to be promoted by evacuation.
   if (candidates > 0) {
+    size_t selected_regions = 0;
+    size_t selected_live = 0;
     QuickSort::sort<AgedRegionData>(sorted_regions, candidates, compare_by_aged_live, false);
     for (size_t i = 0; i < candidates; i++) {
       size_t region_live_data = sorted_regions[i]._live_data;
@@ -607,6 +610,8 @@ size_t ShenandoahGeneration::select_aged_regions(size_t old_available, size_t nu
         ShenandoahHeapRegion* region = sorted_regions[i]._region;
         old_consumed += promotion_need;
         candidate_regions_for_promotion_by_copy[region->index()] = true;
+        selected_regions++;
+        selected_live += region_live_data;
       } else {
         // We rejected this promotable region from the collection set because we had no room to hold its copy.
         // Add this region to promo potential for next GC.
@@ -615,6 +620,9 @@ size_t ShenandoahGeneration::select_aged_regions(size_t old_available, size_t nu
       // We keep going even if one region is excluded from selection because we need to accumulate all eligible
       // regions that are not preselected into promo_potential
     }
+    log_info(gc)("Preselected " SIZE_FORMAT " regions containing " SIZE_FORMAT " live bytes,"
+                 " consuming: " SIZE_FORMAT " of budgeted: " SIZE_FORMAT,
+                 selected_regions, selected_live, old_consumed, old_available);
   }
   heap->set_pad_for_promote_in_place(promote_in_place_pad);
   heap->set_promotion_potential(promo_potential);


### PR DESCRIPTION
An assert failure identified an error in previous implementation.  See JBS ticket for description of issue and reproducer.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed (1 review required, with at least 1 [Committer](https://openjdk.org/bylaws#committer))

### Issue
 * [JDK-8315478](https://bugs.openjdk.org/browse/JDK-8315478): GenShen: Tolerate round-off errors in preselected promotion budget (**Sub-task** - P3)


### Reviewers
 * [William Kemper](https://openjdk.org/census#wkemper) (@earthling-amzn - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/shenandoah.git pull/317/head:pull/317` \
`$ git checkout pull/317`

Update a local copy of the PR: \
`$ git checkout pull/317` \
`$ git pull https://git.openjdk.org/shenandoah.git pull/317/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 317`

View PR using the GUI difftool: \
`$ git pr show -t 317`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/shenandoah/pull/317.diff">https://git.openjdk.org/shenandoah/pull/317.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/shenandoah/pull/317#issuecomment-1703028347)