### PR TITLE
8318572: GenShen: Fix error in log message for ingored old-has-grown triggers

### DIFF
--- a/src/hotspot/share/gc/shenandoah/heuristics/shenandoahOldHeuristics.cpp
+++ b/src/hotspot/share/gc/shenandoah/heuristics/shenandoahOldHeuristics.cpp
@@ -524,14 +524,14 @@ bool ShenandoahOldHeuristics::should_start_gc() {
     size_t trigger_threshold = _old_generation->usage_trigger_threshold();
     size_t heap_size = heap->capacity();
     size_t consecutive_young_cycles;
-    if ((current_usage < ShenandoahIgnoreOldGrowthBelowPercentage * heap_size / 100) &&
+    size_t ignore_threshold = (ShenandoahIgnoreOldGrowthBelowPercentage * heap_size) / 100;
+    if ((current_usage < ignore_threshold) &&
         ((consecutive_young_cycles = heap->shenandoah_policy()->consecutive_young_gc_count())
          < ShenandoahDoNotIgnoreGrowthAfterYoungCycles)) {
-      log_info(gc)("Ignoring Trigger (OLD): Old has overgrown: usage (" SIZE_FORMAT "%s) is below threshold (" SIZE_FORMAT
-                   "%s) after " SIZE_FORMAT " consecutive completed young GCs",
+      log_info(gc)("Ignoring Trigger (OLD): Old has overgrown: usage (" SIZE_FORMAT "%s) is below threshold ("
+                   SIZE_FORMAT "%s) after " SIZE_FORMAT " consecutive completed young GCs",
                    byte_size_in_proper_unit(current_usage), proper_unit_for_byte_size(current_usage),
-                   byte_size_in_proper_unit(ShenandoahDoNotIgnoreGrowthAfterYoungCycles),
-                   proper_unit_for_byte_size(ShenandoahDoNotIgnoreGrowthAfterYoungCycles),
+                   byte_size_in_proper_unit(ignore_threshold), proper_unit_for_byte_size(ignore_threshold),
                    consecutive_young_cycles);
       _growth_trigger = false;
     } else if (current_usage > trigger_threshold) {

--- a/src/hotspot/share/gc/shenandoah/heuristics/shenandoahOldHeuristics.cpp
+++ b/src/hotspot/share/gc/shenandoah/heuristics/shenandoahOldHeuristics.cpp
@@ -528,11 +528,11 @@ bool ShenandoahOldHeuristics::should_start_gc() {
     if ((current_usage < ignore_threshold) &&
         ((consecutive_young_cycles = heap->shenandoah_policy()->consecutive_young_gc_count())
          < ShenandoahDoNotIgnoreGrowthAfterYoungCycles)) {
-      log_info(gc)("Ignoring Trigger (OLD): Old has overgrown: usage (" SIZE_FORMAT "%s) is below threshold ("
-                   SIZE_FORMAT "%s) after " SIZE_FORMAT " consecutive completed young GCs",
-                   byte_size_in_proper_unit(current_usage), proper_unit_for_byte_size(current_usage),
-                   byte_size_in_proper_unit(ignore_threshold), proper_unit_for_byte_size(ignore_threshold),
-                   consecutive_young_cycles);
+      log_debug(gc)("Ignoring Trigger (OLD): Old has overgrown: usage (" SIZE_FORMAT "%s) is below threshold ("
+                    SIZE_FORMAT "%s) after " SIZE_FORMAT " consecutive completed young GCs",
+                    byte_size_in_proper_unit(current_usage), proper_unit_for_byte_size(current_usage),
+                    byte_size_in_proper_unit(ignore_threshold), proper_unit_for_byte_size(ignore_threshold),
+                    consecutive_young_cycles);
       _growth_trigger = false;
     } else if (current_usage > trigger_threshold) {
       size_t live_at_previous_old = _old_generation->get_live_bytes_after_last_mark();

--- a/src/hotspot/share/gc/shenandoah/shenandoah_globals.hpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoah_globals.hpp
@@ -336,9 +336,9 @@
           "evacuate more live objects on every cycle, while leaving "       \
           "less headroom for application to allocate while GC is "          \
           "evacuating and updating references. This parameter is "          \
-          "consulted at the of marking, before selecting the collection "   \
-          "set.  If available memory at this time is smaller than the "     \
-          "indicated reserve, the bound on collection set size is "         \
+          "consulted at the end of marking, before selecting the "          \
+          "collection set.  If available memory at this time is smaller "   \
+          "than the indicated reserve, the bound on collection set size is "\
           "adjusted downward.  The size of a generational mixed "           \
           "evacuation collection set (comprised of both young and old "     \
           "regions) is also bounded by this parameter.  In percents of "    \


### PR DESCRIPTION
Fix messages in log and user guidance.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed (1 review required, with at least 1 [Committer](https://openjdk.org/bylaws#committer))

### Issue
 * [JDK-8318572](https://bugs.openjdk.org/browse/JDK-8318572): GenShen: Fix error in log message for ingored old-has-grown triggers (**Bug** - P4)


### Reviewers
 * [William Kemper](https://openjdk.org/census#wkemper) (@earthling-amzn - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/shenandoah.git pull/345/head:pull/345` \
`$ git checkout pull/345`

Update a local copy of the PR: \
`$ git checkout pull/345` \
`$ git pull https://git.openjdk.org/shenandoah.git pull/345/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 345`

View PR using the GUI difftool: \
`$ git pr show -t 345`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/shenandoah/pull/345.diff">https://git.openjdk.org/shenandoah/pull/345.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/shenandoah/pull/345#issuecomment-1771810621)