### PR TITLE
8332548: GenShen: Factor generational mode out of gc helpers

### DIFF
--- a/src/hotspot/share/gc/shenandoah/shenandoahConcurrentGC.hpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahConcurrentGC.hpp
@@ -133,6 +133,8 @@ protected:
 private:
   void start_mark();
 
+  static bool has_in_place_promotions(ShenandoahHeap* heap) ;
+
   // Messages for GC trace events, they have to be immortal for
   // passing around the logging/tracing systems
   const char* init_mark_event_message() const;

--- a/src/hotspot/share/gc/shenandoah/shenandoahConcurrentGC.hpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahConcurrentGC.hpp
@@ -104,7 +104,7 @@ private:
   void entry_evacuate();
   void entry_update_thread_roots();
   void entry_updaterefs();
-  void entry_global_coalesce_and_fill();
+
   void entry_cleanup_complete();
 
   // Actual work for the phases
@@ -124,7 +124,7 @@ private:
   void op_update_thread_roots();
   void op_final_updaterefs();
   void op_final_roots();
-  void op_global_coalesce_and_fill();
+
   void op_cleanup_complete();
 
 protected:
@@ -144,6 +144,8 @@ private:
 protected:
   // Check GC cancellation and abort concurrent GC
   bool check_cancellation_and_abort(ShenandoahDegenPoint point);
+
+  void complete_concurrent_gc(const ShenandoahHeap* heap);
 };
 
 #endif // SHARE_GC_SHENANDOAH_SHENANDOAHCONCURRENTGC_HPP

--- a/src/hotspot/share/gc/shenandoah/shenandoahConcurrentGC.hpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahConcurrentGC.hpp
@@ -144,8 +144,6 @@ private:
 protected:
   // Check GC cancellation and abort concurrent GC
   bool check_cancellation_and_abort(ShenandoahDegenPoint point);
-
-  void complete_concurrent_gc(const ShenandoahHeap* heap);
 };
 
 #endif // SHARE_GC_SHENANDOAH_SHENANDOAHCONCURRENTGC_HPP

--- a/src/hotspot/share/gc/shenandoah/shenandoahDegeneratedGC.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahDegeneratedGC.cpp
@@ -131,10 +131,10 @@ void ShenandoahDegenGC::op_degenerated() {
       // Note that we can only do this for "outside-cycle" degens, otherwise we would risk
       // changing the cycle parameters mid-cycle during concurrent -> degenerated handover.
       heap->set_unload_classes(_generation->heuristics()->can_unload_classes() &&
-                                (!heap->mode()->is_generational() || _generation->is_global()));
+                               (!heap->mode()->is_generational() || _generation->is_global()));
 
       if (heap->mode()->is_generational() &&
-            (_generation->is_young() || (_generation->is_global() && ShenandoahVerify))) {
+          (_generation->is_young() || (_generation->is_global() && ShenandoahVerify))) {
         // Swap remembered sets for young, or if the verifier will run during a global collect
         // TODO: This path should not depend on ShenandoahVerify
         _generation->swap_remembered_set();
@@ -164,15 +164,15 @@ void ShenandoahDegenGC::op_degenerated() {
           // we will rescan the roots on this safepoint.
           heap->old_generation()->transfer_pointers_from_satb();
         }
-      }
 
-      if (_degen_point == ShenandoahDegenPoint::_degenerated_roots) {
-        // We only need this if the concurrent cycle has already swapped the card tables.
-        // Marking will use the 'read' table, but interesting pointers may have been
-        // recorded in the 'write' table in the time between the cancelled concurrent cycle
-        // and this degenerated cycle. These pointers need to be included the 'read' table
-        // used to scan the remembered set during the STW mark which follows here.
-        _generation->merge_write_table();
+        if (_degen_point == ShenandoahDegenPoint::_degenerated_roots) {
+          // We only need this if the concurrent cycle has already swapped the card tables.
+          // Marking will use the 'read' table, but interesting pointers may have been
+          // recorded in the 'write' table in the time between the cancelled concurrent cycle
+          // and this degenerated cycle. These pointers need to be included the 'read' table
+          // used to scan the remembered set during the STW mark which follows here.
+          _generation->merge_write_table();
+        }
       }
 
       op_reset();
@@ -280,36 +280,37 @@ void ShenandoahDegenGC::op_degenerated() {
       // In above case, update roots should disarm them
       ShenandoahCodeRoots::disarm_nmethods();
 
-      if (heap->mode()->is_generational() && heap->is_concurrent_old_mark_in_progress()) {
-        // This is still necessary for degenerated cycles because the degeneration point may occur
-        // after final mark of the young generation. See ShenandoahConcurrentGC::op_final_updaterefs for
-        // a more detailed explanation.
-        heap->old_generation()->transfer_pointers_from_satb();
-      }
-
       op_cleanup_complete();
-      // We defer generation resizing actions until after cset regions have been recycled.
+
       if (heap->mode()->is_generational()) {
-        auto result = ShenandoahGenerationalHeap::heap()->balance_generations();
+        if (heap->is_concurrent_old_mark_in_progress()) {
+          // This is still necessary for degenerated cycles because the degeneration point may occur
+          // after final mark of the young generation. See ShenandoahConcurrentGC::op_final_updaterefs for
+          // a more detailed explanation.
+          heap->old_generation()->transfer_pointers_from_satb();
+        }
+
+        // We defer generation resizing actions until after cset regions have been recycled.
+        ShenandoahGenerationalHeap* gen_heap = ShenandoahGenerationalHeap::heap();
+        auto result = gen_heap->balance_generations();
         LogTarget(Info, gc, ergo) lt;
         if (lt.is_enabled()) {
           LogStream ls(lt);
           result.print_on("Degenerated GC", &ls);
         }
+
+        // In case degeneration interrupted concurrent evacuation or update references, we need to clean up
+        // transient state. Otherwise, these actions have no effect.
+        gen_heap->reset_generation_reserves();
+
+        if (!gen_heap->old_generation()->is_parseable()) {
+          op_global_coalesce_and_fill();
+        }
       }
+
       break;
     default:
       ShouldNotReachHere();
-  }
-
-  if (heap->mode()->is_generational()) {
-    // In case degeneration interrupted concurrent evacuation or update references, we need to clean up transient state.
-    // Otherwise, these actions have no effect.
-    ShenandoahGenerationalHeap::heap()->reset_generation_reserves();
-
-    if (!ShenandoahGenerationalHeap::heap()->old_generation()->is_parseable()) {
-      op_global_coalesce_and_fill();
-    }
   }
 
   if (ShenandoahVerify) {

--- a/src/hotspot/share/gc/shenandoah/shenandoahDegeneratedGC.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahDegeneratedGC.cpp
@@ -131,10 +131,10 @@ void ShenandoahDegenGC::op_degenerated() {
       // Note that we can only do this for "outside-cycle" degens, otherwise we would risk
       // changing the cycle parameters mid-cycle during concurrent -> degenerated handover.
       heap->set_unload_classes(_generation->heuristics()->can_unload_classes() &&
-                               (!heap->mode()->is_generational() || _generation->is_global()));
+                                (!heap->mode()->is_generational() || _generation->is_global()));
 
       if (heap->mode()->is_generational() &&
-          (_generation->is_young() || (_generation->is_global() && ShenandoahVerify))) {
+            (_generation->is_young() || (_generation->is_global() && ShenandoahVerify))) {
         // Swap remembered sets for young, or if the verifier will run during a global collect
         // TODO: This path should not depend on ShenandoahVerify
         _generation->swap_remembered_set();

--- a/src/hotspot/share/gc/shenandoah/shenandoahDegeneratedGC.hpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahDegeneratedGC.hpp
@@ -58,9 +58,6 @@ private:
   void op_update_roots();
   void op_cleanup_complete();
 
-  // This will rebuild card offsets, which is necessary if classes were unloaded
-  void op_global_coalesce_and_fill();
-
   // Fail handling
   void op_degenerated_futile();
   void op_degenerated_fail();

--- a/src/hotspot/share/gc/shenandoah/shenandoahGenerationalHeap.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahGenerationalHeap.cpp
@@ -22,6 +22,7 @@
  *
  */
 
+#include <utilities/events.hpp>
 #include "precompiled.hpp"
 
 #include "gc/shenandoah/shenandoahCollectorPolicy.hpp"
@@ -33,6 +34,7 @@
 #include "gc/shenandoah/shenandoahHeapRegion.hpp"
 #include "gc/shenandoah/shenandoahInitLogger.hpp"
 #include "gc/shenandoah/shenandoahMemoryPool.hpp"
+#include "gc/shenandoah/shenandoahMonitoringSupport.hpp"
 #include "gc/shenandoah/shenandoahOldGeneration.hpp"
 #include "gc/shenandoah/shenandoahOopClosures.inline.hpp"
 #include "gc/shenandoah/shenandoahPhaseTimings.hpp"
@@ -41,6 +43,7 @@
 #include "gc/shenandoah/shenandoahYoungGeneration.hpp"
 #include "gc/shenandoah/shenandoahUtils.hpp"
 #include "logging/log.hpp"
+#include "shenandoahWorkerPolicy.hpp"
 
 
 class ShenandoahGenerationalInitLogger : public ShenandoahInitLogger {
@@ -942,5 +945,88 @@ void ShenandoahGenerationalHeap::update_heap_references(bool concurrent) {
   if (ShenandoahEnableCardStats) { // generational check proxy
     assert(card_scan() != nullptr, "Card table must exist when card stats are enabled");
     card_scan()->log_card_stats(nworkers, CARD_STAT_UPDATE_REFS);
+  }
+}
+
+void ShenandoahGenerationalHeap::complete_degenerated_cycle() {
+  shenandoah_assert_heaplocked_or_safepoint();
+  if (is_concurrent_old_mark_in_progress()) {
+    // This is still necessary for degenerated cycles because the degeneration point may occur
+    // after final mark of the young generation. See ShenandoahConcurrentGC::op_final_updaterefs for
+    // a more detailed explanation.
+    old_generation()->transfer_pointers_from_satb();
+  }
+
+  // We defer generation resizing actions until after cset regions have been recycled.
+  auto result = balance_generations();
+  LogTarget(Info, gc, ergo) lt;
+  if (lt.is_enabled()) {
+    LogStream ls(lt);
+    result.print_on("Degenerated GC", &ls);
+  }
+
+  // In case degeneration interrupted concurrent evacuation or update references, we need to clean up
+  // transient state. Otherwise, these actions have no effect.
+  reset_generation_reserves();
+
+  if (!old_generation()->is_parseable()) {
+    ShenandoahGCPhase phase(ShenandoahPhaseTimings::degen_gc_coalesce_and_fill);
+    coalesce_and_fill_old_regions(false);
+  }
+}
+
+void ShenandoahGenerationalHeap::complete_concurrent_cycle() {
+  if (!old_generation()->is_parseable()) {
+    // Class unloading may render the card offsets unusable, so we must rebuild them before
+    // the next remembered set scan. We _could_ let the control thread do this sometime after
+    // the global cycle has completed and before the next young collection, but under memory
+    // pressure the control thread may not have the time (that is, because it's running back
+    // to back GCs). In that scenario, we would have to make the old regions parsable before
+    // we could start a young collection. This could delay the start of the young cycle and
+    // throw off the heuristics.
+    entry_global_coalesce_and_fill();
+  }
+
+  ShenandoahGenerationalHeap::TransferResult result;
+  {
+    ShenandoahHeapLocker locker(lock());
+
+    result = balance_generations();
+    reset_generation_reserves();
+  }
+
+  LogTarget(Info, gc, ergo) lt;
+  if (lt.is_enabled()) {
+    LogStream ls(lt);
+    result.print_on("Concurrent GC", &ls);
+  }
+}
+
+void ShenandoahGenerationalHeap::entry_global_coalesce_and_fill() {
+  const char* msg = "Coalescing and filling old regions";
+  ShenandoahConcurrentPhase gc_phase(msg, ShenandoahPhaseTimings::conc_coalesce_and_fill);
+
+  TraceCollectorStats tcs(monitoring_support()->concurrent_collection_counters());
+  EventMark em("%s", msg);
+  ShenandoahWorkerScope scope(workers(),
+                              ShenandoahWorkerPolicy::calc_workers_for_conc_marking(),
+                              "concurrent coalesce and fill");
+
+  coalesce_and_fill_old_regions(true);
+}
+
+void ShenandoahGenerationalHeap::update_region_ages() {
+  ShenandoahMarkingContext *ctx = complete_marking_context();
+  for (size_t i = 0; i < num_regions(); i++) {
+    ShenandoahHeapRegion *r = get_region(i);
+    if (r->is_active() && r->is_young()) {
+      HeapWord* tams = ctx->top_at_mark_start(r);
+      HeapWord* top = r->top();
+      if (top > tams) {
+        r->reset_age();
+      } else if (is_aging_cycle()) {
+        r->increment_age();
+      }
+    }
   }
 }

--- a/src/hotspot/share/gc/shenandoah/shenandoahGenerationalHeap.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahGenerationalHeap.cpp
@@ -22,7 +22,6 @@
  *
  */
 
-#include <utilities/events.hpp>
 #include "precompiled.hpp"
 
 #include "gc/shenandoah/shenandoahCollectorPolicy.hpp"
@@ -40,10 +39,11 @@
 #include "gc/shenandoah/shenandoahPhaseTimings.hpp"
 #include "gc/shenandoah/shenandoahRegulatorThread.hpp"
 #include "gc/shenandoah/shenandoahScanRemembered.inline.hpp"
+#include "gc/shenandoah/shenandoahWorkerPolicy.hpp"
 #include "gc/shenandoah/shenandoahYoungGeneration.hpp"
 #include "gc/shenandoah/shenandoahUtils.hpp"
 #include "logging/log.hpp"
-#include "shenandoahWorkerPolicy.hpp"
+#include "utilities/events.hpp"
 
 
 class ShenandoahGenerationalInitLogger : public ShenandoahInitLogger {
@@ -958,7 +958,7 @@ void ShenandoahGenerationalHeap::complete_degenerated_cycle() {
   }
 
   // We defer generation resizing actions until after cset regions have been recycled.
-  auto result = balance_generations();
+  TransferResult result = balance_generations();
   LogTarget(Info, gc, ergo) lt;
   if (lt.is_enabled()) {
     LogStream ls(lt);
@@ -987,7 +987,7 @@ void ShenandoahGenerationalHeap::complete_concurrent_cycle() {
     entry_global_coalesce_and_fill();
   }
 
-  ShenandoahGenerationalHeap::TransferResult result;
+  TransferResult result;
   {
     ShenandoahHeapLocker locker(lock());
 

--- a/src/hotspot/share/gc/shenandoah/shenandoahGenerationalHeap.hpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahGenerationalHeap.hpp
@@ -50,6 +50,10 @@ public:
     return _is_aging_cycle.is_set();
   }
 
+  // Age regions that haven't been used for allocations in the current cycle.
+  // Reset ages for regions that have been used for allocations.
+  void update_region_ages();
+
   oop evacuate_object(oop p, Thread* thread) override;
   oop try_evacuate_object(oop p, Thread* thread, ShenandoahHeapRegion* from_region, ShenandoahAffiliation target_gen);
 
@@ -62,6 +66,7 @@ public:
   // ---------- Update References
   //
   void update_heap_references(bool concurrent) override;
+
 private:
   HeapWord* allocate_from_plab(Thread* thread, size_t size, bool is_promotion);
   HeapWord* allocate_from_plab_slow(Thread* thread, size_t size, bool is_promotion);
@@ -103,11 +108,15 @@ public:
   // Transfers surplus old regions to young, or takes regions from young to satisfy old region deficit
   TransferResult balance_generations();
 
-  // Makes old regions parsable
-  void coalesce_and_fill_old_regions(bool concurrent);
-
+  // Balance generations, coalesce and fill old regions if necessary
+  void complete_degenerated_cycle();
+  void complete_concurrent_cycle();
 private:
   void initialize_controller() override;
+  void entry_global_coalesce_and_fill();
+
+  // Makes old regions parsable. This will also rebuild card offsets, which is necessary if classes were unloaded
+  void coalesce_and_fill_old_regions(bool concurrent);
 
   ShenandoahRegulatorThread* _regulator_thread;
 

--- a/src/hotspot/share/gc/shenandoah/shenandoahGenerationalHeap.hpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahGenerationalHeap.hpp
@@ -50,8 +50,8 @@ public:
     return _is_aging_cycle.is_set();
   }
 
-  // Age regions that haven't been used for allocations in the current cycle.
-  // Reset ages for regions that have been used for allocations.
+  // Ages regions that haven't been used for allocations in the current cycle.
+  // Resets ages for regions that have been used for allocations.
   void update_region_ages();
 
   oop evacuate_object(oop p, Thread* thread) override;
@@ -108,7 +108,7 @@ public:
   // Transfers surplus old regions to young, or takes regions from young to satisfy old region deficit
   TransferResult balance_generations();
 
-  // Balance generations, coalesce and fill old regions if necessary
+  // Balances generations, coalesces and fills old regions if necessary
   void complete_degenerated_cycle();
   void complete_concurrent_cycle();
 private:


### PR DESCRIPTION
Some of the generational mode support in `shenandoahConcurrentGC.cpp` and `shenandoahDegeneratedGC.cpp` can be factored into generational mode specific files and coalesced under fewer generational mode checks.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed (1 review required, with at least 1 [Committer](https://openjdk.org/bylaws#committer))

### Issue
 * [JDK-8332548](https://bugs.openjdk.org/browse/JDK-8332548): GenShen: Factor generational mode out of gc helpers (**Task** - P4)


### Reviewers
 * [Y. Srinivas Ramakrishna](https://openjdk.org/census#ysr) (@ysramakrishna - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/shenandoah.git pull/436/head:pull/436` \
`$ git checkout pull/436`

Update a local copy of the PR: \
`$ git checkout pull/436` \
`$ git pull https://git.openjdk.org/shenandoah.git pull/436/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 436`

View PR using the GUI difftool: \
`$ git pr show -t 436`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/shenandoah/pull/436.diff">https://git.openjdk.org/shenandoah/pull/436.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/shenandoah/pull/436#issuecomment-2121312877)