### PR TITLE
8322347: GenShen: Run shenandoah tier2 and tier3 tests separately in GHA

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -64,7 +64,8 @@ jobs:
           - 'hs/tier1 compiler part 2'
           - 'hs/tier1 compiler part 3'
           - 'hs/tier1 gc'
-          - 'hs/all shenandoah'
+          - 'hs/tier2_gc_shenandoah shenandoah tier2'
+          - 'hs/tier3_gc_shenandoah shenandoah tier3'
           - 'hs/tier1 runtime'
           - 'hs/tier1 serviceability'
           - 'lib-test/tier1'
@@ -102,8 +103,12 @@ jobs:
             test-suite: 'test/hotspot/jtreg/:tier1_gc'
             debug-suffix: -debug
 
-          - test-name: 'hs/all shenandoah'
-            test-suite: 'test/hotspot/jtreg/:hotspot_gc_shenandoah'
+          - test-name: 'hs/tier2_gc_shenandoah shenandoah tier2'
+            test-suite: 'test/hotspot/jtreg/:tier2_gc_shenandoah'
+            debug-suffix: -debug
+
+          - test-name: 'hs/tier3_gc_shenandoah shenandoah tier3'
+            test-suite: 'test/hotspot/jtreg/:tier3_gc_shenandoah'
             debug-suffix: -debug
 
           - test-name: 'hs/tier1 runtime'


### PR DESCRIPTION
The Shenandoah tier1 tests already run as part of the gc tier1 tests, so running all Shenandoah tiers repeats them. Running tier2 and tier3 tests separately should have them run in parallel and decrease overall time for GHA to complete.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed (1 review required, with at least 1 [Committer](https://openjdk.org/bylaws#committer))

### Issue
 * [JDK-8322347](https://bugs.openjdk.org/browse/JDK-8322347): GenShen: Run shenandoah tier2 and tier3 tests separately in GHA (**Task** - P4)


### Reviewers
 * [Y. Srinivas Ramakrishna](https://openjdk.org/census#ysr) (@ysramakrishna - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/shenandoah.git pull/375/head:pull/375` \
`$ git checkout pull/375`

Update a local copy of the PR: \
`$ git checkout pull/375` \
`$ git pull https://git.openjdk.org/shenandoah.git pull/375/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 375`

View PR using the GUI difftool: \
`$ git pr show -t 375`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/shenandoah/pull/375.diff">https://git.openjdk.org/shenandoah/pull/375.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/shenandoah/pull/375#issuecomment-1861918389)