### PR TITLE
8321401: GenShen: Each mutator must see FullGC before throwing OOM

### DIFF
--- a/src/hotspot/share/gc/shenandoah/shenandoahHeap.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahHeap.cpp
@@ -1334,20 +1334,6 @@ HeapWord* ShenandoahHeap::allocate_memory(ShenandoahAllocRequest& req, bool is_p
       result = allocate_memory_under_lock(req, in_new_region, is_promotion);
     }
 
-#ifdef KELVIN_BROKEN
-    // Check that gc overhead is not exceeded.
-    //
-    // Shenandoah will grind along for quite a while allocating one
-    // object at a time using shared (non-tlab) allocations. This check
-    // is testing that the GC overhead limit has not been exceeded.
-    // This will notify the collector to start a cycle, but will raise
-    // an OOME to the mutator if the last Full GCs have not made progress.
-    if (result == nullptr && !req.is_lab_alloc() && get_gc_no_progress_count() > ShenandoahNoProgressThreshold) {
-      control_thread()->handle_alloc_failure(req, false);
-      return nullptr;
-    }
-#endif
-
     // Block until control thread reacted, then retry allocation.
     //
     // It might happen that one of the threads requesting allocation would unblock

--- a/src/hotspot/share/gc/shenandoah/shenandoahHeap.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahHeap.cpp
@@ -1412,7 +1412,9 @@ HeapWord* ShenandoahHeap::allocate_memory_under_lock(ShenandoahAllocRequest& req
       if (req.affiliation() == YOUNG_GENERATION) {
         if (req.is_mutator_alloc()) {
           // TODO: this should query free_set->mutator_free() rather than young_gen()->available().
-          // We care not
+          // This mutator allocation cannot access memory that is reserved for Collector.  Should probably
+          // entirely remove the "try_smaller_lab_size control path".  The original motivation for this
+          // path is no longer relevant.
           size_t young_words_available = young_generation()->available() / HeapWordSize;
           if (ShenandoahElasticTLAB && req.is_lab_alloc() && (req.min_size() < young_words_available)) {
             // Allow ourselves to try a smaller lab size even if requested_bytes <= young_available.  We may need a smaller

--- a/src/hotspot/share/gc/shenandoah/shenandoahHeap.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahHeap.cpp
@@ -1334,6 +1334,7 @@ HeapWord* ShenandoahHeap::allocate_memory(ShenandoahAllocRequest& req, bool is_p
       result = allocate_memory_under_lock(req, in_new_region, is_promotion);
     }
 
+#ifdef KELVIN_BROKEN
     // Check that gc overhead is not exceeded.
     //
     // Shenandoah will grind along for quite a while allocating one
@@ -1345,6 +1346,7 @@ HeapWord* ShenandoahHeap::allocate_memory(ShenandoahAllocRequest& req, bool is_p
       control_thread()->handle_alloc_failure(req, false);
       return nullptr;
     }
+#endif
 
     // Block until control thread reacted, then retry allocation.
     //
@@ -1423,6 +1425,8 @@ HeapWord* ShenandoahHeap::allocate_memory_under_lock(ShenandoahAllocRequest& req
     if (mode()->is_generational()) {
       if (req.affiliation() == YOUNG_GENERATION) {
         if (req.is_mutator_alloc()) {
+          // TODO: this should query free_set->mutator_free() rather than young_gen()->available().
+          // We care not
           size_t young_words_available = young_generation()->available() / HeapWordSize;
           if (ShenandoahElasticTLAB && req.is_lab_alloc() && (req.min_size() < young_words_available)) {
             // Allow ourselves to try a smaller lab size even if requested_bytes <= young_available.  We may need a smaller

--- a/src/hotspot/share/gc/shenandoah/shenandoah_globals.hpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoah_globals.hpp
@@ -505,11 +505,6 @@
           "How many back-to-back Degenerated GCs should happen before "     \
           "going to a Full GC.")                                            \
                                                                             \
-  product(uintx, ShenandoahNoProgressThreshold, 5, EXPERIMENTAL,            \
-          "After this number of consecutive Full GCs fail to make "         \
-          "progress, Shenandoah will raise out of memory errors. Note "     \
-          "that progress is determined by ShenandoahCriticalFreeThreshold") \
-                                                                            \
   product(bool, ShenandoahImplicitGCInvokesConcurrent, false, EXPERIMENTAL, \
           "Should internally-caused GC requests invoke concurrent cycles, " \
           "should they do the stop-the-world (Degenerated / Full GC)? "     \

--- a/test/hotspot/jtreg/gc/shenandoah/oom/TestThreadFailure.java
+++ b/test/hotspot/jtreg/gc/shenandoah/oom/TestThreadFailure.java
@@ -79,7 +79,7 @@ public class TestThreadFailure {
         {
             ProcessBuilder pb = ProcessTools.createLimitedTestJavaProcessBuilder(
                     "-Xmx32m",
-                    "-XX:+UnlockExperimentalVMOptions", "-XX:ShenandoahNoProgressThreshold=12",
+                    "-XX:+UnlockExperimentalVMOptions",
                     "-XX:+UseShenandoahGC", "-XX:ShenandoahGCMode=generational",
                     TestThreadFailure.class.getName(),
                     "test");


### PR DESCRIPTION
Require each thread to observe unproductive Full GC before it throws OOM exception.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Committer](https://openjdk.org/bylaws#committer))

### Warnings
&nbsp;⚠️ Patch contains a binary file (test/jdk/java/util/zip/ZipFile/crash.jar)
&nbsp;⚠️ Patch contains a binary file (test/jdk/java/util/zip/ZipFile/input.jar)
&nbsp;⚠️ Patch contains a binary file (test/jdk/java/util/zip/ZipFile/input.zip)
&nbsp;⚠️ Patch contains a binary file (test/jdk/java/util/zip/test.zip)
&nbsp;⚠️ Patch contains a binary file (test/jdk/javax/management/loading/LibraryLoader/native.jar)
&nbsp;⚠️ Patch contains a binary file (test/jdk/javax/swing/AbstractButton/5049549/DE1.gif)
&nbsp;⚠️ Patch contains a binary file (test/jdk/javax/swing/AbstractButton/5049549/DI1.gif)
&nbsp;⚠️ Patch contains a binary file (test/jdk/javax/swing/AbstractButton/5049549/DS1.gif)
&nbsp;⚠️ Patch contains a binary file (test/jdk/javax/swing/AbstractButton/5049549/PR1.gif)
&nbsp;⚠️ Patch contains a binary file (test/jdk/javax/swing/AbstractButton/5049549/RO1.gif)
&nbsp;⚠️ Patch contains a binary file (test/jdk/javax/swing/AbstractButton/5049549/RS1.gif)
&nbsp;⚠️ Patch contains a binary file (test/jdk/javax/swing/AbstractButton/5049549/SE1.gif)

### Issue
 * [JDK-8321401](https://bugs.openjdk.org/browse/JDK-8321401): GenShen: Each mutator must see FullGC before throwing OOM (**Bug** - P3)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/shenandoah.git pull/365/head:pull/365` \
`$ git checkout pull/365`

Update a local copy of the PR: \
`$ git checkout pull/365` \
`$ git pull https://git.openjdk.org/shenandoah.git pull/365/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 365`

View PR using the GUI difftool: \
`$ git pr show -t 365`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/shenandoah/pull/365.diff">https://git.openjdk.org/shenandoah/pull/365.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/shenandoah/pull/365#issuecomment-1840937400)