### PR TITLE
8318019: GenShen: Fix assertion to allow empty evacuation cycles

### DIFF
--- a/src/hotspot/share/gc/shenandoah/shenandoahHeap.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahHeap.cpp
@@ -2423,9 +2423,9 @@ void ShenandoahHeap::set_concurrent_young_mark_in_progress(bool in_progress) {
 void ShenandoahHeap::set_concurrent_old_mark_in_progress(bool in_progress) {
 #ifdef ASSERT
   // has_forwarded_objects() iff UPDATEREFS or EVACUATION
-  bool has_forwarded = has_forwarded_objects()? 1: 0;
-  bool updating_or_evacuating = _gc_state.is_set(UPDATEREFS | EVACUATION)? 1: 0;
-  bool evacuating = gc_state.is_set(EVACUATION)? 1: 0;
+  bool has_forwarded = has_forwarded_objects();
+  bool updating_or_evacuating = _gc_state.is_set(UPDATEREFS | EVACUATION);
+  bool evacuating = _gc_state.is_set(EVACUATION);
   assert ((has_forwarded == updating_or_evacuating) || (evacuating && !has_forwarded && collection_set()->is_empty()),
           "Updating or evacuating iff has forwarded object, or evacuation phase is promoting in place without forwarding");
 #endif

--- a/src/hotspot/share/gc/shenandoah/shenandoahHeap.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahHeap.cpp
@@ -2425,7 +2425,9 @@ void ShenandoahHeap::set_concurrent_old_mark_in_progress(bool in_progress) {
   // has_forwarded_objects() iff UPDATEREFS or EVACUATION
   bool has_forwarded = has_forwarded_objects()? 1: 0;
   bool updating_or_evacuating = _gc_state.is_set(UPDATEREFS | EVACUATION)? 1: 0;
-  assert (has_forwarded == updating_or_evacuating, "Has forwarded objects iff updating or evacuating");
+  bool evacuating = gc_state.is_set(EVACUATION)? 1: 0;
+  assert ((has_forwarded == updating_or_evacuating) || (evacuating && !has_forwarded && collection_set()->is_empty()),
+          "Updating or evacuating iff has forwarded object, or evacuation phase is promoting in place without forwarding");
 #endif
   if (!in_progress && is_concurrent_young_mark_in_progress()) {
     // If young-marking is in progress when we turn off OLD_MARKING, leave MARKING (and YOUNG_MARKING) on


### PR DESCRIPTION
Assertion needs to allow for gc phase EVACUATION even if no forwarding objects because we are only promoting in place.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed (1 review required, with at least 1 [Committer](https://openjdk.org/bylaws#committer))

### Issue
 * [JDK-8318019](https://bugs.openjdk.org/browse/JDK-8318019): GenShen: Fix assertion to allow empty evacuation cycles (**Bug** - P4)


### Reviewers
 * [William Kemper](https://openjdk.org/census#wkemper) (@earthling-amzn - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/shenandoah.git pull/337/head:pull/337` \
`$ git checkout pull/337`

Update a local copy of the PR: \
`$ git checkout pull/337` \
`$ git pull https://git.openjdk.org/shenandoah.git pull/337/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 337`

View PR using the GUI difftool: \
`$ git pr show -t 337`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/shenandoah/pull/337.diff">https://git.openjdk.org/shenandoah/pull/337.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/shenandoah/pull/337#issuecomment-1759739230)