### PR TITLE
8322242: [GenShen] TestAllocObjects#generational fails with "Unrecognized VM option 'ShenandoahSuspendibleWorkers'"

### DIFF
--- a/test/hotspot/jtreg/gc/shenandoah/TestAllocObjects.java
+++ b/test/hotspot/jtreg/gc/shenandoah/TestAllocObjects.java
@@ -107,11 +107,6 @@
  * @run main/othervm -Xmx1g -Xms1g -XX:+UnlockDiagnosticVMOptions -XX:+UnlockExperimentalVMOptions
  *      -XX:+UseShenandoahGC -XX:ShenandoahGCHeuristics=adaptive -XX:ShenandoahGCMode=generational
  *      TestAllocObjects
- *
- * @run main/othervm -Xmx1g -Xms1g -XX:+UnlockDiagnosticVMOptions -XX:+UnlockExperimentalVMOptions
- *      -XX:+UseShenandoahGC -XX:ShenandoahGCHeuristics=adaptive -XX:ShenandoahGCMode=generational
- *      -XX:+ShenandoahSuspendibleWorkers
- *      TestAllocObjects
  */
 
 /*


### PR DESCRIPTION
/summary

ShenandoahSuspendibleWorkers was removed in JDK-8321410 in openjdk/jdk tip, but this version of the flag, which is present only in tests in genshen was missed in the merge from upstream. With this removal there are no other instances of this flag in the code or tests.

**Testing:** Verified that the test passes with the offending flag/test removed.

/issue

JDK-8322242

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed (1 review required, with at least 1 [Committer](https://openjdk.org/bylaws#committer))

### Issue
 * [JDK-8322242](https://bugs.openjdk.org/browse/JDK-8322242): [GenShen] TestAllocObjects#generational fails with "Unrecognized VM option 'ShenandoahSuspendibleWorkers'" (**Bug** - P4)


### Reviewers
 * [Kelvin Nilsen](https://openjdk.org/census#kdnilsen) (@kdnilsen - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/shenandoah.git pull/374/head:pull/374` \
`$ git checkout pull/374`

Update a local copy of the PR: \
`$ git checkout pull/374` \
`$ git pull https://git.openjdk.org/shenandoah.git pull/374/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 374`

View PR using the GUI difftool: \
`$ git pr show -t 374`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/shenandoah/pull/374.diff">https://git.openjdk.org/shenandoah/pull/374.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/shenandoah/pull/374#issuecomment-1858698578)