### PR TITLE
8326626: GenShen: Remove dead code associated with non-elastic TLABS

### DIFF
--- a/src/hotspot/share/gc/shenandoah/shenandoahFreeSet.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahFreeSet.cpp
@@ -785,14 +785,6 @@ HeapWord* ShenandoahFreeSet::try_allocate_in(ShenandoahHeapRegion* r, Shenandoah
                            " because min_size() is " SIZE_FORMAT, req.size(), r->index(), adjusted_size, req.min_size());
       }
     }
-  } else if (req.is_lab_alloc() && req.type() == ShenandoahAllocRequest::_alloc_plab) {
-
-    // inelastic PLAB
-    size_t size = req.size();
-    size_t usable_free = get_usable_free_words(r->free());
-    if (size <= usable_free) {
-      result = allocate_aligned_plab(size, req, r);
-    }
   } else {
     size_t size = req.size();
     result = r->allocate(size, req);

--- a/src/hotspot/share/gc/shenandoah/shenandoahFreeSet.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahFreeSet.cpp
@@ -785,6 +785,14 @@ HeapWord* ShenandoahFreeSet::try_allocate_in(ShenandoahHeapRegion* r, Shenandoah
                            " because min_size() is " SIZE_FORMAT, req.size(), r->index(), adjusted_size, req.min_size());
       }
     }
+  } else if (req.is_lab_alloc() && req.type() == ShenandoahAllocRequest::_alloc_plab) {
+
+    // inelastic PLAB
+    size_t size = req.size();
+    size_t usable_free = get_usable_free_words(r->free());
+    if (size <= usable_free) {
+      result = allocate_aligned_plab(size, req, r);
+    }
   } else {
     size_t size = req.size();
     result = r->allocate(size, req);


### PR DESCRIPTION
Remove extraneous remnant of code that is no longer needed because all LABs are not elastic.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed (1 review required, with at least 1 [Committer](https://openjdk.org/bylaws#committer))

### Issue
 * [JDK-8326626](https://bugs.openjdk.org/browse/JDK-8326626): GenShen: Remove dead code associated with non-elastic TLABS (**Bug** - P4)


### Reviewers
 * [William Kemper](https://openjdk.org/census#wkemper) (@earthling-amzn - Committer)
 * [Aleksey Shipilev](https://openjdk.org/census#shade) (@shipilev - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/shenandoah.git pull/400/head:pull/400` \
`$ git checkout pull/400`

Update a local copy of the PR: \
`$ git checkout pull/400` \
`$ git pull https://git.openjdk.org/shenandoah.git pull/400/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 400`

View PR using the GUI difftool: \
`$ git pr show -t 400`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/shenandoah/pull/400.diff">https://git.openjdk.org/shenandoah/pull/400.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/shenandoah/pull/400#issuecomment-1963122548)