### PR TITLE
8315875: GenShen: Remove heap mode check from ShenandoahInitLogger

### DIFF
--- a/src/hotspot/share/gc/shenandoah/shenandoahArguments.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahArguments.cpp
@@ -29,6 +29,7 @@
 #include "gc/shared/workerPolicy.hpp"
 #include "gc/shenandoah/shenandoahArguments.hpp"
 #include "gc/shenandoah/shenandoahCollectorPolicy.hpp"
+#include "gc/shenandoah/shenandoahGenerationalHeap.hpp"
 #include "gc/shenandoah/shenandoahHeap.inline.hpp"
 #include "gc/shenandoah/shenandoahHeapRegion.hpp"
 #include "runtime/globals_extension.hpp"
@@ -206,5 +207,8 @@ void ShenandoahArguments::initialize_alignments() {
 }
 
 CollectedHeap* ShenandoahArguments::create_heap() {
+  if (strcmp(ShenandoahGCMode, "generational") == 0) {
+    return new ShenandoahGenerationalHeap(new ShenandoahCollectorPolicy());
+  }
   return new ShenandoahHeap(new ShenandoahCollectorPolicy());
 }

--- a/src/hotspot/share/gc/shenandoah/shenandoahGenerationalHeap.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahGenerationalHeap.cpp
@@ -1,0 +1,73 @@
+/*
+ * Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ *
+ */
+
+#include "precompiled.hpp"
+
+#include "gc/shenandoah/shenandoahGenerationalHeap.hpp"
+#include "gc/shenandoah/shenandoahInitLogger.hpp"
+#include "gc/shenandoah/shenandoahOldGeneration.hpp"
+#include "gc/shenandoah/shenandoahYoungGeneration.hpp"
+
+#include "logging/log.hpp"
+
+class ShenandoahGenerationalInitLogger : public ShenandoahInitLogger {
+public:
+  static void print() {
+    ShenandoahGenerationalInitLogger logger;
+    logger.print_all();
+  }
+
+  void print_heap() override {
+    ShenandoahInitLogger::print_heap();
+
+    ShenandoahGenerationalHeap* heap = ShenandoahGenerationalHeap::heap();
+
+    ShenandoahYoungGeneration* young = heap->young_generation();
+    log_info(gc, init)("Young Generation Soft Size: " PROPERFMT, PROPERFMTARGS(young->soft_max_capacity()));
+    log_info(gc, init)("Young Generation Max: " PROPERFMT, PROPERFMTARGS(young->max_capacity()));
+
+    ShenandoahOldGeneration* old = heap->old_generation();
+    log_info(gc, init)("Old Generation Soft Size: " PROPERFMT, PROPERFMTARGS(old->soft_max_capacity()));
+    log_info(gc, init)("Old Generation Max: " PROPERFMT, PROPERFMTARGS(old->max_capacity()));
+  }
+
+protected:
+  void print_gc_specific() override {
+    ShenandoahInitLogger::print_gc_specific();
+
+    ShenandoahGenerationalHeap* heap = ShenandoahGenerationalHeap::heap();
+    log_info(gc, init)("Young Heuristics: %s", heap->young_generation()->heuristics()->name());
+    log_info(gc, init)("Old Heuristics: %s", heap->old_generation()->heuristics()->name());
+  }
+};
+
+ShenandoahGenerationalHeap* ShenandoahGenerationalHeap::heap() {
+  CollectedHeap* heap = Universe::heap();
+  return checked_cast<ShenandoahGenerationalHeap*>(heap);
+}
+
+void ShenandoahGenerationalHeap::print_init_logger() const {
+  ShenandoahGenerationalInitLogger logger;
+  logger.print_all();
+}

--- a/src/hotspot/share/gc/shenandoah/shenandoahGenerationalHeap.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahGenerationalHeap.cpp
@@ -25,6 +25,7 @@
 #include "precompiled.hpp"
 
 #include "gc/shenandoah/shenandoahGenerationalHeap.hpp"
+#include "gc/shenandoah/shenandoahHeap.inline.hpp"
 #include "gc/shenandoah/shenandoahInitLogger.hpp"
 #include "gc/shenandoah/shenandoahOldGeneration.hpp"
 #include "gc/shenandoah/shenandoahYoungGeneration.hpp"

--- a/src/hotspot/share/gc/shenandoah/shenandoahGenerationalHeap.hpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahGenerationalHeap.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, Red Hat, Inc. All rights reserved.
+ * Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -22,18 +22,18 @@
  *
  */
 
-#ifndef SHARE_GC_SHENANDOAH_SHENANDOAHINITLOGGER_HPP
-#define SHARE_GC_SHENANDOAH_SHENANDOAHINITLOGGER_HPP
+#ifndef SHARE_GC_SHENANDOAH_SHENANDOAHGENERATIONALHEAP
+#define SHARE_GC_SHENANDOAH_SHENANDOAHGENERATIONALHEAP
 
-#include "gc/shared/gcInitLogger.hpp"
+#include "gc/shenandoah/shenandoahHeap.hpp"
 
-class ShenandoahInitLogger : public GCInitLogger {
-protected:
-  void print_heap() override;
-  void print_gc_specific() override;
-
+class ShenandoahGenerationalHeap : public ShenandoahHeap {
 public:
-  static void print();
+  explicit ShenandoahGenerationalHeap(ShenandoahCollectorPolicy* policy) : ShenandoahHeap(policy) {}
+
+  static ShenandoahGenerationalHeap* heap();
+
+  void print_init_logger() const override;
 };
 
-#endif // SHARE_GC_SHENANDOAH_SHENANDOAHINITLOGGER_HPP
+#endif //SHARE_GC_SHENANDOAH_SHENANDOAHGENERATIONALHEAP

--- a/src/hotspot/share/gc/shenandoah/shenandoahHeap.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahHeap.cpp
@@ -487,9 +487,13 @@ jint ShenandoahHeap::initialize() {
   _control_thread = new ShenandoahControlThread();
   _regulator_thread = new ShenandoahRegulatorThread(_control_thread);
 
-  ShenandoahInitLogger::print();
+  print_init_logger();
 
   return JNI_OK;
+}
+
+void ShenandoahHeap::print_init_logger() const {
+  ShenandoahInitLogger::print();
 }
 
 size_t ShenandoahHeap::max_size_for(ShenandoahGeneration* generation) const {

--- a/src/hotspot/share/gc/shenandoah/shenandoahHeap.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahHeap.cpp
@@ -730,6 +730,9 @@ void ShenandoahHeap::post_initialize() {
   JFR_ONLY(ShenandoahJFRSupport::register_jfr_type_serializers());
 }
 
+ShenandoahHeuristics* ShenandoahHeap::heuristics() {
+  return _global_generation->heuristics();
+}
 
 ShenandoahOldHeuristics* ShenandoahHeap::old_heuristics() {
   return (ShenandoahOldHeuristics*) _old_generation->heuristics();

--- a/src/hotspot/share/gc/shenandoah/shenandoahHeap.hpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahHeap.hpp
@@ -198,7 +198,7 @@ public:
   jint initialize() override;
   void post_initialize() override;
   void initialize_heuristics_generations();
-
+  virtual void print_init_logger() const;
   void initialize_serviceability() override;
 
   void print_on(outputStream* st)              const override;

--- a/src/hotspot/share/gc/shenandoah/shenandoahHeap.hpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahHeap.hpp
@@ -179,6 +179,7 @@ public:
     _gc_generation = generation;
   }
 
+  ShenandoahHeuristics* heuristics();
   ShenandoahOldHeuristics* old_heuristics();
   ShenandoahYoungHeuristics* young_heuristics();
 

--- a/src/hotspot/share/gc/shenandoah/shenandoahInitLogger.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahInitLogger.cpp
@@ -24,63 +24,33 @@
  */
 
 #include "precompiled.hpp"
+#include "gc/shenandoah/shenandoahGlobalGeneration.hpp"
 #include "gc/shenandoah/shenandoahHeap.inline.hpp"
 #include "gc/shenandoah/shenandoahHeapRegion.hpp"
 #include "gc/shenandoah/shenandoahInitLogger.hpp"
-#include "gc/shenandoah/shenandoahOldGeneration.hpp"
-#include "gc/shenandoah/shenandoahYoungGeneration.hpp"
 #include "gc/shenandoah/heuristics/shenandoahHeuristics.hpp"
 #include "gc/shenandoah/mode/shenandoahMode.hpp"
 #include "logging/log.hpp"
-#include "runtime/globals.hpp"
 #include "utilities/globalDefinitions.hpp"
-
-void ShenandoahInitLogger::print_heap() {
-  GCInitLogger::print_heap();
-
-  ShenandoahHeap* heap = ShenandoahHeap::heap();
-
-  log_info(gc, init)("Mode: %s",
-                     heap->mode()->name());
-
-  if (!heap->mode()->is_generational()) {
-    log_info(gc, init)("Heuristics: %s", heap->global_generation()->heuristics()->name());
-  } else {
-    log_info(gc, init)("Young Heuristics: %s", heap->young_generation()->heuristics()->name());
-    log_info(gc, init)("Young Generation Soft Size: " SIZE_FORMAT "%s",
-                       byte_size_in_proper_unit(heap->young_generation()->soft_max_capacity()),
-                       proper_unit_for_byte_size(heap->young_generation()->soft_max_capacity()));
-    log_info(gc, init)("Young Generation Max: " SIZE_FORMAT "%s",
-                       byte_size_in_proper_unit(heap->young_generation()->max_capacity()),
-                       proper_unit_for_byte_size(heap->young_generation()->max_capacity()));
-    log_info(gc, init)("Old Heuristics: %s", heap->old_generation()->heuristics()->name());
-    log_info(gc, init)("Old Generation Soft Size: " SIZE_FORMAT "%s",
-                       byte_size_in_proper_unit(heap->old_generation()->soft_max_capacity()),
-                       proper_unit_for_byte_size(heap->old_generation()->soft_max_capacity()));
-    log_info(gc, init)("Old Generation Max: " SIZE_FORMAT "%s",
-                       byte_size_in_proper_unit(heap->old_generation()->max_capacity()),
-                       proper_unit_for_byte_size(heap->old_generation()->max_capacity()));
-  }
-
-
-
-  log_info(gc, init)("Heap Region Count: " SIZE_FORMAT,
-                     ShenandoahHeapRegion::region_count());
-
-  log_info(gc, init)("Heap Region Size: " SIZE_FORMAT "%s",
-                     byte_size_in_exact_unit(ShenandoahHeapRegion::region_size_bytes()),
-                     exact_unit_for_byte_size(ShenandoahHeapRegion::region_size_bytes()));
-
-  log_info(gc, init)("TLAB Size Max: " SIZE_FORMAT "%s",
-                     byte_size_in_exact_unit(ShenandoahHeapRegion::max_tlab_size_bytes()),
-                     exact_unit_for_byte_size(ShenandoahHeapRegion::max_tlab_size_bytes()));
-
-  log_info(gc, init)("Humongous Object Threshold: " SIZE_FORMAT "%s",
-          byte_size_in_exact_unit(ShenandoahHeapRegion::humongous_threshold_bytes()),
-          exact_unit_for_byte_size(ShenandoahHeapRegion::humongous_threshold_bytes()));
-}
 
 void ShenandoahInitLogger::print() {
   ShenandoahInitLogger init_log;
   init_log.print_all();
+}
+
+void ShenandoahInitLogger::print_heap() {
+  GCInitLogger::print_heap();
+
+  log_info(gc, init)("Heap Region Count: " SIZE_FORMAT, ShenandoahHeapRegion::region_count());
+  log_info(gc, init)("Heap Region Size: " PROPERFMT, PROPERFMTARGS(ShenandoahHeapRegion::region_size_bytes()));
+  log_info(gc, init)("TLAB Size Max: " PROPERFMT, PROPERFMTARGS(ShenandoahHeapRegion::max_tlab_size_bytes()));
+  log_info(gc, init)("Humongous Object Threshold: " PROPERFMT, PROPERFMTARGS(ShenandoahHeapRegion::humongous_threshold_bytes()));
+}
+
+void ShenandoahInitLogger::print_gc_specific() {
+  GCInitLogger::print_gc_specific();
+
+  ShenandoahHeap* heap = ShenandoahHeap::heap();
+  log_info(gc, init)("Mode: %s", heap->mode()->name());
+  log_info(gc, init)("Heuristics: %s", heap->global_generation()->heuristics()->name());
 }

--- a/src/hotspot/share/gc/shenandoah/shenandoahInitLogger.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahInitLogger.cpp
@@ -24,7 +24,6 @@
  */
 
 #include "precompiled.hpp"
-#include "gc/shenandoah/shenandoahGlobalGeneration.hpp"
 #include "gc/shenandoah/shenandoahHeap.inline.hpp"
 #include "gc/shenandoah/shenandoahHeapRegion.hpp"
 #include "gc/shenandoah/shenandoahInitLogger.hpp"
@@ -52,5 +51,5 @@ void ShenandoahInitLogger::print_gc_specific() {
 
   ShenandoahHeap* heap = ShenandoahHeap::heap();
   log_info(gc, init)("Mode: %s", heap->mode()->name());
-  log_info(gc, init)("Heuristics: %s", heap->global_generation()->heuristics()->name());
+  log_info(gc, init)("Heuristics: %s", heap->heuristics()->name());
 }


### PR DESCRIPTION
There are some additional improvements to the init logger that should be easy to upstream.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed (1 review required, with at least 1 [Committer](https://openjdk.org/bylaws#committer))

### Issue
 * [JDK-8315875](https://bugs.openjdk.org/browse/JDK-8315875): GenShen: Remove heap mode check from ShenandoahInitLogger (**Task** - P4)


### Reviewers
 * [Kelvin Nilsen](https://openjdk.org/census#kdnilsen) (@kdnilsen - Committer) ⚠️ Review applies to [9ef0a6d6](https://git.openjdk.org/shenandoah/pull/320/files/9ef0a6d67a293f0af01d858bbc0ca2e78f0cef10)
 * [Aleksey Shipilev](https://openjdk.org/census#shade) (@shipilev - Committer) ⚠️ Review applies to [9960fe7d](https://git.openjdk.org/shenandoah/pull/320/files/9960fe7d71fe9d664f04d7f7efc87576d146b5ec)
 * [Y. Srinivas Ramakrishna](https://openjdk.org/census#ysr) (@ysramakrishna - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/shenandoah.git pull/320/head:pull/320` \
`$ git checkout pull/320`

Update a local copy of the PR: \
`$ git checkout pull/320` \
`$ git pull https://git.openjdk.org/shenandoah.git pull/320/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 320`

View PR using the GUI difftool: \
`$ git pr show -t 320`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/shenandoah/pull/320.diff">https://git.openjdk.org/shenandoah/pull/320.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/shenandoah/pull/320#issuecomment-1710619517)