### PR TITLE
8322219: GenShen: GHA for shenandoah repo should run all shenandoah jtreg tests

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -64,6 +64,7 @@ jobs:
           - 'hs/tier1 compiler part 2'
           - 'hs/tier1 compiler part 3'
           - 'hs/tier1 gc'
+          - 'hs/all shenandoah'
           - 'hs/tier1 runtime'
           - 'hs/tier1 serviceability'
           - 'lib-test/tier1'
@@ -99,6 +100,10 @@ jobs:
 
           - test-name: 'hs/tier1 gc'
             test-suite: 'test/hotspot/jtreg/:tier1_gc'
+            debug-suffix: -debug
+
+          - test-name: 'hs/all shenandoah'
+            test-suite: 'test/hotspot/jtreg/:hotspot_gc_shenandoah'
             debug-suffix: -debug
 
           - test-name: 'hs/tier1 runtime'


### PR DESCRIPTION
GHA for shenandoah repo should run all shenandoah jtreg tests

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed (1 review required, with at least 1 [Committer](https://openjdk.org/bylaws#committer))

### Issue
 * [JDK-8322219](https://bugs.openjdk.org/browse/JDK-8322219): GenShen: GHA for shenandoah repo should run all shenandoah jtreg tests (**Task** - P4)


### Reviewers
 * [Y. Srinivas Ramakrishna](https://openjdk.org/census#ysr) (@ysramakrishna - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/shenandoah.git pull/373/head:pull/373` \
`$ git checkout pull/373`

Update a local copy of the PR: \
`$ git checkout pull/373` \
`$ git pull https://git.openjdk.org/shenandoah.git pull/373/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 373`

View PR using the GUI difftool: \
`$ git pr show -t 373`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/shenandoah/pull/373.diff">https://git.openjdk.org/shenandoah/pull/373.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/shenandoah/pull/373#issuecomment-1858330501)