### PR TITLE
8319198: GenShen: Old at end of Full GC must include newly promoted objects

### DIFF
--- a/src/hotspot/share/gc/shenandoah/shenandoahFullGC.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahFullGC.cpp
@@ -190,6 +190,9 @@ void ShenandoahFullGC::op_full(GCCause::Cause cause) {
     assert((heap->old_generation()->used() + heap->old_generation()->get_humongous_waste())
            <= heap->old_generation()->used_regions_size(), "Old consumed can be no larger than span of affiliated regions");
 
+    // Establish baseline for next old-has-grown trigger.
+    heap->old_generation()->set_live_bytes_after_last_mark(heap->old_generation()->used() +
+                                                           heap->old_generation()->get_humongous_waste());
   }
   if (metrics.is_good_progress()) {
     ShenandoahHeap::heap()->notify_gc_progress();
@@ -421,7 +424,6 @@ void ShenandoahFullGC::phase1_mark_heap() {
     }
   }
   log_info(gc)("Live bytes in old after STW mark: " PROPERFMT, PROPERFMTARGS(live_bytes_in_old));
-  heap->old_generation()->set_live_bytes_after_last_mark(live_bytes_in_old);
 }
 
 class ShenandoahPrepareForCompactionTask : public WorkerTask {


### PR DESCRIPTION
At end of Full GC, remember live bytes after last old-gen mark after promotions are completed rather than immediately after old marking is completed.  This is a more accurate representation of old live.  This reduces the likelihood that we will need to immediately trigger another old-gen GC following the Full GC.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed (1 review required, with at least 1 [Committer](https://openjdk.org/bylaws#committer))

### Issue
 * [JDK-8319198](https://bugs.openjdk.org/browse/JDK-8319198): GenShen: Old at end of Full GC must include newly promoted objects (**Bug** - P4)


### Reviewers
 * [William Kemper](https://openjdk.org/census#wkemper) (@earthling-amzn - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/shenandoah.git pull/350/head:pull/350` \
`$ git checkout pull/350`

Update a local copy of the PR: \
`$ git checkout pull/350` \
`$ git pull https://git.openjdk.org/shenandoah.git pull/350/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 350`

View PR using the GUI difftool: \
`$ git pr show -t 350`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/shenandoah/pull/350.diff">https://git.openjdk.org/shenandoah/pull/350.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/shenandoah/pull/350#issuecomment-1789229578)