### PR TITLE
8332094: GenShen: Reuse existing code to verify usage before rebuilding free set

### DIFF
--- a/src/hotspot/share/gc/shenandoah/shenandoahGenerationalHeap.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahGenerationalHeap.cpp
@@ -710,4 +710,3 @@ void ShenandoahGenerationalHeap::coalesce_and_fill_old_regions(bool concurrent) 
   workers()->run_task(&coalesce);
   old_generation()->set_parseable(true);
 }
-

--- a/src/hotspot/share/gc/shenandoah/shenandoahHeap.hpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahHeap.hpp
@@ -194,9 +194,6 @@ public:
   void prepare_for_verify() override;
   void verify(VerifyOption vo) override;
 
-  bool verify_generation_usage(bool verify_old, size_t old_regions, size_t old_bytes, size_t old_waste,
-                               bool verify_young, size_t young_regions, size_t young_bytes, size_t young_waste);
-
 // WhiteBox testing support.
   bool supports_concurrent_gc_breakpoints() const override {
     return true;

--- a/src/hotspot/share/gc/shenandoah/shenandoahVerifier.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahVerifier.cpp
@@ -342,8 +342,8 @@ public:
     _loc = nullptr;
   }
 
-  virtual void do_oop(oop* p) { do_oop_work(p); }
-  virtual void do_oop(narrowOop* p) { do_oop_work(p); }
+  void do_oop(oop* p) override { do_oop_work(p); }
+  void do_oop(narrowOop* p) override { do_oop_work(p); }
 };
 
 // This closure computes the amounts of used, committed, and garbage memory and the number of regions contained within
@@ -354,7 +354,7 @@ private:
 public:
   ShenandoahCalculateRegionStatsClosure() : _used(0), _committed(0), _garbage(0), _regions(0), _humongous_waste(0) {};
 
-  void heap_region_do(ShenandoahHeapRegion* r) {
+  void heap_region_do(ShenandoahHeapRegion* r) override {
     _used += r->used();
     _garbage += r->garbage();
     _committed += r->is_committed() ? ShenandoahHeapRegion::region_size_bytes() : 0;
@@ -366,14 +366,14 @@ public:
             r->used(), (r->is_humongous() ? "humongous" : "regular"), r->index(), _used);
   }
 
-  size_t used() { return _used; }
-  size_t committed() { return _committed; }
-  size_t garbage() { return _garbage; }
-  size_t regions() { return _regions; }
-  size_t waste() { return _humongous_waste; }
+  size_t used() const { return _used; }
+  size_t committed() const { return _committed; }
+  size_t garbage() const { return _garbage; }
+  size_t regions() const { return _regions; }
+  size_t waste() const { return _humongous_waste; }
 
   // span is the total memory affiliated with these stats (some of which is in use and other is available)
-  size_t span() { return _regions * ShenandoahHeapRegion::region_size_bytes(); }
+  size_t span() const { return _regions * ShenandoahHeapRegion::region_size_bytes(); }
 };
 
 class ShenandoahGenerationStatsClosure : public ShenandoahHeapRegionClosure {
@@ -417,28 +417,22 @@ class ShenandoahGenerationStatsClosure : public ShenandoahHeapRegionClosure {
     }
 
     guarantee(stats.used() == generation_used,
-              "%s: generation (%s) used size must be consistent: generation-used: " SIZE_FORMAT "%s, regions-used: " SIZE_FORMAT "%s",
-              label, generation->name(),
-              byte_size_in_proper_unit(generation_used), proper_unit_for_byte_size(generation_used),
-              byte_size_in_proper_unit(stats.used()),    proper_unit_for_byte_size(stats.used()));
+              "%s: generation (%s) used size must be consistent: generation-used: " PROPERFMT ", regions-used: " PROPERFMT,
+              label, generation->name(), PROPERFMTARGS(generation_used), PROPERFMTARGS(stats.used()));
 
     guarantee(stats.regions() == generation_used_regions,
               "%s: generation (%s) used regions (" SIZE_FORMAT ") must equal regions that are in use (" SIZE_FORMAT ")",
               label, generation->name(), generation->used_regions(), stats.regions());
 
     size_t generation_capacity = generation->max_capacity();
-    size_t humongous_regions_promoted = 0;
     guarantee(stats.span() <= generation_capacity,
-              "%s: generation (%s) size spanned by regions (" SIZE_FORMAT ") must not exceed current capacity (" SIZE_FORMAT "%s)",
-              label, generation->name(), stats.regions(),
-              byte_size_in_proper_unit(generation_capacity), proper_unit_for_byte_size(generation_capacity));
+              "%s: generation (%s) size spanned by regions (" SIZE_FORMAT ") must not exceed current capacity (" PROPERFMT ")",
+              label, generation->name(), stats.regions(), PROPERFMTARGS(generation_capacity));
 
     size_t humongous_waste = generation->get_humongous_waste();
     guarantee(stats.waste() == humongous_waste,
-              "%s: generation (%s) humongous waste must be consistent: generation: " SIZE_FORMAT "%s, regions: " SIZE_FORMAT "%s",
-              label, generation->name(),
-              byte_size_in_proper_unit(humongous_waste), proper_unit_for_byte_size(humongous_waste),
-              byte_size_in_proper_unit(stats.waste()),   proper_unit_for_byte_size(stats.waste()));
+              "%s: generation (%s) humongous waste must be consistent: generation: " PROPERFMT ", regions: " PROPERFMT,
+              label, generation->name(), PROPERFMTARGS(humongous_waste), PROPERFMTARGS(stats.waste()));
   }
 };
 
@@ -471,7 +465,7 @@ public:
     }
   }
 
-  void heap_region_do(ShenandoahHeapRegion* r) {
+  void heap_region_do(ShenandoahHeapRegion* r) override {
     switch (_regions) {
       case ShenandoahVerifier::_verify_regions_disable:
         break;
@@ -559,11 +553,11 @@ public:
     _bitmap(bitmap),
     _processed(0) {};
 
-  size_t processed() {
+  size_t processed() const {
     return _processed;
   }
 
-  virtual void work(uint worker_id) {
+  void work(uint worker_id) override {
     ResourceMark rm;
     ShenandoahVerifierStack stack;
 
@@ -602,7 +596,7 @@ public:
 
 class ShenandoahVerifyNoIncompleteSatbBuffers : public ThreadClosure {
 public:
-  virtual void do_thread(Thread* thread) {
+  void do_thread(Thread* thread) override {
     SATBMarkQueue& queue = ShenandoahThreadLocalData::satb_mark_queue(thread);
     if (!queue.is_empty()) {
       fatal("All SATB buffers should have been flushed during mark");
@@ -649,7 +643,7 @@ public:
     return Atomic::load(&_processed);
   }
 
-  virtual void work(uint worker_id) {
+  void work(uint worker_id) override {
     if (_options._verify_marked == ShenandoahVerifier::_verify_marked_complete_satb_empty) {
       ShenandoahVerifyNoIncompleteSatbBuffers verify_satb;
       Threads::possibly_parallel_threads_do(true, &verify_satb);
@@ -753,7 +747,7 @@ private:
 
 public:
   VerifyThreadGCState(const char* label, char expected) : _label(label), _expected(expected) {}
-  void do_thread(Thread* t) {
+  void do_thread(Thread* t) override {
     char actual = ShenandoahThreadLocalData::gc_state(t);
     if (!verify_gc_state(actual, _expected)) {
       fatal("%s: Thread %s: expected gc-state %d, actual %d", _label, t->name(), _expected, actual);
@@ -1240,8 +1234,8 @@ private:
   }
 
 public:
-  void do_oop(narrowOop* p) { do_oop_work(p); }
-  void do_oop(oop* p)       { do_oop_work(p); }
+  void do_oop(narrowOop* p) override { do_oop_work(p); }
+  void do_oop(oop* p)       override { do_oop_work(p); }
 };
 
 void ShenandoahVerifier::verify_roots_in_to_space() {
@@ -1262,7 +1256,7 @@ protected:
 
 public:
   // Argument distinguishes between initial mark or start of update refs verification.
-  ShenandoahVerifyRemSetClosure(bool init_mark) :
+  explicit ShenandoahVerifyRemSetClosure(bool init_mark) :
             _init_mark(init_mark),
             _heap(ShenandoahHeap::heap()),
             _scanner(_heap->card_scan()) {}
@@ -1285,8 +1279,8 @@ public:
     }
   }
 
-  virtual void do_oop(narrowOop* p) { work(p); }
-  virtual void do_oop(oop* p)       { work(p); }
+  void do_oop(narrowOop* p) override { work(p); }
+  void do_oop(oop* p)       override { work(p); }
 };
 
 void ShenandoahVerifier::help_verify_region_rem_set(ShenandoahHeapRegion* r, ShenandoahMarkingContext* ctx, HeapWord* from,
@@ -1465,4 +1459,13 @@ void ShenandoahVerifier::verify_rem_set_before_update_ref() {
                                  "Remembered set violation at init-update-references");
     }
   }
+}
+
+void ShenandoahVerifier::verify_before_rebuilding_free_set() {
+  ShenandoahGenerationStatsClosure cl;
+  _heap->heap_region_iterate(&cl);
+
+  ShenandoahGenerationStatsClosure::validate_usage(false, "Before free set rebuild", _heap->old_generation(), cl.old);
+  ShenandoahGenerationStatsClosure::validate_usage(false, "Before free set rebuild", _heap->young_generation(), cl.young);
+  ShenandoahGenerationStatsClosure::validate_usage(false, "Before free set rebuild", _heap->global_generation(), cl.global);
 }

--- a/src/hotspot/share/gc/shenandoah/shenandoahVerifier.hpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahVerifier.hpp
@@ -226,9 +226,10 @@ public:
 
   // Roots should only contain to-space oops
   void verify_roots_in_to_space();
-
   void verify_roots_no_forwarded();
 
+  // Check that generation usages are accurate before rebuilding free set
+  void verify_before_rebuilding_free_set();
 private:
    void help_verify_region_rem_set(ShenandoahHeapRegion* r, ShenandoahMarkingContext* ctx,
                                     HeapWord* from, HeapWord* top, HeapWord* update_watermark, const char* message);


### PR DESCRIPTION
We had some code in shHeap that largely duplicated existing functionality in the shVerify. This change just reuses the existing code (which has nicer assert messages).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed (1 review required, with at least 1 [Committer](https://openjdk.org/bylaws#committer))

### Issue
 * [JDK-8332094](https://bugs.openjdk.org/browse/JDK-8332094): GenShen: Reuse existing code to verify usage before rebuilding free set (**Task** - P4)


### Reviewers
 * [Kelvin Nilsen](https://openjdk.org/census#kdnilsen) (@kdnilsen - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/shenandoah.git pull/432/head:pull/432` \
`$ git checkout pull/432`

Update a local copy of the PR: \
`$ git checkout pull/432` \
`$ git pull https://git.openjdk.org/shenandoah.git pull/432/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 432`

View PR using the GUI difftool: \
`$ git pr show -t 432`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/shenandoah/pull/432.diff">https://git.openjdk.org/shenandoah/pull/432.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/shenandoah/pull/432#issuecomment-2105370215)