### PR TITLE
8323630: GenShen: Control thread may (still) ignore requests to start concurrent GC

### DIFF
--- a/src/hotspot/share/gc/shenandoah/shenandoahControlThread.hpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahControlThread.hpp
@@ -86,14 +86,14 @@ public:
 private:
   ShenandoahSharedFlag _allow_old_preemption;
   ShenandoahSharedFlag _preemption_requested;
-  ShenandoahSharedFlag _gc_requested;
   ShenandoahSharedFlag _alloc_failure_gc;
   ShenandoahSharedFlag _humongous_alloc_failure_gc;
   ShenandoahSharedFlag _graceful_shutdown;
   ShenandoahSharedFlag _do_counters_update;
   ShenandoahSharedFlag _force_counters_update;
-  GCCause::Cause       _requested_gc_cause;
-  ShenandoahGenerationType _requested_generation;
+
+  volatile GCCause::Cause  _requested_gc_cause;
+  volatile ShenandoahGenerationType _requested_generation;
   ShenandoahGC::ShenandoahDegenPoint _degen_point;
   ShenandoahGeneration* _degen_generation;
 
@@ -123,9 +123,6 @@ private:
 
   // True if allocation failure flag has been set.
   bool is_alloc_failure_gc();
-
-  // True if humongous allocation failure flag has been set.
-  bool is_humongous_alloc_failure_gc();
 
   void reset_gc_id();
   void update_gc_id();

--- a/src/hotspot/share/gc/shenandoah/shenandoahControlThread.hpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahControlThread.hpp
@@ -92,7 +92,7 @@ private:
   ShenandoahSharedFlag _do_counters_update;
   ShenandoahSharedFlag _force_counters_update;
 
-  volatile GCCause::Cause  _requested_gc_cause;
+  GCCause::Cause  _requested_gc_cause;
   volatile ShenandoahGenerationType _requested_generation;
   ShenandoahGC::ShenandoahDegenPoint _degen_point;
   ShenandoahGeneration* _degen_generation;


### PR DESCRIPTION
A race condition exists in which the control thread may clear the `_requested_gc_cause` immediately after a mutator requests an explicit gc. When this happens, the control thread will no longer accept requests from the regulator to start concurrent GC cycles. The mutator thread will never wakeup, eventually the application will run out of memory or no progress will be made.

The change here is intended to simplify the thread communication protocol by reducing the number of variables in play.