### PR TITLE
8332330: Shenandoah: Change jcheck configuration for fix version to match project repo

### DIFF
--- a/.jcheck/conf
+++ b/.jcheck/conf
@@ -1,7 +1,7 @@
 [general]
 project=shenandoah
 jbs=JDK
-version=23
+version=repo-shenandoah
 
 [checks]
 error=author,committer,reviewers,merge,issues,executable,symlink,message,hg-tag,whitespace,problemlists


### PR DESCRIPTION
Per https://bugs.openjdk.org/browse/SKARA-2262, we need to configure the correct fixVersion in `.jcheck/conf` in this repo for the bot to interact properly with JBS.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed (1 review required, with at least 1 [Committer](https://openjdk.org/bylaws#committer))

### Issue
 * [JDK-8332330](https://bugs.openjdk.org/browse/JDK-8332330): Shenandoah: Change jcheck configuration for fix version to match project repo (**Task** - P4)


### Reviewers
 * [Kelvin Nilsen](https://openjdk.org/census#kdnilsen) (@kdnilsen - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/shenandoah.git pull/434/head:pull/434` \
`$ git checkout pull/434`

Update a local copy of the PR: \
`$ git checkout pull/434` \
`$ git pull https://git.openjdk.org/shenandoah.git pull/434/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 434`

View PR using the GUI difftool: \
`$ git pr show -t 434`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/shenandoah/pull/434.diff">https://git.openjdk.org/shenandoah/pull/434.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/shenandoah/pull/434#issuecomment-2113628125)