### PR TITLE
8319931: GenShen: Increase no progress threshold for TestThreadFailure

### DIFF
--- a/test/hotspot/jtreg/gc/shenandoah/oom/TestThreadFailure.java
+++ b/test/hotspot/jtreg/gc/shenandoah/oom/TestThreadFailure.java
@@ -79,7 +79,7 @@ public class TestThreadFailure {
         {
             ProcessBuilder pb = ProcessTools.createLimitedTestJavaProcessBuilder(
                     "-Xmx32m",
-                    "-XX:+UnlockExperimentalVMOptions", "-XX:ShenandoahNoProgressThreshold=8",
+                    "-XX:+UnlockExperimentalVMOptions", "-XX:ShenandoahNoProgressThreshold=12",
                     "-XX:+UseShenandoahGC", "-XX:ShenandoahGCMode=generational",
                     TestThreadFailure.class.getName(),
                     "test");


### PR DESCRIPTION
The test walks to close to the edge of an out of memory cliff. Intermittent failures are caused by [JDK-8316632](https://bugs.openjdk.org/browse/JDK-8316632). Further investigation is needed for Genshen. The intention of this PR is just to increase the setting `ShenandoahNoProgressThreshold` for this test to pass.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed (1 review required, with at least 1 [Committer](https://openjdk.org/bylaws#committer))

### Issue
 * [JDK-8319931](https://bugs.openjdk.org/browse/JDK-8319931): GenShen: Increase no progress threshold for TestThreadFailure (**Bug** - P4)


### Reviewers
 * [Kelvin Nilsen](https://openjdk.org/census#kdnilsen) (@kdnilsen - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/shenandoah.git pull/356/head:pull/356` \
`$ git checkout pull/356`

Update a local copy of the PR: \
`$ git checkout pull/356` \
`$ git pull https://git.openjdk.org/shenandoah.git pull/356/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 356`

View PR using the GUI difftool: \
`$ git pr show -t 356`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/shenandoah/pull/356.diff">https://git.openjdk.org/shenandoah/pull/356.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/shenandoah/pull/356#issuecomment-1808617295)