### PR TITLE
8315560: GenShen: assert failed: Object klass pointer must go to metaspace

### DIFF
--- a/src/hotspot/share/gc/shenandoah/shenandoahGeneration.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahGeneration.cpp
@@ -561,7 +561,7 @@ size_t ShenandoahGeneration::select_aged_regions(size_t old_available, size_t nu
       if ((r->garbage() < old_garbage_threshold)) {
         HeapWord* tams = ctx->top_at_mark_start(r);
         HeapWord* original_top = r->top();
-        if (tams == original_top) {
+        if (!heap->is_concurrent_old_mark_in_progress() && tams == original_top) {
           // No allocations from this region have been made during concurrent mark. It meets all the criteria
           // for in-place-promotion. Though we only need the value of top when we fill the end of the region,
           // we use this field to indicate that this region should be promoted in place during the evacuation

--- a/src/hotspot/share/gc/shenandoah/shenandoahHeapRegion.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahHeapRegion.cpp
@@ -1006,6 +1006,7 @@ void ShenandoahHeapRegion::promote_in_place() {
   ShenandoahMarkingContext* marking_context = heap->marking_context();
   HeapWord* tams = marking_context->top_at_mark_start(this);
   assert(heap->active_generation()->is_mark_complete(), "sanity");
+  assert(!heap->is_concurrent_old_mark_in_progress(), "Cannot promote in place during old marking");
   assert(is_young(), "Only young regions can be promoted");
   assert(is_regular(), "Use different service to promote humongous regions");
   assert(age() >= heap->age_census()->tenuring_threshold(), "Only promote regions that are sufficiently aged");
@@ -1031,7 +1032,7 @@ void ShenandoahHeapRegion::promote_in_place() {
   while (obj_addr < tams) {
     oop obj = cast_to_oop(obj_addr);
     if (marking_context->is_marked(obj)) {
-      assert(obj->klass() != NULL, "klass should not be NULL");
+      assert(obj->klass() != nullptr, "klass should not be NULL");
       // This thread is responsible for registering all objects in this region.  No need for lock.
       heap->card_scan()->register_object_without_lock(obj_addr);
       obj_addr += obj->size();


### PR DESCRIPTION
We have seen crashes caused when the interned string table is cleaned concurrently by mutator actions. Strings which have become unreachable may be inserted in the SATB buffer during concurrent mark of old. If these pointers reside in young regions which are later promoted in place to old regions, the referenced object (which is young and unmarked) will be filled.  When the old marking tries to follow through the pointer, it may crash.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed (1 review required, with at least 1 [Committer](https://openjdk.org/bylaws#committer))

### Issue
 * [JDK-8315560](https://bugs.openjdk.org/browse/JDK-8315560): GenShen: assert failed: Object klass pointer must go to metaspace (**Bug** - P3)


### Reviewers
 * [Kelvin Nilsen](https://openjdk.org/census#kdnilsen) (@kdnilsen - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/shenandoah.git pull/348/head:pull/348` \
`$ git checkout pull/348`

Update a local copy of the PR: \
`$ git checkout pull/348` \
`$ git pull https://git.openjdk.org/shenandoah.git pull/348/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 348`

View PR using the GUI difftool: \
`$ git pr show -t 348`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/shenandoah/pull/348.diff">https://git.openjdk.org/shenandoah/pull/348.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/shenandoah/pull/348#issuecomment-1776229049)