### PR TITLE
8325670: GenShen: Allow old to expand at end of each GC

### DIFF
--- a/src/hotspot/share/gc/shenandoah/shenandoahHeap.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahHeap.cpp
@@ -1271,8 +1271,12 @@ void ShenandoahHeap::adjust_generation_sizes_for_next_cycle(
   const size_t young_reserve = (young_generation()->max_capacity() * ShenandoahEvacReserve) / 100;
 
   // In the case that ShenandoahOldEvacRatioPercent equals 100, max_old_reserve is limited only by xfer_limit.
-  const size_t max_old_reserve = (ShenandoahOldEvacRatioPercent == 100) ?
-    old_available + xfer_limit: (young_reserve * ShenandoahOldEvacRatioPercent) / (100 - ShenandoahOldEvacRatioPercent);
+
+  const size_t bound_on_old_reserve = old_available + xfer_limit + young_reserve;
+  const size_t max_old_reserve = (ShenandoahOldEvacRatioPercent == 100)?
+    bound_on_old_reserve: MIN2((young_reserve * ShenandoahOldEvacRatioPercent) / (100 - ShenandoahOldEvacRatioPercent),
+                               bound_on_old_reserve);
+
   const size_t region_size_bytes = ShenandoahHeapRegion::region_size_bytes();
 
   // Decide how much old space we should reserve for a mixed collection

--- a/src/hotspot/share/gc/shenandoah/shenandoahHeap.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahHeap.cpp
@@ -1269,10 +1269,10 @@ void ShenandoahHeap::adjust_generation_sizes_for_next_cycle(
   const size_t old_available = old_generation()->available();
   // The free set will reserve this amount of memory to hold young evacuations
   const size_t young_reserve = (young_generation()->max_capacity() * ShenandoahEvacReserve) / 100;
-  const size_t max_old_reserve = (ShenandoahOldEvacRatioPercent == 100) ?
-     old_available : MIN2((young_reserve * ShenandoahOldEvacRatioPercent) / (100 - ShenandoahOldEvacRatioPercent),
-                          old_available);
 
+  // In the case that ShenandoahOldEvacRatioPercent equals 100, max_old_reserve is limited only by xfer_limit.
+  const size_t max_old_reserve = (ShenandoahOldEvacRatioPercent == 100) ?
+    old_available + xfer_limit: (young_reserve * ShenandoahOldEvacRatioPercent) / (100 - ShenandoahOldEvacRatioPercent);
   const size_t region_size_bytes = ShenandoahHeapRegion::region_size_bytes();
 
   // Decide how much old space we should reserve for a mixed collection
@@ -1300,6 +1300,7 @@ void ShenandoahHeap::adjust_generation_sizes_for_next_cycle(
   const bool doing_promotions = promo_load > 0;
   if (doing_promotions) {
     // We're promoting and have a bound on the maximum amount that can be promoted
+    assert(max_old_reserve >= reserve_for_mixed, "Sanity");
     const size_t available_for_promotions = max_old_reserve - reserve_for_mixed;
     reserve_for_promo = MIN2((size_t)(promo_load * ShenandoahPromoEvacWaste), available_for_promotions);
   }


### PR DESCRIPTION
At the end of GC, we set aside collector reserves to satisfy anticipated needs of the next GC.

This PR reverts a change that accidentally prevents old-gen from being enlarged by this action.  The observed failure condition was that mixed evacuations were not able to be performed, because old-gen was not large enough to receive the results of the desired evacuations.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed (1 review required, with at least 1 [Committer](https://openjdk.org/bylaws#committer))

### Issue
 * [JDK-8325670](https://bugs.openjdk.org/browse/JDK-8325670): GenShen: Allow old to expand at end of each GC (**Bug** - P3)


### Reviewers
 * [Y. Srinivas Ramakrishna](https://openjdk.org/census#ysr) (@ysramakrishna - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/shenandoah.git pull/394/head:pull/394` \
`$ git checkout pull/394`

Update a local copy of the PR: \
`$ git checkout pull/394` \
`$ git pull https://git.openjdk.org/shenandoah.git pull/394/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 394`

View PR using the GUI difftool: \
`$ git pr show -t 394`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/shenandoah/pull/394.diff">https://git.openjdk.org/shenandoah/pull/394.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/shenandoah/pull/394#issuecomment-1939221929)