### PR TITLE
8318053: GenShen: Control thread may ignore requests to start concurrent GC

### DIFF
--- a/src/hotspot/share/gc/shenandoah/shenandoahControlThread.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahControlThread.cpp
@@ -775,6 +775,7 @@ bool ShenandoahControlThread::check_cancellation_or_degen(ShenandoahGC::Shenando
 
   if (is_alloc_failure_gc()) {
     _degen_point = point;
+    _preemption_requested.unset();
     return true;
   }
 

--- a/src/hotspot/share/gc/shenandoah/shenandoahControlThread.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahControlThread.cpp
@@ -899,6 +899,10 @@ void ShenandoahControlThread::request_gc(GCCause::Cause cause) {
 bool ShenandoahControlThread::request_concurrent_gc(ShenandoahGenerationType generation) {
   if (_preemption_requested.is_set() || _gc_requested.is_set() || ShenandoahHeap::heap()->cancelled_gc()) {
     // Ignore subsequent requests from the heuristics
+    log_debug(gc, thread)("Reject request for concurrent gc: preemption_requested: %s, gc_requested: %s, gc_cancelled: %s",
+                          BOOL_TO_STR(_preemption_requested.is_set()),
+                          BOOL_TO_STR(_gc_requested.is_set()),
+                          BOOL_TO_STR(ShenandoahHeap::heap()->cancelled_gc()));
     return false;
   }
 
@@ -930,6 +934,9 @@ bool ShenandoahControlThread::request_concurrent_gc(ShenandoahGenerationType gen
     return true;
   }
 
+  log_debug(gc, thread)("Reject request for concurrent gc: mode: %s, allow_old_preemption: %s",
+                        gc_mode_name(gc_mode()),
+                        BOOL_TO_STR(_allow_old_preemption.is_set()));
   return false;
 }
 


### PR DESCRIPTION
If a request to interrupt an old cycle is accepted, but there is an allocation failure before the requested cycle begins, then the control thread may become stuck in a state where it believes it should ignore further concurrent cycle requests.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed (1 review required, with at least 1 [Committer](https://openjdk.org/bylaws#committer))

### Issue
 * [JDK-8318053](https://bugs.openjdk.org/browse/JDK-8318053): GenShen: Control thread may ignore requests to start concurrent GC (**Bug** - P4)


### Reviewers
 * [Kelvin Nilsen](https://openjdk.org/census#kdnilsen) (@kdnilsen - Committer)
 * [Y. Srinivas Ramakrishna](https://openjdk.org/census#ysr) (@ysramakrishna - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/shenandoah.git pull/339/head:pull/339` \
`$ git checkout pull/339`

Update a local copy of the PR: \
`$ git checkout pull/339` \
`$ git pull https://git.openjdk.org/shenandoah.git pull/339/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 339`

View PR using the GUI difftool: \
`$ git pr show -t 339`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/shenandoah/pull/339.diff">https://git.openjdk.org/shenandoah/pull/339.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/shenandoah/pull/339#issuecomment-1760552447)