### PR TITLE
8324173: GenShen: Fix error that could cause young gcs to fail when old marking is running

### DIFF
--- a/src/hotspot/share/gc/shenandoah/shenandoahControlThread.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahControlThread.cpp
@@ -891,6 +891,7 @@ bool ShenandoahControlThread::request_concurrent_gc(ShenandoahGenerationType gen
     }
 
     log_info(gc)("Preempting old generation mark to allow %s GC", shenandoah_generation_name(generation));
+    _requested_generation = generation;
     _preemption_requested.set();
     ShenandoahHeap::heap()->cancel_gc(GCCause::_shenandoah_concurrent_gc);
     notify_control_thread();


### PR DESCRIPTION
Accidentally deleted a line of code in recent PR#382. This violated the following assertion during an extremem run:
```
#  Internal Error (/codebuild/output/src3111/src/s3/00/src/hotspot/share/gc/shenandoah/shenandoahControlThread.cpp:747), pid=1492, tid=1502
#  assert(_requested_generation == YOUNG) failed: Only young GCs may preempt old.
```
Reached by this call stack:
```
V  [libjvm.so+0x16ed734]  ShenandoahControlThread::check_cancellation_or_degen(ShenandoahGC::ShenandoahDegenPoint)+0x294  (shenandoahControlThread.cpp:747)
V  [libjvm.so+0x16ee875]  ShenandoahControlThread::resume_concurrent_old_cycle(ShenandoahGeneration*, GCCause::Cause)+0x1e5  (shenandoahControlThread.cpp:601)
V  [libjvm.so+0x16eedf3]  ShenandoahControlThread::service_concurrent_old_cycle(ShenandoahHeap*, GCCause::Cause&)+0x1b3  (shenandoahControlThread.cpp:559)
V  [libjvm.so+0x16f02ae]  ShenandoahControlThread::run_service()+0x9fe  (shenandoahControlThread.cpp:308)

```

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed (1 review required, with at least 1 [Committer](https://openjdk.org/bylaws#committer))

### Issue
 * [JDK-8324173](https://bugs.openjdk.org/browse/JDK-8324173): GenShen: Fix error that could cause young gcs to fail when old marking is running (**Bug** - P4)


### Reviewers
 * [Kelvin Nilsen](https://openjdk.org/census#kdnilsen) (@kdnilsen - Committer)
 * [Y. Srinivas Ramakrishna](https://openjdk.org/census#ysr) (@ysramakrishna - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/shenandoah.git pull/385/head:pull/385` \
`$ git checkout pull/385`

Update a local copy of the PR: \
`$ git checkout pull/385` \
`$ git pull https://git.openjdk.org/shenandoah.git pull/385/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 385`

View PR using the GUI difftool: \
`$ git pr show -t 385`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/shenandoah/pull/385.diff">https://git.openjdk.org/shenandoah/pull/385.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/shenandoah/pull/385#issuecomment-1899269372)