### PR TITLE
JDK-8320336: GenShen: Reduce proactive humongous defragmentation efforts

### DIFF
--- a/src/hotspot/share/gc/shenandoah/shenandoahHeap.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahHeap.cpp
@@ -3126,16 +3126,19 @@ void ShenandoahHeap::rebuild_free_set(bool concurrent) {
   // Rebuild free set based on adjusted generation sizes.
   _free_set->rebuild(young_cset_regions, old_cset_regions);
 
-  if (mode()->is_generational()) {
+  if (mode()->is_generational() && (ShenandoahGenerationalHumongousReserve > 0)) {
     size_t old_region_span = (first_old_region <= last_old_region)? (last_old_region + 1 - first_old_region): 0;
     size_t allowed_old_gen_span = num_regions() - (ShenandoahGenerationalHumongousReserve * num_regions() / 100);
 
     // Tolerate lower density if total span is small.  Here's the implementation:
-    //   if old_gen spans more than 100% and density < 87.5%, trigger old-defrag
-    //   else if old_gen spans more than 87.5% and density < 75%, trigger old-defrag
-    //   else if old_gen spans more than 75% and density < 62.5%, trigger old-defrag
-    //   else if old_gen spans more than 62.5% and density < 50%, trigger old-defrag
-    //   else if old_gen spans more than 50% and density < 37.5%, trigger old-defrag
+    //   if old_gen spans more than 100% and density < 75%, trigger old-defrag
+    //   else if old_gen spans more than 87.5% and density < 62.5%, trigger old-defrag
+    //   else if old_gen spans more than 75% and density < 50%, trigger old-defrag
+    //   else if old_gen spans more than 62.5% and density < 37.5%, trigger old-defrag
+    //   else if old_gen spans more than 50% and density < 25%, trigger old-defrag
+    //
+    // A previous implementation was more aggressive in triggering, resulting in degraded throughput when
+    // humongous allocation was not required.
 
     ShenandoahGeneration* old_gen = old_generation();
     size_t old_available = old_gen->available();
@@ -3151,12 +3154,12 @@ void ShenandoahHeap::rebuild_free_set(bool concurrent) {
     uint eighths = 8;
     for (uint i = 0; i < 5; i++) {
       size_t span_threshold = eighths * allowed_old_gen_span / 8;
-      eighths--;
-      double density_threshold = eighths / 8.0;
+      double density_threshold = (eighths - 2) / 8.0;
       if ((old_region_span >= span_threshold) && (old_density < density_threshold)) {
         old_heuristics()->trigger_old_is_fragmented(old_density, first_old_region, last_old_region);
         break;
       }
+      eighths--;
     }
 
     size_t old_used = old_generation()->used() + old_generation()->get_humongous_waste();


### PR DESCRIPTION
Only trigger defragmentation of old-gen memory if JVM is configured to reserve a certain amount of the heap to support humongous objects.  Even when the JVM is so configured, be slightly less aggressive in triggering defragmentation of old-gen memory.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed (1 review required, with at least 1 [Committer](https://openjdk.org/bylaws#committer))

### Issue
 * [JDK-8320336](https://bugs.openjdk.org/browse/JDK-8320336): GenShen: Reduce proactive humongous defragmentation efforts (**Bug** - P4)


### Reviewers
 * [William Kemper](https://openjdk.org/census#wkemper) (@earthling-amzn - Committer)
 * [Y. Srinivas Ramakrishna](https://openjdk.org/census#ysr) (@ysramakrishna - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/shenandoah.git pull/361/head:pull/361` \
`$ git checkout pull/361`

Update a local copy of the PR: \
`$ git checkout pull/361` \
`$ git pull https://git.openjdk.org/shenandoah.git pull/361/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 361`

View PR using the GUI difftool: \
`$ git pr show -t 361`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/shenandoah/pull/361.diff">https://git.openjdk.org/shenandoah/pull/361.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/shenandoah/pull/361#issuecomment-1816807892)