### PR TITLE
8312117: GenShen: Preempt OLD marking more quickly when YOUNG triggers arise

### DIFF
--- a/src/hotspot/share/gc/shenandoah/shenandoahControlThread.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahControlThread.cpp
@@ -1100,8 +1100,8 @@ const char* ShenandoahControlThread::gc_mode_name(ShenandoahControlThread::GCMod
 void ShenandoahControlThread::set_gc_mode(ShenandoahControlThread::GCMode new_mode) {
   if (_mode != new_mode) {
     log_info(gc)("Transition from: %s to: %s", gc_mode_name(_mode), gc_mode_name(new_mode));
-    _mode = new_mode;
     MonitorLocker ml(&_regulator_lock, Mutex::_no_safepoint_check_flag);
+    _mode = new_mode;
     ml.notify_all();
   }
 }

--- a/src/hotspot/share/gc/shenandoah/shenandoahControlThread.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahControlThread.cpp
@@ -905,6 +905,7 @@ bool ShenandoahControlThread::request_concurrent_gc(ShenandoahGenerationType gen
     _requested_gc_cause = GCCause::_shenandoah_concurrent_gc;
     _requested_generation = generation;
     notify_control_thread();
+
     MonitorLocker ml(&_regulator_lock, Mutex::_no_safepoint_check_flag);
     while (_mode == none) {
       ml.wait();

--- a/src/hotspot/share/gc/shenandoah/shenandoahRegulatorThread.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahRegulatorThread.cpp
@@ -72,7 +72,7 @@ void ShenandoahRegulatorThread::regulate_concurrent_cycles() {
     ShenandoahControlThread::GCMode mode = _control_thread->gc_mode();
     if (mode == ShenandoahControlThread::none) {
       if (should_unload_classes()) {
-        if (_control_thread->request_concurrent_gc(ShenandoahControlThread::select_global_generation())) {
+        if (request_concurrent_gc(ShenandoahControlThread::select_global_generation())) {
           log_info(gc)("Heuristics request for global (unload classes) accepted.");
         }
       } else {
@@ -137,19 +137,41 @@ void ShenandoahRegulatorThread::regulator_sleep() {
   }
 
   os::naked_short_sleep(_sleep);
+  if (LogTarget(Info, gc, thread)::is_enabled()) {
+    double elapsed = os::elapsedTime() - current;
+    double hiccup = elapsed - double(_sleep);
+    if (hiccup > 0.0) {
+      log_info(gc, thread)("Regulator hiccup time: %.3fs", hiccup);
+    }
+  }
 }
 
 bool ShenandoahRegulatorThread::start_old_cycle() {
-  return !ShenandoahHeap::heap()->doing_mixed_evacuations() && !ShenandoahHeap::heap()->collection_set()->has_old_regions() &&
-    _old_heuristics->should_start_gc() && _control_thread->request_concurrent_gc(OLD);
+  // TODO: These first two checks might be vestigial
+  return !ShenandoahHeap::heap()->doing_mixed_evacuations()
+      && !ShenandoahHeap::heap()->collection_set()->has_old_regions()
+      && _old_heuristics->should_start_gc()
+      && request_concurrent_gc(OLD);
+}
+
+bool ShenandoahRegulatorThread::request_concurrent_gc(ShenandoahGenerationType generation) {
+  double now = os::elapsedTime();
+  bool accepted = _control_thread->request_concurrent_gc(generation);
+  if (LogTarget(Info, gc, thread)::is_enabled() && accepted) {
+    double wait_time = os::elapsedTime() - now;
+    if (wait_time > 0) {
+      log_info(gc, thread)("Regulator waited %.3fs for control thread to acknowledge request.", wait_time);
+    }
+  }
+  return accepted;
 }
 
 bool ShenandoahRegulatorThread::start_young_cycle() {
-  return _young_heuristics->should_start_gc() && _control_thread->request_concurrent_gc(YOUNG);
+  return _young_heuristics->should_start_gc() && request_concurrent_gc(YOUNG);
 }
 
 bool ShenandoahRegulatorThread::start_global_cycle() {
-  return _global_heuristics->should_start_gc() && _control_thread->request_concurrent_gc(ShenandoahControlThread::select_global_generation());
+  return _global_heuristics->should_start_gc() && request_concurrent_gc(ShenandoahControlThread::select_global_generation());
 }
 
 void ShenandoahRegulatorThread::stop_service() {

--- a/src/hotspot/share/gc/shenandoah/shenandoahRegulatorThread.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahRegulatorThread.cpp
@@ -140,7 +140,7 @@ void ShenandoahRegulatorThread::regulator_sleep() {
   if (LogTarget(Debug, gc, thread)::is_enabled()) {
     double elapsed = os::elapsedTime() - current;
     double hiccup = elapsed - double(_sleep);
-    if (hiccup > 0.0) {
+    if (hiccup > 0.001) {
       log_debug(gc, thread)("Regulator hiccup time: %.3fs", hiccup);
     }
   }
@@ -159,7 +159,7 @@ bool ShenandoahRegulatorThread::request_concurrent_gc(ShenandoahGenerationType g
   bool accepted = _control_thread->request_concurrent_gc(generation);
   if (LogTarget(Debug, gc, thread)::is_enabled() && accepted) {
     double wait_time = os::elapsedTime() - now;
-    if (wait_time > 0) {
+    if (wait_time > 0.001) {
       log_debug(gc, thread)("Regulator waited %.3fs for control thread to acknowledge request.", wait_time);
     }
   }

--- a/src/hotspot/share/gc/shenandoah/shenandoahRegulatorThread.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahRegulatorThread.cpp
@@ -137,11 +137,11 @@ void ShenandoahRegulatorThread::regulator_sleep() {
   }
 
   os::naked_short_sleep(_sleep);
-  if (LogTarget(Info, gc, thread)::is_enabled()) {
+  if (LogTarget(Debug, gc, thread)::is_enabled()) {
     double elapsed = os::elapsedTime() - current;
     double hiccup = elapsed - double(_sleep);
     if (hiccup > 0.0) {
-      log_info(gc, thread)("Regulator hiccup time: %.3fs", hiccup);
+      log_debug(gc, thread)("Regulator hiccup time: %.3fs", hiccup);
     }
   }
 }
@@ -157,10 +157,10 @@ bool ShenandoahRegulatorThread::start_old_cycle() {
 bool ShenandoahRegulatorThread::request_concurrent_gc(ShenandoahGenerationType generation) {
   double now = os::elapsedTime();
   bool accepted = _control_thread->request_concurrent_gc(generation);
-  if (LogTarget(Info, gc, thread)::is_enabled() && accepted) {
+  if (LogTarget(Debug, gc, thread)::is_enabled() && accepted) {
     double wait_time = os::elapsedTime() - now;
     if (wait_time > 0) {
-      log_info(gc, thread)("Regulator waited %.3fs for control thread to acknowledge request.", wait_time);
+      log_debug(gc, thread)("Regulator waited %.3fs for control thread to acknowledge request.", wait_time);
     }
   }
   return accepted;

--- a/src/hotspot/share/gc/shenandoah/shenandoahRegulatorThread.hpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahRegulatorThread.hpp
@@ -85,6 +85,8 @@ class ShenandoahRegulatorThread: public ConcurrentGCThread {
   double _last_sleep_adjust_time;
 
   void regulator_sleep();
+
+  bool request_concurrent_gc(ShenandoahGenerationType generation);
 };
 
 


### PR DESCRIPTION
Have regulator thread wait until expected condition is met

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed (1 review required, with at least 1 [Committer](https://openjdk.org/bylaws#committer))

### Issue
 * [JDK-8312117](https://bugs.openjdk.org/browse/JDK-8312117): GenShen: Preempt OLD marking more quickly when YOUNG triggers arise (**Sub-task** - P3)


### Reviewers
 * [Kelvin Nilsen](https://openjdk.org/census#kdnilsen) (@kdnilsen - Committer) ⚠️ Review applies to [fbc5de1f](https://git.openjdk.org/shenandoah/pull/333/files/fbc5de1f12676902ec90ae7ffd72abfc98e353c4)
 * [Y. Srinivas Ramakrishna](https://openjdk.org/census#ysr) (@ysramakrishna - Committer) ⚠️ Review applies to [7319707c](https://git.openjdk.org/shenandoah/pull/333/files/7319707cb18103a56e5afa7b55736d2b7d180845)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/shenandoah.git pull/333/head:pull/333` \
`$ git checkout pull/333`

Update a local copy of the PR: \
`$ git checkout pull/333` \
`$ git pull https://git.openjdk.org/shenandoah.git pull/333/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 333`

View PR using the GUI difftool: \
`$ git pr show -t 333`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/shenandoah/pull/333.diff">https://git.openjdk.org/shenandoah/pull/333.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/shenandoah/pull/333#issuecomment-1743459027)