### PR TITLE
8316137: GenShen: missing ShenandoahCardBarrier filter

### DIFF
--- a/src/hotspot/share/gc/shenandoah/shenandoahBarrierSet.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahBarrierSet.cpp
@@ -53,7 +53,7 @@ ShenandoahBarrierSet::ShenandoahBarrierSet(ShenandoahHeap* heap, MemRegion heap_
   _satb_mark_queue_buffer_allocator("SATB Buffer Allocator", ShenandoahSATBBufferSize),
   _satb_mark_queue_set(&_satb_mark_queue_buffer_allocator)
 {
-  if (heap->mode()->is_generational()) {
+  if (ShenandoahCardBarrier) {
     _card_table = new ShenandoahCardTable(heap_region);
     _card_table->initialize();
   }

--- a/src/hotspot/share/gc/shenandoah/shenandoahBarrierSet.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahBarrierSet.cpp
@@ -158,9 +158,7 @@ void ShenandoahBarrierSet::clone_barrier_runtime(oop src) {
 }
 
 void ShenandoahBarrierSet::write_ref_array(HeapWord* start, size_t count) {
-  if (!_heap->mode()->is_generational()) {
-    return;
-  }
+  assert(ShenandoahCardBarrier, "Did you mean to enable ShenandoahCardBarrier?");
 
   HeapWord* end = (HeapWord*)((char*) start + (count * heapOopSize));
   // In the case of compressed oops, start and end may potentially be misaligned;

--- a/src/hotspot/share/gc/shenandoah/shenandoahBarrierSet.inline.hpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahBarrierSet.inline.hpp
@@ -376,7 +376,9 @@ bool ShenandoahBarrierSet::AccessBarrier<decorators, BarrierSetT>::oop_arraycopy
   ShenandoahBarrierSet* bs = ShenandoahBarrierSet::barrier_set();
   bs->arraycopy_barrier(src, dst, length);
   bool result = Raw::oop_arraycopy_in_heap(src_obj, src_offset_in_bytes, src_raw, dst_obj, dst_offset_in_bytes, dst_raw, length);
-  bs->write_ref_array((HeapWord*) dst, length);
+  if (ShenandoahCardBarrier) {
+    bs->write_ref_array((HeapWord*) dst, length);
+  }
   return result;
 }
 

--- a/src/hotspot/share/gc/shenandoah/shenandoahBarrierSet.inline.hpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahBarrierSet.inline.hpp
@@ -187,10 +187,9 @@ inline void ShenandoahBarrierSet::keep_alive_if_weak(DecoratorSet decorators, oo
 
 template <DecoratorSet decorators, typename T>
 inline void ShenandoahBarrierSet::write_ref_field_post(T* field) {
-  if (ShenandoahHeap::heap()->mode()->is_generational()) {
-    volatile CardTable::CardValue* byte = card_table()->byte_for(field);
-    *byte = CardTable::dirty_card_val();
-  }
+  assert(ShenandoahCardBarrier, "Error");
+  volatile CardTable::CardValue* byte = card_table()->byte_for(field);
+  *byte = CardTable::dirty_card_val();
 }
 
 template <typename T>
@@ -280,8 +279,10 @@ inline void ShenandoahBarrierSet::AccessBarrier<decorators, BarrierSetT>::oop_st
   shenandoah_assert_not_forwarded_except  (addr, value, value == nullptr || ShenandoahHeap::heap()->cancelled_gc() || !ShenandoahHeap::heap()->is_concurrent_mark_in_progress());
 
   oop_store_common(addr, value);
-  ShenandoahBarrierSet* bs = ShenandoahBarrierSet::barrier_set();
-  bs->write_ref_field_post<decorators>(addr);
+  if (ShenandoahCardBarrier) {
+    ShenandoahBarrierSet* bs = ShenandoahBarrierSet::barrier_set();
+    bs->write_ref_field_post<decorators>(addr);
+  }
 }
 
 template <DecoratorSet decorators, typename BarrierSetT>
@@ -303,7 +304,9 @@ inline oop ShenandoahBarrierSet::AccessBarrier<decorators, BarrierSetT>::oop_ato
   assert((decorators & (AS_NO_KEEPALIVE | ON_UNKNOWN_OOP_REF)) == 0, "must be absent");
   ShenandoahBarrierSet* bs = ShenandoahBarrierSet::barrier_set();
   oop result = bs->oop_cmpxchg(decorators, addr, compare_value, new_value);
-  bs->write_ref_field_post<decorators>(addr);
+  if (ShenandoahCardBarrier) {
+    bs->write_ref_field_post<decorators>(addr);
+  }
   return result;
 }
 
@@ -314,7 +317,9 @@ inline oop ShenandoahBarrierSet::AccessBarrier<decorators, BarrierSetT>::oop_ato
   DecoratorSet resolved_decorators = AccessBarrierSupport::resolve_possibly_unknown_oop_ref_strength<decorators>(base, offset);
   auto addr = AccessInternal::oop_field_addr<decorators>(base, offset);
   oop result = bs->oop_cmpxchg(resolved_decorators, addr, compare_value, new_value);
-  bs->write_ref_field_post<decorators>(addr);
+  if (ShenandoahCardBarrier) {
+    bs->write_ref_field_post<decorators>(addr);
+  }
   return result;
 }
 
@@ -332,7 +337,9 @@ inline oop ShenandoahBarrierSet::AccessBarrier<decorators, BarrierSetT>::oop_ato
   assert((decorators & (AS_NO_KEEPALIVE | ON_UNKNOWN_OOP_REF)) == 0, "must be absent");
   ShenandoahBarrierSet* bs = ShenandoahBarrierSet::barrier_set();
   oop result = bs->oop_xchg(decorators, addr, new_value);
-  bs->write_ref_field_post<decorators>(addr);
+  if (ShenandoahCardBarrier) {
+    bs->write_ref_field_post<decorators>(addr);
+  }
   return result;
 }
 
@@ -343,7 +350,9 @@ inline oop ShenandoahBarrierSet::AccessBarrier<decorators, BarrierSetT>::oop_ato
   DecoratorSet resolved_decorators = AccessBarrierSupport::resolve_possibly_unknown_oop_ref_strength<decorators>(base, offset);
   auto addr = AccessInternal::oop_field_addr<decorators>(base, offset);
   oop result = bs->oop_xchg(resolved_decorators, addr, new_value);
-  bs->write_ref_field_post<decorators>(addr);
+  if (ShenandoahCardBarrier) {
+    bs->write_ref_field_post<decorators>(addr);
+  }
   return result;
 }
 

--- a/src/hotspot/share/gc/shenandoah/shenandoahBarrierSet.inline.hpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahBarrierSet.inline.hpp
@@ -187,7 +187,7 @@ inline void ShenandoahBarrierSet::keep_alive_if_weak(DecoratorSet decorators, oo
 
 template <DecoratorSet decorators, typename T>
 inline void ShenandoahBarrierSet::write_ref_field_post(T* field) {
-  assert(ShenandoahCardBarrier, "Error");
+  assert(ShenandoahCardBarrier, "Did you mean to enable ShenandoahCardBarrier?");
   volatile CardTable::CardValue* byte = card_table()->byte_for(field);
   *byte = CardTable::dirty_card_val();
 }


### PR DESCRIPTION
A few instances of (inline) calls to the card-barrier code from the VM missed the idiomatic changes in the parent ticket https://bugs.openjdk.org/browse/JDK-8315247. This PR takes care of the cases that I had previously missed where we were doing a generational mode check on the heap.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed (1 review required, with at least 1 [Committer](https://openjdk.org/bylaws#committer))

### Issue
 * [JDK-8316137](https://bugs.openjdk.org/browse/JDK-8316137): GenShen: missing ShenandoahCardBarrier filter (**Sub-task** - P3)


### Reviewers
 * [William Kemper](https://openjdk.org/census#wkemper) (@earthling-amzn - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/shenandoah.git pull/322/head:pull/322` \
`$ git checkout pull/322`

Update a local copy of the PR: \
`$ git checkout pull/322` \
`$ git pull https://git.openjdk.org/shenandoah.git pull/322/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 322`

View PR using the GUI difftool: \
`$ git pr show -t 322`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/shenandoah/pull/322.diff">https://git.openjdk.org/shenandoah/pull/322.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/shenandoah/pull/322#issuecomment-1716316854)