### PR TITLE
Purge pip regions from satb at update refs

### DIFF
--- a/src/hotspot/share/gc/shenandoah/shenandoahConcurrentGC.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahConcurrentGC.cpp
@@ -605,6 +605,10 @@ public:
 
   void heap_region_do(ShenandoahHeapRegion* r) {
     assert(!r->has_live(), "Region " SIZE_FORMAT " should have no live data", r->index());
+    // TODO: Isolate this generational shenandoah code from single-generation code
+    if (ShenandoahHeap::heap()->mode()->is_generational()) {
+      r->clear_top_before_promote();
+    }
     if (r->is_active()) {
       // Check if region needs updating its TAMS. We have updated it already during concurrent
       // reset, so it is very likely we don't need to do another write here.  Since most regions

--- a/src/hotspot/share/gc/shenandoah/shenandoahConcurrentGC.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahConcurrentGC.cpp
@@ -603,10 +603,16 @@ private:
 public:
   ShenandoahInitMarkUpdateRegionStateClosure() : _ctx(ShenandoahHeap::heap()->marking_context()) {}
 
+  // This iterator visits young-regions only at init_mark for young.  Visits young and old at init_mark for bootstrap old
+  // or global GC.
   void heap_region_do(ShenandoahHeapRegion* r) {
     assert(!r->has_live(), "Region " SIZE_FORMAT " should have no live data", r->index());
     // TODO: Isolate this generational shenandoah code from single-generation code
     if (ShenandoahHeap::heap()->mode()->is_generational()) {
+#undef KELVIN_DEBUG
+#ifdef KELVIN_DEBUG
+      log_info(gc)("Clearing top_before_promte for region " SIZE_FORMAT, r->index());
+#endif
       r->clear_top_before_promote();
     }
     if (r->is_active()) {

--- a/src/hotspot/share/gc/shenandoah/shenandoahFreeSet.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahFreeSet.cpp
@@ -713,6 +713,7 @@ HeapWord* ShenandoahFreeSet::try_allocate_in(ShenandoahHeapRegion* r, Shenandoah
   if (!r->is_affiliated()) {
     ShenandoahMarkingContext* const ctx = _heap->complete_marking_context();
     r->set_affiliation(req.affiliation());
+    r->clear_top_before_promote();
     if (r->is_old()) {
       // Any OLD region allocated during concurrent coalesce-and-fill does not need to be coalesced and filled because
       // all objects allocated within this region are above TAMS (and thus are implicitly marked).  In case this is an

--- a/src/hotspot/share/gc/shenandoah/shenandoahFullGC.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahFullGC.cpp
@@ -1327,6 +1327,10 @@ public:
   void heap_region_do(ShenandoahHeapRegion* r) {
     assert (!r->is_cset(), "cset regions should have been demoted already");
 
+    if (_is_generational) {
+      r->clear_top_before_promote();
+    }
+
     // Need to reset the complete-top-at-mark-start pointer here because
     // the complete marking bitmap is no longer valid. This ensures
     // size-based iteration in marked_object_iterate().

--- a/src/hotspot/share/gc/shenandoah/shenandoahGeneration.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahGeneration.cpp
@@ -494,7 +494,7 @@ static int compare_by_aged_live(AgedRegionData a, AgedRegionData b) {
   else return 0;
 }
 
-inline void assert_no_in_place_promotions() {
+inline void ShenandoahGeneration::assert_no_in_place_promotions() {
 #ifdef ASSERT
   class ShenandoahNoInPlacePromotions : public ShenandoahHeapRegionClosure {
   public:
@@ -503,7 +503,8 @@ inline void assert_no_in_place_promotions() {
              "Region " SIZE_FORMAT " should not be ready for in-place promotion", r->index());
     }
   } cl;
-  ShenandoahHeap::heap()->heap_region_iterate(&cl);
+  // Iterate only over the regions that belong to this generation.
+  heap_region_iterate(&cl);
 #endif
 }
 

--- a/src/hotspot/share/gc/shenandoah/shenandoahGeneration.hpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahGeneration.hpp
@@ -92,6 +92,8 @@ private:
 
   size_t available(size_t capacity) const;
 
+  inline void assert_no_in_place_promotions();
+
  public:
   ShenandoahGeneration(ShenandoahGenerationType type,
                        uint max_workers,

--- a/src/hotspot/share/gc/shenandoah/shenandoahHeapRegion.hpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahHeapRegion.hpp
@@ -353,6 +353,7 @@ public:
     return _index;
   }
 
+  inline void clear_top_before_promote();
   inline void save_top_before_promote();
   inline HeapWord* get_top_before_promote() const { return _top_before_promoted; }
   inline void restore_top_before_promote();

--- a/src/hotspot/share/gc/shenandoah/shenandoahHeapRegion.inline.hpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahHeapRegion.inline.hpp
@@ -251,6 +251,9 @@ inline void ShenandoahHeapRegion::save_top_before_promote() {
 
 inline void ShenandoahHeapRegion::restore_top_before_promote() {
   _top = _top_before_promoted;
+}
+
+inline void ShenandoahHeapRegion::clear_top_before_promote() {
   _top_before_promoted = nullptr;
  }
 

--- a/src/hotspot/share/gc/shenandoah/shenandoahSATBMarkQueueSet.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahSATBMarkQueueSet.cpp
@@ -65,7 +65,7 @@ public:
     //
     // TOOD: isolate this genshen code from single-generation code.
     if (_heap->mode()->is_generational()) {
-      return (_heap->is_in(entry) && _heap->heap_region_containing(entry)->get_top_before_promote() != nullptr) || 
+      return (_heap->is_in(entry) && _heap->heap_region_containing(entry)->get_top_before_promote() != nullptr) ||
         !_heap->requires_marking(entry);
     } else {
       return !_heap->requires_marking(entry);


### PR DESCRIPTION
DRAFT: This endeavors to fix a problem when pointers to dead objects residing in promoted in place regions are accidentally placed into the satb buffer (usually when a reference object is overwritten with null).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [ ] Commit message must refer to an issue
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Committer](https://openjdk.org/bylaws#committer))

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/shenandoah.git pull/330/head:pull/330` \
`$ git checkout pull/330`

Update a local copy of the PR: \
`$ git checkout pull/330` \
`$ git pull https://git.openjdk.org/shenandoah.git pull/330/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 330`

View PR using the GUI difftool: \
`$ git pr show -t 330`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/shenandoah/pull/330.diff">https://git.openjdk.org/shenandoah/pull/330.diff</a>

</details>
