### PR TITLE
8316297: GenShen: Degenerated GCs fail to make progress

### DIFF
--- a/src/hotspot/share/gc/shenandoah/shenandoahGeneration.hpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahGeneration.hpp
@@ -124,6 +124,7 @@ private:
   virtual size_t free_unaffiliated_regions() const;
   size_t used() const override { return _used; }
   size_t available() const override;
+  size_t available_with_reserve() const;
 
   // Returns the memory available based on the _soft_ max heap capacity (soft_max_heap - used).
   // The soft max heap size may be adjusted lower than the max heap size to cause the trigger

--- a/src/hotspot/share/gc/shenandoah/shenandoahYoungGeneration.hpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahYoungGeneration.hpp
@@ -64,6 +64,9 @@ public:
   }
 
   size_t available() const override;
+
+  // Do not override available_with_reserve() because that needs to see memory reserved for Collector
+
   size_t soft_available() const override;
 };
 


### PR DESCRIPTION
A recent change to the implementation of ShenandoahYoungGeneration::available() resulted in a budgeting shortfall during degenerated GC.  The problem is that we degenerate after mutator allocations fail, at which time young available memory is in very short supply.  The change to available() caused us to only see the mutator budget, which has been depleted.  This resulted in a very high probability that degenerated GC would fail to make progress, forcing degenerated GC to upgrade to full GC.

This PR makes the Collector reserve memory visible to the function that computes evacuation budgets, thereby increasing the likelihood of a successful degenerated cycle and obviating the need for a Full GC.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed (1 review required, with at least 1 [Committer](https://openjdk.org/bylaws#committer))

### Issue
 * [JDK-8316297](https://bugs.openjdk.org/browse/JDK-8316297): GenShen: Degenerated GCs fail to make progress (**Bug** - P3)


### Reviewers
 * [William Kemper](https://openjdk.org/census#wkemper) (@earthling-amzn - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/shenandoah.git pull/324/head:pull/324` \
`$ git checkout pull/324`

Update a local copy of the PR: \
`$ git checkout pull/324` \
`$ git pull https://git.openjdk.org/shenandoah.git pull/324/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 324`

View PR using the GUI difftool: \
`$ git pr show -t 324`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/shenandoah/pull/324.diff">https://git.openjdk.org/shenandoah/pull/324.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/shenandoah/pull/324#issuecomment-1719584173)