### PR TITLE
8320119: GenShen: Correct misspellings of parsable

### DIFF
--- a/src/hotspot/share/gc/shenandoah/heuristics/shenandoahOldHeuristics.cpp
+++ b/src/hotspot/share/gc/shenandoah/heuristics/shenandoahOldHeuristics.cpp
@@ -215,7 +215,7 @@ bool ShenandoahOldHeuristics::prime_collection_set(ShenandoahCollectionSet* coll
     // or did we just not have enough room for any of them in this collection set?
     // We don't want a region with a stuck pin to prevent subsequent old collections, so
     // if they are all pinned we transition to a state that will allow us to make these uncollected
-    // (pinned) regions parseable.
+    // (pinned) regions parsable.
     if (all_candidates_are_pinned()) {
       log_info(gc)("All candidate regions " UINT32_FORMAT " are pinned", unprocessed_old_collection_candidates());
       _old_generation->transition_to(ShenandoahOldGeneration::FILLING);

--- a/src/hotspot/share/gc/shenandoah/shenandoahGeneration.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahGeneration.cpp
@@ -571,7 +571,7 @@ size_t ShenandoahGeneration::select_aged_regions(size_t old_available, size_t nu
           if (remnant_size > ShenandoahHeap::min_fill_size()) {
             ShenandoahHeap::fill_with_object(original_top, remnant_size);
             // Fill the remnant memory within this region to assure no allocations prior to promote in place.  Otherwise,
-            // newly allocated objects will not be parseable when promote in place tries to register them.  Furthermore, any
+            // newly allocated objects will not be parsable when promote in place tries to register them.  Furthermore, any
             // new allocations would not necessarily be eligible for promotion.  This addresses both issues.
             r->set_top(r->end());
             promote_in_place_pad += remnant_size * HeapWordSize;
@@ -733,7 +733,7 @@ void ShenandoahGeneration::prepare_regions_and_collection_set(bool concurrent) {
       if (is_global()) {
         // We have just chosen a collection set for a global cycle. The mark bitmap covering old regions is complete, so
         // the remembered set scan can use that to avoid walking into garbage. When the next old mark begins, we will
-        // use the mark bitmap to make the old regions parseable by coalescing and filling any unmarked objects. Thus,
+        // use the mark bitmap to make the old regions parsable by coalescing and filling any unmarked objects. Thus,
         // we prepare for old collections by remembering which regions are old at this time. Note that any objects
         // promoted into old regions will be above TAMS, and so will be considered marked. However, free regions that
         // become old after this point will not be covered correctly by the mark bitmap, so we must be careful not to

--- a/src/hotspot/share/gc/shenandoah/shenandoahHeap.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahHeap.cpp
@@ -1880,7 +1880,7 @@ public:
     assert(plab != nullptr, "PLAB should be initialized for %s", thread->name());
 
     // There are two reasons to retire all plabs between old-gen evacuation passes.
-    //  1. We need to make the plab memory parseable by remembered-set scanning.
+    //  1. We need to make the plab memory parsable by remembered-set scanning.
     //  2. We need to establish a trustworthy UpdateWaterMark value within each old-gen heap region
     ShenandoahHeap::heap()->retire_plab(plab, thread);
     if (_resize && ShenandoahThreadLocalData::plab_size(thread) > 0) {

--- a/src/hotspot/share/gc/shenandoah/shenandoahHeapRegion.hpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahHeapRegion.hpp
@@ -394,7 +394,7 @@ public:
   }
 
   // Coalesce contiguous spans of garbage objects by filling header and reregistering start locations with remembered set.
-  // This is used by old-gen GC following concurrent marking to make old-gen HeapRegions parseable.  Return true iff
+  // This is used by old-gen GC following concurrent marking to make old-gen HeapRegions parsable.  Return true iff
   // region is completely coalesced and filled.  Returns false if cancelled before task is complete.
   bool oop_fill_and_coalesce();
 

--- a/src/hotspot/share/gc/shenandoah/shenandoahOldGC.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahOldGC.cpp
@@ -87,7 +87,7 @@ void ShenandoahOldGC::op_final_mark() {
 bool ShenandoahOldGC::collect(GCCause::Cause cause) {
   ShenandoahHeap* heap = ShenandoahHeap::heap();
   assert(!heap->doing_mixed_evacuations(), "Should not start an old gc with pending mixed evacuations");
-  assert(!heap->is_prepare_for_old_mark_in_progress(), "Old regions need to be parseable during concurrent mark.");
+  assert(!heap->is_prepare_for_old_mark_in_progress(), "Old regions need to be parsable during concurrent mark.");
 
   // Enable preemption of old generation mark.
   _allow_preemption.set();

--- a/src/hotspot/share/gc/shenandoah/shenandoah_globals.hpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoah_globals.hpp
@@ -530,7 +530,7 @@
           "likelihood. Following each mixed collection, abandon all "       \
           "remaining mixed collection candidate regions with likelihood "   \
           "ShenandoahCoalesceChance. Abandoning a mixed collection will "   \
-          "cause the old regions to be made parseable, rather than being "  \
+          "cause the old regions to be made parsable, rather than being "   \
           "evacuated.")                                                     \
           range(0, 100)                                                     \
                                                                             \


### PR DESCRIPTION
There should be no 'e' in the word that describes something that is able to be parsed.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed (1 review required, with at least 1 [Committer](https://openjdk.org/bylaws#committer))

### Issue
 * [JDK-8320119](https://bugs.openjdk.org/browse/JDK-8320119): GenShen: Correct misspellings of parsable (**Task** - P4)


### Reviewers
 * [Kelvin Nilsen](https://openjdk.org/census#kdnilsen) (@kdnilsen - Committer)
 * [Y. Srinivas Ramakrishna](https://openjdk.org/census#ysr) (@ysramakrishna - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/shenandoah.git pull/358/head:pull/358` \
`$ git checkout pull/358`

Update a local copy of the PR: \
`$ git checkout pull/358` \
`$ git pull https://git.openjdk.org/shenandoah.git pull/358/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 358`

View PR using the GUI difftool: \
`$ git pr show -t 358`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/shenandoah/pull/358.diff">https://git.openjdk.org/shenandoah/pull/358.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/shenandoah/pull/358#issuecomment-1811602888)