### PR TITLE
8316299: GenShen: Reduce frequency of expedited GC

### DIFF
--- a/src/hotspot/share/gc/shenandoah/heuristics/shenandoahYoungHeuristics.cpp
+++ b/src/hotspot/share/gc/shenandoah/heuristics/shenandoahYoungHeuristics.cpp
@@ -135,25 +135,16 @@ bool ShenandoahYoungHeuristics::should_start_gc() {
   // be done, we start up the young-gen GC threads so they can do some of this old-gen work.  As implemented, promotion
   // gets priority over old-gen marking.
   ShenandoahHeap* heap = ShenandoahHeap::heap();
+
+  size_t promo_expedite_threshold = (heap->young_generation()->max_capacity() * ShenandoahEvacReserve) / 512;
   size_t promo_potential = heap->get_promotion_potential();
-  if (promo_potential > 0) {
+  if (promo_potential > promo_expedite_threshold) {
     // Detect unsigned arithmetic underflow
     assert(promo_potential < heap->capacity(), "Sanity");
     log_info(gc)("Trigger (%s): expedite promotion of " SIZE_FORMAT "%s",
                  _space_info->name(),
                  byte_size_in_proper_unit(promo_potential),
                  proper_unit_for_byte_size(promo_potential));
-    return true;
-  }
-
-  size_t promo_in_place_potential = heap->get_promotion_in_place_potential();
-  if (promo_in_place_potential > 0) {
-    // Detect unsigned arithmetic underflow
-    assert(promo_in_place_potential < heap->capacity(), "Sanity");
-    log_info(gc)("Trigger (%s): expedite promotion in place of " SIZE_FORMAT "%s",
-                 _space_info->name(),
-                 byte_size_in_proper_unit(promo_in_place_potential),
-                 proper_unit_for_byte_size(promo_in_place_potential));
     return true;
   }
 

--- a/src/hotspot/share/gc/shenandoah/shenandoahFullGC.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahFullGC.cpp
@@ -1556,7 +1556,6 @@ void ShenandoahFullGC::phase5_epilog() {
 
     // In case this Full GC resulted from degeneration, clear the tally on anticipated promotion.
     heap->clear_promotion_potential();
-    heap->clear_promotion_in_place_potential();
 
     if (heap->mode()->is_generational()) {
       // Invoke this in case we are able to transfer memory from OLD to YOUNG.

--- a/src/hotspot/share/gc/shenandoah/shenandoahGeneration.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahGeneration.cpp
@@ -532,9 +532,7 @@ size_t ShenandoahGeneration::select_aged_regions(size_t old_available, size_t nu
 
   size_t old_consumed = 0;
   size_t promo_potential = 0;
-  size_t anticipated_promote_in_place_live = 0;
 
-  heap->clear_promotion_in_place_potential();
   heap->clear_promotion_potential();
   size_t candidates = 0;
   size_t candidates_live = 0;
@@ -621,7 +619,6 @@ size_t ShenandoahGeneration::select_aged_regions(size_t old_available, size_t nu
         }
         else {
           anticipated_promote_in_place_regions++;
-          anticipated_promote_in_place_live += r->get_live_data_bytes();
         }
       }
     }
@@ -657,7 +654,6 @@ size_t ShenandoahGeneration::select_aged_regions(size_t old_available, size_t nu
   }
   heap->set_pad_for_promote_in_place(promote_in_place_pad);
   heap->set_promotion_potential(promo_potential);
-  heap->set_promotion_in_place_potential(anticipated_promote_in_place_live);
   return old_consumed;
 }
 

--- a/src/hotspot/share/gc/shenandoah/shenandoahGeneration.hpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahGeneration.hpp
@@ -85,12 +85,6 @@ private:
   // at or above tenure age and which contain more than ShenandoahOldGarbageThreshold
   // amounts of garbage.
   //
-  // A side effect performed by this function is to tally up the number of regions and
-  // the number of live bytes that we plan to promote-in-place during the current GC cycle.
-  // This information, which is stored with an invocation of heap->set_promotion_in_place_potential(),
-  // feeds into subsequent decisions about when to trigger the next GC and may identify
-  // special work to be done during this GC cycle if we choose to abbreviate it.
-  //
   // Returns bytes of old-gen memory consumed by selected aged regions
   size_t select_aged_regions(size_t old_available,
                              size_t num_regions, bool

--- a/src/hotspot/share/gc/shenandoah/shenandoahHeap.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahHeap.cpp
@@ -586,7 +586,6 @@ ShenandoahHeap::ShenandoahHeap(ShenandoahCollectorPolicy* policy) :
   _prepare_for_old_mark(false),
   _initial_size(0),
   _promotion_potential(0),
-  _promotion_in_place_potential(0),
   _committed(0),
   _max_workers(MAX3(ConcGCThreads, ParallelGCThreads, 1U)),
   _workers(nullptr),

--- a/src/hotspot/share/gc/shenandoah/shenandoahHeap.hpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahHeap.hpp
@@ -226,7 +226,6 @@ private:
            size_t _initial_size;
            size_t _minimum_size;
            size_t _promotion_potential;
-           size_t _promotion_in_place_potential;
            size_t _pad_for_promote_in_place;    // bytes of filler
            size_t _promotable_humongous_regions;
            size_t _promotable_humongous_usage;
@@ -452,10 +451,6 @@ public:
   inline void clear_promotion_potential() { _promotion_potential = 0; };
   inline void set_promotion_potential(size_t val) { _promotion_potential = val; };
   inline size_t get_promotion_potential() { return _promotion_potential; };
-
-  inline void clear_promotion_in_place_potential() { _promotion_in_place_potential = 0; };
-  inline void set_promotion_in_place_potential(size_t val) { _promotion_in_place_potential = val; };
-  inline size_t get_promotion_in_place_potential() { return _promotion_in_place_potential; };
 
   inline void set_pad_for_promote_in_place(size_t pad) { _pad_for_promote_in_place = pad; }
   inline size_t get_pad_for_promote_in_place() { return _pad_for_promote_in_place; }


### PR DESCRIPTION
We have found that expedited GCs too frequently yield very little benefit because they occur so soon after the previous GC that there has been no accumulation of garbage.

The primary motivation for expediting GC is to avoid a situation under which there is so much "promotion" work to be performed that the urgent need to reclaim garbage from young-generation is obstructed by this promotion work.

This PR ends the practice of expediting to support promotion in place.  The effort required to promote a region in place is minimal and unlikely to contend in a major way with young collection efforts.

This PR also reduces the likelihood that we will expedite for promotion by evacuation, because it requires the amount of accumulated promo potential to exceed a particular threshold.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed (1 review required, with at least 1 [Committer](https://openjdk.org/bylaws#committer))

### Issue
 * [JDK-8316299](https://bugs.openjdk.org/browse/JDK-8316299): GenShen: Reduce frequency of expedited GC (**Bug** - P3)


### Reviewers
 * [Aleksey Shipilev](https://openjdk.org/census#shade) (@shipilev - Committer) ⚠️ Review applies to [44b203a0](https://git.openjdk.org/shenandoah/pull/325/files/44b203a0d287b9b69fc4c50cbf812b2ccaea72f9)
 * [William Kemper](https://openjdk.org/census#wkemper) (@earthling-amzn - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/shenandoah.git pull/325/head:pull/325` \
`$ git checkout pull/325`

Update a local copy of the PR: \
`$ git checkout pull/325` \
`$ git pull https://git.openjdk.org/shenandoah.git pull/325/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 325`

View PR using the GUI difftool: \
`$ git pr show -t 325`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/shenandoah/pull/325.diff">https://git.openjdk.org/shenandoah/pull/325.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/shenandoah/pull/325#issuecomment-1719678818)