### PR TITLE
8318619: GenShen: Add configurable threshold for young triggers to expedite old evacuations

### DIFF
--- a/src/hotspot/share/gc/shenandoah/heuristics/shenandoahYoungHeuristics.cpp
+++ b/src/hotspot/share/gc/shenandoah/heuristics/shenandoahYoungHeuristics.cpp
@@ -35,7 +35,6 @@
 
 ShenandoahYoungHeuristics::ShenandoahYoungHeuristics(ShenandoahYoungGeneration* generation)
         : ShenandoahGenerationalHeuristics(generation) {
-  assert(!generation->is_old(), "Young heuristics only accept the young generation");
 }
 
 
@@ -136,7 +135,7 @@ bool ShenandoahYoungHeuristics::should_start_gc() {
   // gets priority over old-gen marking.
   ShenandoahHeap* heap = ShenandoahHeap::heap();
 
-  size_t promo_expedite_threshold = (heap->young_generation()->max_capacity() * ShenandoahEvacReserve) / 512;
+  size_t promo_expedite_threshold = checked_cast<size_t>(percent_of(heap->young_generation()->max_capacity(), ShenandoahExpeditePromotionsThreshold));
   size_t promo_potential = heap->get_promotion_potential();
   if (promo_potential > promo_expedite_threshold) {
     // Detect unsigned arithmetic underflow
@@ -150,8 +149,11 @@ bool ShenandoahYoungHeuristics::should_start_gc() {
 
   ShenandoahOldHeuristics* old_heuristics = heap->old_heuristics();
   size_t mixed_candidates = old_heuristics->unprocessed_old_collection_candidates();
-  if (mixed_candidates > 0) {
+  if (mixed_candidates > ShenandoahExpediteMixedThreshold && !heap->is_concurrent_weak_root_in_progress()) {
     // We need to run young GC in order to open up some free heap regions so we can finish mixed evacuations.
+    // If concurrent weak root processing is in progress, it means the old cycle has chosen mixed collection
+    // candidates, but has not completed. There is no point in evaluating the trigger before the young cycle
+    // will be able to start.
     log_info(gc)("Trigger (%s): expedite mixed evacuation of " SIZE_FORMAT " regions",
                  _space_info->name(), mixed_candidates);
     return true;

--- a/src/hotspot/share/gc/shenandoah/heuristics/shenandoahYoungHeuristics.cpp
+++ b/src/hotspot/share/gc/shenandoah/heuristics/shenandoahYoungHeuristics.cpp
@@ -135,7 +135,7 @@ bool ShenandoahYoungHeuristics::should_start_gc() {
   // gets priority over old-gen marking.
   ShenandoahHeap* heap = ShenandoahHeap::heap();
 
-  size_t promo_expedite_threshold = checked_cast<size_t>(percent_of(heap->young_generation()->max_capacity(), ShenandoahExpeditePromotionsThreshold));
+  size_t promo_expedite_threshold = percent_of(heap->young_generation()->max_capacity(), ShenandoahExpeditePromotionsThreshold);
   size_t promo_potential = heap->get_promotion_potential();
   if (promo_potential > promo_expedite_threshold) {
     // Detect unsigned arithmetic underflow
@@ -152,8 +152,8 @@ bool ShenandoahYoungHeuristics::should_start_gc() {
   if (mixed_candidates > ShenandoahExpediteMixedThreshold && !heap->is_concurrent_weak_root_in_progress()) {
     // We need to run young GC in order to open up some free heap regions so we can finish mixed evacuations.
     // If concurrent weak root processing is in progress, it means the old cycle has chosen mixed collection
-    // candidates, but has not completed. There is no point in evaluating the trigger before the young cycle
-    // will be able to start.
+    // candidates, but has not completed. There is no point in trying to start the young cycle before the old
+    // cycle completes.
     log_info(gc)("Trigger (%s): expedite mixed evacuation of " SIZE_FORMAT " regions",
                  _space_info->name(), mixed_candidates);
     return true;

--- a/src/hotspot/share/gc/shenandoah/shenandoah_globals.hpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoah_globals.hpp
@@ -144,6 +144,16 @@
           " compact - run GC more frequently and with deeper targets to "   \
           "free up more memory.")                                           \
                                                                             \
+  product(uintx, ShenandoahExpeditePromotionsThreshold, 5, EXPERIMENTAL,    \
+          "When Shenandoah expects to promote at least this percentage "    \
+          "of the young generation, trigger a young collection to "         \
+          "expedite these promotions.")                                     \
+          range(0,100)                                                      \
+                                                                            \
+  product(uintx, ShenandoahExpediteMixedThreshold, 10, EXPERIMENTAL,        \
+          "When there are this many old regions waiting to be collected, "  \
+          "trigger a mixed collection immediately.")                        \
+                                                                            \
   product(uintx, ShenandoahUnloadClassesFrequency, 1, EXPERIMENTAL,         \
           "Unload the classes every Nth cycle. Normally affects concurrent "\
           "GC cycles, as degenerated and full GCs would try to unload "     \


### PR DESCRIPTION
When Shenandoah expects to free up space by promotions into young, or evacuations in old it may trigger a young collection. This change sets configurable thresholds for these conditions.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed (1 review required, with at least 1 [Committer](https://openjdk.org/bylaws#committer))

### Issue
 * [JDK-8318619](https://bugs.openjdk.org/browse/JDK-8318619): GenShen: Add configurable threshold for young triggers to expedite old evacuations (**Enhancement** - P4)


### Reviewers
 * [Kelvin Nilsen](https://openjdk.org/census#kdnilsen) (@kdnilsen - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/shenandoah.git pull/347/head:pull/347` \
`$ git checkout pull/347`

Update a local copy of the PR: \
`$ git checkout pull/347` \
`$ git pull https://git.openjdk.org/shenandoah.git pull/347/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 347`

View PR using the GUI difftool: \
`$ git pr show -t 347`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/shenandoah/pull/347.diff">https://git.openjdk.org/shenandoah/pull/347.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/shenandoah/pull/347#issuecomment-1773360172)