### PR TITLE
8332095: GenShen: Move more generational mode members out of shHeap

### DIFF
--- a/src/hotspot/share/gc/shenandoah/shenandoahConcurrentGC.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahConcurrentGC.cpp
@@ -1215,7 +1215,8 @@ void ShenandoahConcurrentGC::op_final_updaterefs() {
     heap->verifier()->verify_roots_in_to_space();
   }
 
-  // This needs to see is_aging_cycle
+  // If we are running in generational mode and this is an aging cycle, this will also age active
+  // regions that haven't been used for allocation.
   heap->update_heap_region_states(true /*concurrent*/);
 
   heap->set_update_refs_in_progress(false);

--- a/src/hotspot/share/gc/shenandoah/shenandoahConcurrentGC.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahConcurrentGC.cpp
@@ -645,7 +645,7 @@ void ShenandoahConcurrentGC::op_init_mark() {
       // old generation mark queue. Any pointers in a young region will be
       // abandoned.
       ShenandoahGCPhase phase(ShenandoahPhaseTimings::init_transfer_satb);
-      heap->transfer_old_pointers_from_satb();
+      heap->old_generation()->transfer_pointers_from_satb();
     }
   }
 
@@ -1230,7 +1230,7 @@ void ShenandoahConcurrentGC::op_final_updaterefs() {
     // We are not concerned about skipping this step in abbreviated cycles because regions
     // with no live objects cannot have been written to and so cannot have entries in the SATB
     // buffers.
-    heap->transfer_old_pointers_from_satb();
+    heap->old_generation()->transfer_pointers_from_satb();
   }
 
   heap->update_heap_region_states(true /*concurrent*/);
@@ -1264,7 +1264,7 @@ void ShenandoahConcurrentGC::op_final_roots() {
     // the last GC safepoint before concurrent marking of old resumes. We must be sure
     // that old mark threads don't see any pointers to garbage in the SATB buffers.
     if (heap->is_concurrent_old_mark_in_progress()) {
-      heap->transfer_old_pointers_from_satb();
+      heap->old_generation()->transfer_pointers_from_satb();
     }
 
     ShenandoahMarkingContext *ctx = heap->complete_marking_context();

--- a/src/hotspot/share/gc/shenandoah/shenandoahConcurrentGC.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahConcurrentGC.cpp
@@ -639,7 +639,7 @@ void ShenandoahConcurrentGC::op_init_mark() {
     }
 
     if (_generation->is_global()) {
-      heap->cancel_old_gc();
+      heap->old_generation()->cancel_gc();
     } else if (heap->is_concurrent_old_mark_in_progress()) {
       // Purge the SATB buffers, transferring any valid, old pointers to the
       // old generation mark queue. Any pointers in a young region will be

--- a/src/hotspot/share/gc/shenandoah/shenandoahDegeneratedGC.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahDegeneratedGC.cpp
@@ -162,7 +162,7 @@ void ShenandoahDegenGC::op_degenerated() {
           // transferred to the old generation mark queues and the young pointers are NOT part
           // of this snapshot, so they must be dropped here. It is safe to drop them here because
           // we will rescan the roots on this safepoint.
-          heap->transfer_old_pointers_from_satb();
+          heap->old_generation()->transfer_pointers_from_satb();
         }
       }
 
@@ -284,7 +284,7 @@ void ShenandoahDegenGC::op_degenerated() {
         // This is still necessary for degenerated cycles because the degeneration point may occur
         // after final mark of the young generation. See ShenandoahConcurrentGC::op_final_updaterefs for
         // a more detailed explanation.
-        heap->transfer_old_pointers_from_satb();
+        heap->old_generation()->transfer_pointers_from_satb();
       }
 
       op_cleanup_complete();

--- a/src/hotspot/share/gc/shenandoah/shenandoahGenerationalControlThread.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahGenerationalControlThread.cpp
@@ -61,7 +61,7 @@ ShenandoahGenerationalControlThread::ShenandoahGenerationalControlThread() :
 }
 
 void ShenandoahGenerationalControlThread::run_service() {
-  ShenandoahHeap* const heap = ShenandoahHeap::heap();
+  ShenandoahGenerationalHeap* const heap = ShenandoahGenerationalHeap::heap();
 
   const GCMode default_mode = concurrent_normal;
   ShenandoahGenerationType generation = GLOBAL;

--- a/src/hotspot/share/gc/shenandoah/shenandoahGenerationalFullGC.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahGenerationalFullGC.cpp
@@ -59,7 +59,7 @@ void ShenandoahGenerationalFullGC::prepare() {
   heap->reset_generation_reserves();
 
   // Full GC supersedes any marking or coalescing in old generation.
-  heap->cancel_old_gc();
+  heap->old_generation()->cancel_gc();
 }
 
 void ShenandoahGenerationalFullGC::handle_completion(ShenandoahHeap* heap) {

--- a/src/hotspot/share/gc/shenandoah/shenandoahGenerationalFullGC.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahGenerationalFullGC.cpp
@@ -187,7 +187,7 @@ ShenandoahPrepareForGenerationalCompactionObjectClosure::ShenandoahPrepareForGen
                                                           GrowableArray<ShenandoahHeapRegion*>& empty_regions,
                                                           ShenandoahHeapRegion* from_region, uint worker_id) :
         _preserved_marks(preserved_marks),
-        _heap(ShenandoahHeap::heap()),
+        _heap(ShenandoahGenerationalHeap::heap()),
         _tenuring_threshold(0),
         _empty_regions(empty_regions),
         _empty_regions_pos(0),

--- a/src/hotspot/share/gc/shenandoah/shenandoahGenerationalFullGC.hpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahGenerationalFullGC.hpp
@@ -87,9 +87,9 @@ public:
 
 class ShenandoahPrepareForGenerationalCompactionObjectClosure : public ObjectClosure {
 private:
-  PreservedMarks*          const _preserved_marks;
-  ShenandoahHeap*          const _heap;
-  uint                           _tenuring_threshold;
+  PreservedMarks*             const _preserved_marks;
+  ShenandoahGenerationalHeap* const _heap;
+  uint                              _tenuring_threshold;
 
   // _empty_regions is a thread-local list of heap regions that have been completely emptied by this worker thread's
   // compaction efforts.  The worker thread that drives these efforts adds compacted regions to this list if the

--- a/src/hotspot/share/gc/shenandoah/shenandoahGenerationalHeap.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahGenerationalHeap.cpp
@@ -710,4 +710,3 @@ void ShenandoahGenerationalHeap::coalesce_and_fill_old_regions(bool concurrent) 
   workers()->run_task(&coalesce);
   old_generation()->set_parseable(true);
 }
-

--- a/src/hotspot/share/gc/shenandoah/shenandoahGenerationalHeap.hpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahGenerationalHeap.hpp
@@ -41,6 +41,15 @@ public:
 
   // ---------- Evacuations and Promotions
   //
+  ShenandoahSharedFlag  _is_aging_cycle;
+  void set_aging_cycle(bool cond) {
+    _is_aging_cycle.set_cond(cond);
+  }
+
+  inline bool is_aging_cycle() const {
+    return _is_aging_cycle.is_set();
+  }
+
   oop evacuate_object(oop p, Thread* thread) override;
   oop try_evacuate_object(oop p, Thread* thread, ShenandoahHeapRegion* from_region, ShenandoahAffiliation target_gen);
 

--- a/src/hotspot/share/gc/shenandoah/shenandoahGenerationalHeap.hpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahGenerationalHeap.hpp
@@ -91,6 +91,7 @@ public:
   // Transfers surplus old regions to young, or takes regions from young to satisfy old region deficit
   TransferResult balance_generations();
 
+  // Makes old regions parsable
   void coalesce_and_fill_old_regions(bool concurrent);
 
 private:

--- a/src/hotspot/share/gc/shenandoah/shenandoahHeap.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahHeap.cpp
@@ -2884,10 +2884,6 @@ bool ShenandoahHeap::requires_barriers(stackChunkOop obj) const {
   return false;
 }
 
-void ShenandoahHeap::transfer_old_pointers_from_satb() {
-  _old_generation->transfer_pointers_from_satb();
-}
-
 bool ShenandoahHeap::verify_generation_usage(bool verify_old, size_t old_regions, size_t old_bytes, size_t old_waste,
                                              bool verify_young, size_t young_regions, size_t young_bytes, size_t young_waste) {
   size_t tally_old_regions = 0;

--- a/src/hotspot/share/gc/shenandoah/shenandoahHeap.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahHeap.cpp
@@ -970,26 +970,6 @@ HeapWord* ShenandoahHeap::allocate_from_gclab_slow(Thread* thread, size_t size) 
   return gclab->allocate(size);
 }
 
-void ShenandoahHeap::cancel_old_gc() {
-  shenandoah_assert_safepoint();
-  assert(old_generation() != nullptr, "Should only have mixed collections in generation mode.");
-  if (old_generation()->is_idle()) {
-#ifdef ASSERT
-    old_generation()->validate_waiting_for_bootstrap();
-#endif
-  } else {
-    log_info(gc)("Terminating old gc cycle.");
-    // Stop marking
-    old_generation()->cancel_marking();
-    // Stop tracking old regions
-    old_generation()->abandon_collection_candidates();
-    // Remove old generation access to young generation mark queues
-    young_generation()->set_old_gen_task_queues(nullptr);
-    // Transition to IDLE now.
-    old_generation()->transition_to(ShenandoahOldGeneration::WAITING_FOR_BOOTSTRAP);
-  }
-}
-
 // Called from stubs in JIT code or interpreter
 HeapWord* ShenandoahHeap::allocate_new_tlab(size_t min_size,
                                             size_t requested_size,

--- a/src/hotspot/share/gc/shenandoah/shenandoahHeap.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahHeap.cpp
@@ -2018,10 +2018,6 @@ bool ShenandoahHeap::is_prepare_for_old_mark_in_progress() const {
   return old_generation()->is_preparing_for_mark();
 }
 
-void ShenandoahHeap::set_aging_cycle(bool in_progress) {
-  _is_aging_cycle.set_cond(in_progress);
-}
-
 void ShenandoahHeap::manage_satb_barrier(bool active) {
   if (is_concurrent_mark_in_progress()) {
     // Ignore request to deactivate barrier while concurrent mark is in progress.
@@ -2585,7 +2581,7 @@ public:
         // There have been allocations in this region since the start of the cycle.
         // Any objects new to this region must not assimilate elevated age.
         r->reset_age();
-      } else if (ShenandoahHeap::heap()->is_aging_cycle()) {
+      } else if (ShenandoahGenerationalHeap::heap()->is_aging_cycle()) {
         r->increment_age();
       }
     }

--- a/src/hotspot/share/gc/shenandoah/shenandoahHeap.hpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahHeap.hpp
@@ -379,8 +379,6 @@ public:
   void set_concurrent_strong_root_in_progress(bool cond);
   void set_concurrent_weak_root_in_progress(bool cond);
 
-  void set_aging_cycle(bool cond);
-
   inline bool is_stable() const;
   inline bool is_idle() const;
 
@@ -398,7 +396,6 @@ public:
   inline bool is_concurrent_strong_root_in_progress() const;
   inline bool is_concurrent_weak_root_in_progress() const;
   bool is_prepare_for_old_mark_in_progress() const;
-  inline bool is_aging_cycle() const;
 
   // Return the age census object for young gen (in generational mode)
   inline ShenandoahAgeCensus* age_census() const;
@@ -536,7 +533,6 @@ public:
 // ---------- Class Unloading
 //
 private:
-  ShenandoahSharedFlag  _is_aging_cycle;
   ShenandoahSharedFlag _unload_classes;
   ShenandoahUnload     _unloader;
 

--- a/src/hotspot/share/gc/shenandoah/shenandoahHeap.hpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahHeap.hpp
@@ -739,7 +739,6 @@ public:
   inline RememberedScanner* card_scan() { return _card_scan; }
   void clear_cards_for(ShenandoahHeapRegion* region);
   void mark_card_as_dirty(void* location);
-  void cancel_old_gc();
 
 // ---------- Helper functions
 //

--- a/src/hotspot/share/gc/shenandoah/shenandoahHeap.hpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahHeap.hpp
@@ -771,8 +771,6 @@ public:
   // mutator
   static inline uint get_object_age(oop obj);
 
-  void transfer_old_pointers_from_satb();
-
   void log_heap_status(const char *msg) const;
 
 private:

--- a/src/hotspot/share/gc/shenandoah/shenandoahHeap.inline.hpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahHeap.inline.hpp
@@ -507,10 +507,6 @@ inline bool ShenandoahHeap::is_concurrent_weak_root_in_progress() const {
   return _gc_state.is_set(WEAK_ROOTS);
 }
 
-inline bool ShenandoahHeap::is_aging_cycle() const {
-  return _is_aging_cycle.is_set();
-}
-
 template<class T>
 inline void ShenandoahHeap::marked_object_iterate(ShenandoahHeapRegion* region, T* cl) {
   marked_object_iterate(region, cl, region->top());

--- a/src/hotspot/share/gc/shenandoah/shenandoahOldGeneration.hpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahOldGeneration.hpp
@@ -193,6 +193,9 @@ public:
   void record_success_concurrent(bool abbreviated) override;
   void cancel_marking() override;
 
+  // Cancels old gc and transitions to the idle state
+  void cancel_gc();
+
   // We leave the SATB barrier on for the entirety of the old generation
   // marking phase. In some cases, this can cause a write to a perfectly
   // reachable oop to enqueue a pointer that later becomes garbage (because


### PR DESCRIPTION
The following members and methods in shHeap are only used in generational mode and can be moved out of common code:
* ShenandoahHeap::cancel_old_gc
* ShenandoahHeap::transfer_old_pointers_from_satb
* ShenandoahHeap::_is_aging_cycle

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed (1 review required, with at least 1 [Committer](https://openjdk.org/bylaws#committer))

### Issue
 * [JDK-8332095](https://bugs.openjdk.org/browse/JDK-8332095): GenShen: Move more generational mode members out of shHeap (**Task** - P4)


### Reviewers
 * [Kelvin Nilsen](https://openjdk.org/census#kdnilsen) (@kdnilsen - Committer) ⚠️ Review applies to [b875957d](https://git.openjdk.org/shenandoah/pull/431/files/b875957da44a4a54f74686d623a966dfb6353d76)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/shenandoah.git pull/431/head:pull/431` \
`$ git checkout pull/431`

Update a local copy of the PR: \
`$ git checkout pull/431` \
`$ git pull https://git.openjdk.org/shenandoah.git pull/431/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 431`

View PR using the GUI difftool: \
`$ git pr show -t 431`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/shenandoah/pull/431.diff">https://git.openjdk.org/shenandoah/pull/431.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/shenandoah/pull/431#issuecomment-2105368384)