### PR TITLE
8325885: GenShen: harmonize with JDK-8325671

### DIFF
--- a/src/hotspot/share/gc/shenandoah/shenandoahConcurrentMark.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahConcurrentMark.cpp
@@ -241,8 +241,6 @@ void ShenandoahConcurrentMark::concurrent_mark() {
   ShenandoahSATBMarkQueueSet& qset = ShenandoahBarrierSet::satb_mark_queue_set();
   ShenandoahFlushSATBHandshakeClosure flush_satb(qset);
   for (uint flushes = 0; flushes < ShenandoahMaxSATBBufferFlushes; flushes++) {
-    // TODO: ysr : hoist this switch out of the loop & refactor ?? How may
-    // typical calls do we do in this loop?
     switch (_generation->type()) {
       case YOUNG: {
         // Clear any old/partial local census data before the start of marking.

--- a/src/hotspot/share/gc/shenandoah/shenandoahConcurrentMark.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahConcurrentMark.cpp
@@ -66,8 +66,7 @@ public:
     ShenandoahReferenceProcessor* rp = heap->active_generation()->ref_processor();
     assert(rp != nullptr, "need reference processor");
     StringDedup::Requests requests;
-    _cm->mark_loop(GENERATION, worker_id, _terminator, rp,
-                   true /*cancellable*/,
+    _cm->mark_loop(worker_id, _terminator, rp, GENERATION, true /*cancellable*/,
                    ShenandoahStringDedup::is_enabled() ? ENQUEUE_DEDUP : NO_DEDUP,
                    &requests);
   }
@@ -129,8 +128,7 @@ public:
                                                ShenandoahIUBarrier ? &mark_cl : nullptr);
       Threads::possibly_parallel_threads_do(true /* is_par */, &tc);
     }
-    _cm->mark_loop(GENERATION, worker_id, _terminator, rp,
-                   false /*not cancellable*/,
+    _cm->mark_loop(worker_id, _terminator, rp, GENERATION, false /*not cancellable*/,
                    _dedup_string ? ENQUEUE_DEDUP : NO_DEDUP,
                    &requests);
     assert(_cm->task_queues()->is_empty(), "Should be empty");
@@ -197,17 +195,17 @@ void ShenandoahConcurrentMark::mark_concurrent_roots() {
       workers->run_task(&task);
       break;
     }
-    case GLOBAL_GEN: {
+    case GLOBAL: {
       assert(old_task_queues() == nullptr, "Global mark should not have old gen mark queues");
-      ShenandoahMarkConcurrentRootsTask<GLOBAL_GEN> task(task_queues(), nullptr, rp,
-                                                         ShenandoahPhaseTimings::conc_mark_roots, workers->active_workers());
+      ShenandoahMarkConcurrentRootsTask<GLOBAL> task(task_queues(), nullptr, rp,
+                                                     ShenandoahPhaseTimings::conc_mark_roots, workers->active_workers());
       workers->run_task(&task);
       break;
     }
-    case GLOBAL_NON_GEN: {
+    case NON_GEN: {
       assert(old_task_queues() == nullptr, "Non-generational mark should not have old gen mark queues");
-      ShenandoahMarkConcurrentRootsTask<GLOBAL_NON_GEN> task(task_queues(), nullptr, rp,
-                                                         ShenandoahPhaseTimings::conc_mark_roots, workers->active_workers());
+      ShenandoahMarkConcurrentRootsTask<NON_GEN> task(task_queues(), nullptr, rp,
+                                                      ShenandoahPhaseTimings::conc_mark_roots, workers->active_workers());
       workers->run_task(&task);
       break;
     }
@@ -243,6 +241,8 @@ void ShenandoahConcurrentMark::concurrent_mark() {
   ShenandoahSATBMarkQueueSet& qset = ShenandoahBarrierSet::satb_mark_queue_set();
   ShenandoahFlushSATBHandshakeClosure flush_satb(qset);
   for (uint flushes = 0; flushes < ShenandoahMaxSATBBufferFlushes; flushes++) {
+    // TODO: ysr : hoist this switch out of the loop & refactor ?? How may
+    // typical calls do we do in this loop?
     switch (_generation->type()) {
       case YOUNG: {
         // Clear any old/partial local census data before the start of marking.
@@ -259,18 +259,18 @@ void ShenandoahConcurrentMark::concurrent_mark() {
         workers->run_task(&task);
         break;
       }
-      case GLOBAL_GEN: {
+      case GLOBAL: {
         // Clear any old/partial local census data before the start of marking.
         heap->age_census()->reset_local();
         assert(heap->age_census()->is_clear_local(), "Error");
         TaskTerminator terminator(nworkers, task_queues());
-        ShenandoahConcurrentMarkingTask<GLOBAL_GEN> task(this, &terminator);
+        ShenandoahConcurrentMarkingTask<GLOBAL> task(this, &terminator);
         workers->run_task(&task);
         break;
       }
-      case GLOBAL_NON_GEN: {
+      case NON_GEN: {
         TaskTerminator terminator(nworkers, task_queues());
-        ShenandoahConcurrentMarkingTask<GLOBAL_NON_GEN> task(this, &terminator);
+        ShenandoahConcurrentMarkingTask<NON_GEN> task(this, &terminator);
         workers->run_task(&task);
         break;
       }
@@ -336,13 +336,13 @@ void ShenandoahConcurrentMark::finish_mark_work() {
       heap->workers()->run_task(&task);
       break;
     }
-    case GLOBAL_GEN:{
-      ShenandoahFinalMarkingTask<GLOBAL_GEN> task(this, &terminator, ShenandoahStringDedup::is_enabled());
+    case GLOBAL:{
+      ShenandoahFinalMarkingTask<GLOBAL> task(this, &terminator, ShenandoahStringDedup::is_enabled());
       heap->workers()->run_task(&task);
       break;
     }
-    case GLOBAL_NON_GEN:{
-      ShenandoahFinalMarkingTask<GLOBAL_NON_GEN> task(this, &terminator, ShenandoahStringDedup::is_enabled());
+    case NON_GEN:{
+      ShenandoahFinalMarkingTask<NON_GEN> task(this, &terminator, ShenandoahStringDedup::is_enabled());
       heap->workers()->run_task(&task);
       break;
     }

--- a/src/hotspot/share/gc/shenandoah/shenandoahConcurrentMark.hpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahConcurrentMark.hpp
@@ -25,6 +25,7 @@
 #ifndef SHARE_GC_SHENANDOAH_SHENANDOAHCONCURRENTMARK_HPP
 #define SHARE_GC_SHENANDOAH_SHENANDOAHCONCURRENTMARK_HPP
 
+#include "gc/shenandoah/shenandoahGenerationType.hpp"
 #include "gc/shenandoah/shenandoahMark.hpp"
 
 template <ShenandoahGenerationType GENERATION>

--- a/src/hotspot/share/gc/shenandoah/shenandoahControlThread.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahControlThread.cpp
@@ -433,14 +433,14 @@ void ShenandoahControlThread::service_concurrent_normal_cycle(ShenandoahHeap* he
       service_concurrent_old_cycle(heap, cause);
       break;
     }
-    case GLOBAL_GEN: {
+    case GLOBAL: {
       log_info(gc, ergo)("Start GC cycle (GLOBAL)");
       the_generation = heap->global_generation();
       service_concurrent_cycle(the_generation, cause, false);
       break;
     }
-    case GLOBAL_NON_GEN: {
-      log_info(gc, ergo)("Start GC cycle");
+    case NON_GEN: {
+      log_info(gc, ergo)("Start GC cycle (NON-GENERATIONAL)");
       the_generation = heap->global_generation();
       service_concurrent_cycle(the_generation, cause, false);
       break;
@@ -947,8 +947,8 @@ void ShenandoahControlThread::set_gc_mode(ShenandoahControlThread::GCMode new_mo
 
 ShenandoahGenerationType ShenandoahControlThread::select_global_generation() {
   if (ShenandoahHeap::heap()->mode()->is_generational()) {
-    return GLOBAL_GEN;
+    return GLOBAL;
   } else {
-    return GLOBAL_NON_GEN;
+    return NON_GEN;
   }
 }

--- a/src/hotspot/share/gc/shenandoah/shenandoahControlThread.hpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahControlThread.hpp
@@ -29,6 +29,8 @@
 #include "gc/shared/gcCause.hpp"
 #include "gc/shared/concurrentGCThread.hpp"
 #include "gc/shenandoah/shenandoahGC.hpp"
+#include "gc/shenandoah/shenandoahGenerationType.hpp"
+#include "gc/shenandoah/shenandoahHeap.hpp"
 #include "gc/shenandoah/shenandoahPadding.hpp"
 #include "gc/shenandoah/shenandoahSharedVariables.hpp"
 

--- a/src/hotspot/share/gc/shenandoah/shenandoahGeneration.hpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahGeneration.hpp
@@ -105,7 +105,7 @@ private:
 
   bool is_young() const  { return _type == YOUNG; }
   bool is_old() const    { return _type == OLD; }
-  bool is_global() const { return _type == GLOBAL_GEN || _type == GLOBAL_NON_GEN; }
+  bool is_global() const { return _type == GLOBAL || _type == NON_GEN; }
 
   inline ShenandoahGenerationType type() const { return _type; }
 

--- a/src/hotspot/share/gc/shenandoah/shenandoahGenerationType.hpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahGenerationType.hpp
@@ -26,17 +26,17 @@
 #define SHARE_GC_SHENANDOAH_SHENANDOAHGENERATIONTYPE_HPP
 
 enum ShenandoahGenerationType {
-    GLOBAL_NON_GEN,  // Global, non-generational
-    GLOBAL_GEN,      // Global, generational
-    YOUNG,           // Young,  generational
-    OLD              // Old,    generational
+    NON_GEN,         // non-generational
+    GLOBAL,          // generational: Global
+    YOUNG,           // generational: Young
+    OLD              // generational: Old
 };
 
 inline const char* shenandoah_generation_name(ShenandoahGenerationType mode) {
   switch (mode) {
-    case GLOBAL_NON_GEN:
-      return "";
-    case GLOBAL_GEN:
+    case NON_GEN:
+      return "Non-Generational";
+    case GLOBAL:
       return "Global";
     case OLD:
       return "Old";
@@ -44,7 +44,7 @@ inline const char* shenandoah_generation_name(ShenandoahGenerationType mode) {
       return "Young";
     default:
       ShouldNotReachHere();
-      return "?";
+      return "Unknown";
   }
 }
 

--- a/src/hotspot/share/gc/shenandoah/shenandoahGlobalGeneration.hpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahGlobalGeneration.hpp
@@ -33,7 +33,7 @@
 class ShenandoahGlobalGeneration : public ShenandoahGeneration {
 public:
   ShenandoahGlobalGeneration(bool generational, uint max_queues, size_t max_capacity, size_t soft_max_capacity)
-  : ShenandoahGeneration(generational ? GLOBAL_GEN : GLOBAL_NON_GEN, max_queues, max_capacity, soft_max_capacity) { }
+  : ShenandoahGeneration(generational ? GLOBAL : NON_GEN, max_queues, max_capacity, soft_max_capacity) { }
 
 public:
   const char* name() const override;

--- a/src/hotspot/share/gc/shenandoah/shenandoahHeap.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahHeap.cpp
@@ -502,8 +502,8 @@ size_t ShenandoahHeap::max_size_for(ShenandoahGeneration* generation) const {
       return _generation_sizer.max_young_size();
     case OLD:
       return max_capacity() - _generation_sizer.min_young_size();
-    case GLOBAL_GEN:
-    case GLOBAL_NON_GEN:
+    case GLOBAL:
+    case NON_GEN:
       return max_capacity();
     default:
       ShouldNotReachHere();
@@ -517,8 +517,8 @@ size_t ShenandoahHeap::min_size_for(ShenandoahGeneration* generation) const {
       return _generation_sizer.min_young_size();
     case OLD:
       return max_capacity() - _generation_sizer.max_young_size();
-    case GLOBAL_GEN:
-    case GLOBAL_NON_GEN:
+    case GLOBAL:
+    case NON_GEN:
       return min_capacity();
     default:
       ShouldNotReachHere();
@@ -3458,12 +3458,12 @@ void ShenandoahGenerationRegionClosure<OLD>::heap_region_do(ShenandoahHeapRegion
 }
 
 template<>
-void ShenandoahGenerationRegionClosure<GLOBAL_GEN>::heap_region_do(ShenandoahHeapRegion* region) {
+void ShenandoahGenerationRegionClosure<GLOBAL>::heap_region_do(ShenandoahHeapRegion* region) {
   _cl->heap_region_do(region);
 }
 
 template<>
-void ShenandoahGenerationRegionClosure<GLOBAL_NON_GEN>::heap_region_do(ShenandoahHeapRegion* region) {
+void ShenandoahGenerationRegionClosure<NON_GEN>::heap_region_do(ShenandoahHeapRegion* region) {
   _cl->heap_region_do(region);
 }
 

--- a/src/hotspot/share/gc/shenandoah/shenandoahHeapRegionCounters.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahHeapRegionCounters.cpp
@@ -157,8 +157,8 @@ static int encode_phase(ShenandoahHeap* heap) {
 
 static int get_generation_shift(ShenandoahGeneration* generation) {
   switch (generation->type()) {
-    case GLOBAL_NON_GEN:
-    case GLOBAL_GEN:
+    case NON_GEN:
+    case GLOBAL:
       return 0;
     case OLD:
       return 2;

--- a/src/hotspot/share/gc/shenandoah/shenandoahMark.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahMark.cpp
@@ -88,7 +88,8 @@ void ShenandoahMark::mark_loop_prework(uint w, TaskTerminator *t, ShenandoahRefe
 }
 
 template<bool CANCELLABLE, StringDedupMode STRING_DEDUP>
-void ShenandoahMark::mark_loop(ShenandoahGenerationType generation, uint worker_id, TaskTerminator* terminator, ShenandoahReferenceProcessor *rp, StringDedup::Requests* const req) {
+void ShenandoahMark::mark_loop(uint worker_id, TaskTerminator* terminator, ShenandoahReferenceProcessor *rp,
+                               ShenandoahGenerationType generation, StringDedup::Requests* const req) {
   bool update_refs = ShenandoahHeap::heap()->has_forwarded_objects();
   switch (generation) {
     case YOUNG:
@@ -98,11 +99,11 @@ void ShenandoahMark::mark_loop(ShenandoahGenerationType generation, uint worker_
       // Old generation collection only performs marking, it should not update references.
       mark_loop_prework<OLD, CANCELLABLE, STRING_DEDUP>(worker_id, terminator, rp, req, false);
       break;
-    case GLOBAL_GEN:
-      mark_loop_prework<GLOBAL_GEN, CANCELLABLE, STRING_DEDUP>(worker_id, terminator, rp, req, update_refs);
+    case GLOBAL:
+      mark_loop_prework<GLOBAL, CANCELLABLE, STRING_DEDUP>(worker_id, terminator, rp, req, update_refs);
       break;
-    case GLOBAL_NON_GEN:
-      mark_loop_prework<GLOBAL_NON_GEN, CANCELLABLE, STRING_DEDUP>(worker_id, terminator, rp, req, update_refs);
+    case NON_GEN:
+      mark_loop_prework<NON_GEN, CANCELLABLE, STRING_DEDUP>(worker_id, terminator, rp, req, update_refs);
       break;
     default:
       ShouldNotReachHere();
@@ -110,30 +111,30 @@ void ShenandoahMark::mark_loop(ShenandoahGenerationType generation, uint worker_
   }
 }
 
-void ShenandoahMark::mark_loop(ShenandoahGenerationType generation, uint worker_id, TaskTerminator* terminator, ShenandoahReferenceProcessor *rp,
-                               bool cancellable, StringDedupMode dedup_mode, StringDedup::Requests* const req) {
+void ShenandoahMark::mark_loop(uint worker_id, TaskTerminator* terminator, ShenandoahReferenceProcessor *rp,
+                               ShenandoahGenerationType generation, bool cancellable, StringDedupMode dedup_mode, StringDedup::Requests* const req) {
   if (cancellable) {
     switch(dedup_mode) {
       case NO_DEDUP:
-        mark_loop<true, NO_DEDUP>(generation, worker_id, terminator, rp, req);
+        mark_loop<true, NO_DEDUP>(worker_id, terminator, rp, generation, req);
         break;
       case ENQUEUE_DEDUP:
-        mark_loop<true, ENQUEUE_DEDUP>(generation, worker_id, terminator, rp, req);
+        mark_loop<true, ENQUEUE_DEDUP>(worker_id, terminator, rp, generation, req);
         break;
       case ALWAYS_DEDUP:
-        mark_loop<true, ALWAYS_DEDUP>(generation, worker_id, terminator, rp, req);
+        mark_loop<true, ALWAYS_DEDUP>(worker_id, terminator, rp, generation, req);
         break;
     }
   } else {
     switch(dedup_mode) {
       case NO_DEDUP:
-        mark_loop<false, NO_DEDUP>(generation, worker_id, terminator, rp, req);
+        mark_loop<false, NO_DEDUP>(worker_id, terminator, rp, generation, req);
         break;
       case ENQUEUE_DEDUP:
-        mark_loop<false, ENQUEUE_DEDUP>(generation, worker_id, terminator, rp, req);
+        mark_loop<false, ENQUEUE_DEDUP>(worker_id, terminator, rp, generation, req);
         break;
       case ALWAYS_DEDUP:
-        mark_loop<false, ALWAYS_DEDUP>(generation, worker_id, terminator, rp, req);
+        mark_loop<false, ALWAYS_DEDUP>(worker_id, terminator, rp, generation, req);
         break;
     }
   }

--- a/src/hotspot/share/gc/shenandoah/shenandoahMark.hpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahMark.hpp
@@ -29,6 +29,7 @@
 #include "gc/shared/ageTable.hpp"
 #include "gc/shared/stringdedup/stringDedup.hpp"
 #include "gc/shared/taskTerminator.hpp"
+#include "gc/shenandoah/shenandoahGenerationType.hpp"
 #include "gc/shenandoah/shenandoahHeap.hpp"
 #include "gc/shenandoah/shenandoahTaskqueue.hpp"
 
@@ -104,11 +105,11 @@ private:
   inline void dedup_string(oop obj, StringDedup::Requests* const req);
 protected:
   template<bool CANCELLABLE, StringDedupMode STRING_DEDUP>
-  void mark_loop(ShenandoahGenerationType generation, uint worker_id, TaskTerminator* terminator, ShenandoahReferenceProcessor *rp,
-                 StringDedup::Requests* const req);
+  void mark_loop(uint worker_id, TaskTerminator* terminator, ShenandoahReferenceProcessor *rp,
+                 ShenandoahGenerationType generation, StringDedup::Requests* const req);
 
-  void mark_loop(ShenandoahGenerationType generation, uint worker_id, TaskTerminator* terminator, ShenandoahReferenceProcessor *rp,
-                 bool cancellable, StringDedupMode dedup_mode, StringDedup::Requests* const req);
+  void mark_loop(uint worker_id, TaskTerminator* terminator, ShenandoahReferenceProcessor *rp,
+                 ShenandoahGenerationType generation, bool cancellable, StringDedupMode dedup_mode, StringDedup::Requests* const req);
 };
 
 #endif // SHARE_GC_SHENANDOAH_SHENANDOAHMARK_HPP

--- a/src/hotspot/share/gc/shenandoah/shenandoahMark.inline.hpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahMark.inline.hpp
@@ -116,7 +116,7 @@ inline void ShenandoahMark::count_liveness(ShenandoahLiveData* live_data, oop ob
   const size_t size = obj->size();
 
   // Age census for objects in the young generation
-  if (GENERATION == YOUNG || (GENERATION == GLOBAL_GEN && region->is_young())) {
+  if (GENERATION == YOUNG || (GENERATION == GLOBAL && region->is_young())) {
     assert(heap->mode()->is_generational(), "Only if generational");
     if (ShenandoahGenerationalAdaptiveTenuring && !ShenandoahGenerationalCensusAtEvac) {
       assert(region->is_young(), "Only for young objects");
@@ -282,7 +282,7 @@ bool ShenandoahMark::in_generation(ShenandoahHeap* const heap, oop obj) {
     return heap->is_in_young(obj);
   } else if (GENERATION == OLD) {
     return heap->is_in_old(obj);
-  } else if (GENERATION == GLOBAL_GEN || GENERATION == GLOBAL_NON_GEN) {
+  } else if (GENERATION == GLOBAL || GENERATION == NON_GEN) {
     return true;
   } else {
     return false;
@@ -304,7 +304,7 @@ inline void ShenandoahMark::mark_through_ref(T *p, ShenandoahObjToScanQueue* q, 
     if (in_generation<GENERATION>(heap, obj)) {
       mark_ref(q, mark_context, weak, obj);
       shenandoah_assert_marked(p, obj);
-      // TODO: As implemented herein, GLOBAL_GEN collections reconstruct the card table during GLOBAL_GEN concurrent
+      // TODO: As implemented herein, GLOBAL collections reconstruct the card table during GLOBAL concurrent
       // marking. Note that the card table is cleaned at init_mark time so it needs to be reconstructed to support
       // future young-gen collections.  It might be better to reconstruct card table in
       // ShenandoahHeapRegion::global_oop_iterate_and_fill_dead.  We could either mark all live memory as dirty, or could
@@ -312,7 +312,7 @@ inline void ShenandoahMark::mark_through_ref(T *p, ShenandoahObjToScanQueue* q, 
       if (GENERATION == YOUNG && heap->is_in_old(p)) {
         // Mark card as dirty because remembered set scanning still finds interesting pointer.
         heap->mark_card_as_dirty((HeapWord*)p);
-      } else if (GENERATION == GLOBAL_GEN && heap->is_in_old(p) && heap->is_in_young(obj)) {
+      } else if (GENERATION == GLOBAL && heap->is_in_old(p) && heap->is_in_young(obj)) {
         // Mark card as dirty because GLOBAL marking finds interesting pointer.
         heap->mark_card_as_dirty((HeapWord*)p);
       }

--- a/src/hotspot/share/gc/shenandoah/shenandoahOopClosures.hpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahOopClosures.hpp
@@ -28,6 +28,7 @@
 
 #include "gc/shared/stringdedup/stringDedup.hpp"
 #include "gc/shenandoah/shenandoahClosures.inline.hpp"
+#include "gc/shenandoah/shenandoahGenerationType.hpp"
 #include "gc/shenandoah/shenandoahHeap.inline.hpp"
 #include "gc/shenandoah/shenandoahTaskqueue.hpp"
 #include "gc/shenandoah/shenandoahUtils.hpp"

--- a/src/hotspot/share/gc/shenandoah/shenandoahRegulatorThread.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahRegulatorThread.cpp
@@ -63,7 +63,7 @@ void ShenandoahRegulatorThread::regulate_young_and_old_cycles() {
     ShenandoahGenerationalControlThread::GCMode mode = _control_thread->gc_mode();
     if (mode == ShenandoahGenerationalControlThread::none) {
       if (should_start_metaspace_gc()) {
-        if (request_concurrent_gc(GLOBAL_GEN)) {
+        if (request_concurrent_gc(GLOBAL)) {
           log_info(gc)("Heuristics request for global (unload classes) accepted.");
         }
       } else {
@@ -134,7 +134,7 @@ bool ShenandoahRegulatorThread::start_young_cycle() {
 }
 
 bool ShenandoahRegulatorThread::start_global_cycle() {
-  return _global_heuristics->should_start_gc() && request_concurrent_gc(GLOBAL_GEN);
+  return _global_heuristics->should_start_gc() && request_concurrent_gc(GLOBAL);
 }
 
 bool ShenandoahRegulatorThread::request_concurrent_gc(ShenandoahGenerationType generation) {

--- a/src/hotspot/share/gc/shenandoah/shenandoahUtils.hpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahUtils.hpp
@@ -46,9 +46,9 @@ class ShenandoahGeneration;
 
 #define SHENANDOAH_RETURN_EVENT_MESSAGE(generation_type, prefix, postfix) \
   switch (generation_type) {                                              \
-    case GLOBAL_NON_GEN:                                                  \
-      return prefix "" postfix;                                           \
-    case GLOBAL_GEN:                                                      \
+    case NON_GEN:                                                         \
+      return prefix " (NON-GENERATIONAL)" postfix;                        \
+    case GLOBAL:                                                          \
       return prefix " (GLOBAL)" postfix;                                  \
     case YOUNG:                                                           \
       return prefix " (YOUNG)" postfix;                                   \
@@ -56,7 +56,7 @@ class ShenandoahGeneration;
       return prefix " (OLD)" postfix;                                     \
     default:                                                              \
       ShouldNotReachHere();                                               \
-      return prefix " (?)" postfix;                                       \
+      return prefix " (UNKNOWN)" postfix;                                 \
   }                                                                       \
 
 class ShenandoahGCSession : public StackObj {


### PR DESCRIPTION
/issue JDK-8325885

Harmonize with the changes in JDK-8325671.

Renames:
- GLOBAL_NON_GEN -> NON_GEN
- GLOBAL_GEN -> GLOBAL
- ? -> UNKNOWN

Some reordering of arguments to follow existing convention.

**Testing:**
- [x] GHA (TestHumongous... failures are independent, and addressed in JDK-8327000)
- [x] code pipeline testing

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed (1 review required, with at least 1 [Committer](https://openjdk.org/bylaws#committer))

### Issue
 * [JDK-8325885](https://bugs.openjdk.org/browse/JDK-8325885): GenShen: harmonize with JDK-8325671 (**Sub-task** - P4)


### Reviewers
 * [Kelvin Nilsen](https://openjdk.org/census#kdnilsen) (@kdnilsen - Committer) ⚠️ Review applies to [c1d38870](https://git.openjdk.org/shenandoah/pull/402/files/c1d388705d158a27d5a3da4f4d23dd268118d62b)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/shenandoah.git pull/402/head:pull/402` \
`$ git checkout pull/402`

Update a local copy of the PR: \
`$ git checkout pull/402` \
`$ git pull https://git.openjdk.org/shenandoah.git pull/402/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 402`

View PR using the GUI difftool: \
`$ git pr show -t 402`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/shenandoah/pull/402.diff">https://git.openjdk.org/shenandoah/pull/402.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/shenandoah/pull/402#issuecomment-1974203271)