### PR TITLE
8332824: GenShen: Temporarily revert recent changes to GC helpers

### DIFF
--- a/src/hotspot/share/gc/shenandoah/shenandoahConcurrentGC.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahConcurrentGC.cpp
@@ -141,6 +141,19 @@ bool ShenandoahConcurrentGC::collect(GCCause::Cause cause) {
   // Complete marking under STW, and start evacuation
   vmop_entry_final_mark();
 
+  // If GC was cancelled before final mark, then the safepoint operation will do nothing
+  // and the concurrent mark will still be in progress. In this case it is safe to resume
+  // the degenerated cycle from the marking phase. On the other hand, if the GC is cancelled
+  // after final mark (but before this check), then the final mark safepoint operation
+  // will have finished the mark (setting concurrent mark in progress to false). Final mark
+  // will also have setup state (in concurrent stack processing) that will not be safe to
+  // resume from the marking phase in the degenerated cycle. That is, if the cancellation
+  // occurred after final mark, we must resume the degenerated cycle after the marking phase.
+  if (_generation->is_concurrent_mark_in_progress() && check_cancellation_and_abort(ShenandoahDegenPoint::_degenerated_mark)) {
+    assert(!heap->is_concurrent_weak_root_in_progress(), "Weak roots should not be in progress when concurrent mark is in progress");
+    return false;
+  }
+
   // Concurrent stack processing
   if (heap->is_evacuation_in_progress()) {
     entry_thread_roots();
@@ -218,7 +231,31 @@ bool ShenandoahConcurrentGC::collect(GCCause::Cause cause) {
   // We defer generation resizing actions until after cset regions have been recycled.  We do this even following an
   // abbreviated cycle.
   if (heap->mode()->is_generational()) {
-    ShenandoahGenerationalHeap::heap()->complete_concurrent_cycle();
+    if (!heap->old_generation()->is_parseable()) {
+      // Class unloading may render the card offsets unusable, so we must rebuild them before
+      // the next remembered set scan. We _could_ let the control thread do this sometime after
+      // the global cycle has completed and before the next young collection, but under memory
+      // pressure the control thread may not have the time (that is, because it's running back
+      // to back GCs). In that scenario, we would have to make the old regions parsable before
+      // we could start a young collection. This could delay the start of the young cycle and
+      // throw off the heuristics.
+      entry_global_coalesce_and_fill();
+    }
+
+    ShenandoahGenerationalHeap::TransferResult result;
+    {
+      ShenandoahGenerationalHeap* gen_heap = ShenandoahGenerationalHeap::heap();
+      ShenandoahHeapLocker locker(gen_heap->lock());
+
+      result = gen_heap->balance_generations();
+      gen_heap->reset_generation_reserves();
+    }
+
+    LogTarget(Info, gc, ergo) lt;
+    if (lt.is_enabled()) {
+      LogStream ls(lt);
+      result.print_on("Concurrent GC", &ls);
+    }
   }
   return true;
 }
@@ -625,7 +662,6 @@ void ShenandoahConcurrentGC::op_init_mark() {
   start_mark();
 
   if (_do_old_gc_bootstrap) {
-    shenandoah_assert_generational();
     // Update region state for both young and old regions
     // TODO: We should be able to pull this out of the safepoint for the bootstrap
     // cycle. The top of an old region will only move when a GC cycle evacuates
@@ -713,100 +749,138 @@ void ShenandoahConcurrentGC::op_final_mark() {
     // Has to be done after cset selection
     heap->prepare_concurrent_roots();
 
-    if (!heap->collection_set()->is_empty() || has_in_place_promotions(heap)) {
-      // Even if the collection set is empty, we need to do evacuation if there are regions to be promoted in place.
-      // Concurrent evacuation takes responsibility for registering objects and setting the remembered set cards to dirty.
+    if (heap->mode()->is_generational()) {
+      if (!heap->collection_set()->is_empty() || heap->old_generation()->has_in_place_promotions()) {
+        // Even if the collection set is empty, we need to do evacuation if there are regions to be promoted in place.
+        // Concurrent evacuation takes responsibility for registering objects and setting the remembered set cards to dirty.
 
-      LogTarget(Debug, gc, cset) lt;
-      if (lt.is_enabled()) {
-        ResourceMark rm;
-        LogStream ls(lt);
-        heap->collection_set()->print_on(&ls);
-      }
+        LogTarget(Debug, gc, cset) lt;
+        if (lt.is_enabled()) {
+          ResourceMark rm;
+          LogStream ls(lt);
+          heap->collection_set()->print_on(&ls);
+        }
 
-      if (ShenandoahVerify) {
-        heap->verifier()->verify_before_evacuation();
-      }
+        if (ShenandoahVerify) {
+          heap->verifier()->verify_before_evacuation();
+        }
 
-      // TODO: Do we need to set this if we are only promoting regions in place? We don't need the barriers on for that.
-      heap->set_evacuation_in_progress(true);
+        heap->set_evacuation_in_progress(true);
 
-      // Verify before arming for concurrent processing.
-      // Otherwise, verification can trigger stack processing.
-      if (ShenandoahVerify) {
-        heap->verifier()->verify_during_evacuation();
-      }
+        // Verify before arming for concurrent processing.
+        // Otherwise, verification can trigger stack processing.
+        if (ShenandoahVerify) {
+          heap->verifier()->verify_during_evacuation();
+        }
 
-      // Generational mode may promote objects in place during the evacuation phase.
-      // If that is the only reason we are evacuating, we don't need to update references
-      // and there will be no forwarded objects on the heap.
-      heap->set_has_forwarded_objects(!heap->collection_set()->is_empty());
+        // Generational mode may promote objects in place during the evacuation phase.
+        // If that is the only reason we are evacuating, we don't need to update references
+        // and there will be no forwarded objects on the heap.
+        heap->set_has_forwarded_objects(!heap->collection_set()->is_empty());
 
-      // Arm nmethods/stack for concurrent processing
-      if (!heap->collection_set()->is_empty()) {
-        // Iff objects will be evaluated, arm the nmethod barriers. These will be disarmed
-        // under the same condition (established in prepare_concurrent_roots) after strong
-        // root evacuation has completed (see op_strong_roots).
-        ShenandoahCodeRoots::arm_nmethods_for_evac();
-        ShenandoahStackWatermark::change_epoch_id();
-      }
+        // Arm nmethods/stack for concurrent processing
+        if (!heap->collection_set()->is_empty()) {
+          // Iff objects will be evaluated, arm the nmethod barriers. These will be disarmed
+          // under the same condition (established in prepare_concurrent_roots) after strong
+          // root evacuation has completed (see op_strong_roots).
+          ShenandoahCodeRoots::arm_nmethods_for_evac();
+          ShenandoahStackWatermark::change_epoch_id();
+        }
 
-      if (ShenandoahPacing) {
-        heap->pacer()->setup_for_evac();
+        if (ShenandoahPacing) {
+          heap->pacer()->setup_for_evac();
+        }
+      } else {
+        if (ShenandoahVerify) {
+          heap->verifier()->verify_after_concmark();
+        }
+
+        if (VerifyAfterGC) {
+          Universe::verify();
+        }
       }
     } else {
-      if (ShenandoahVerify) {
-        heap->verifier()->verify_after_concmark();
-      }
+      // Not is_generational()
+      if (!heap->collection_set()->is_empty()) {
+        LogTarget(Debug, gc, ergo) lt;
+        if (lt.is_enabled()) {
+          ResourceMark rm;
+          LogStream ls(lt);
+          heap->collection_set()->print_on(&ls);
+        }
 
-      if (VerifyAfterGC) {
-        Universe::verify();
+        if (ShenandoahVerify) {
+          heap->verifier()->verify_before_evacuation();
+        }
+
+        heap->set_evacuation_in_progress(true);
+
+        // Verify before arming for concurrent processing.
+        // Otherwise, verification can trigger stack processing.
+        if (ShenandoahVerify) {
+          heap->verifier()->verify_during_evacuation();
+        }
+
+        // From here on, we need to update references.
+        heap->set_has_forwarded_objects(true);
+
+        // Arm nmethods/stack for concurrent processing
+        ShenandoahCodeRoots::arm_nmethods_for_evac();
+        ShenandoahStackWatermark::change_epoch_id();
+
+        if (ShenandoahPacing) {
+          heap->pacer()->setup_for_evac();
+        }
+      } else {
+        if (ShenandoahVerify) {
+          heap->verifier()->verify_after_concmark();
+        }
+
+        if (VerifyAfterGC) {
+          Universe::verify();
+        }
       }
     }
   }
 }
 
-bool ShenandoahConcurrentGC::has_in_place_promotions(ShenandoahHeap* heap) {
-  return heap->mode()->is_generational() && heap->old_generation()->has_in_place_promotions();
-}
-
-template<bool GENERATIONAL>
 class ShenandoahConcurrentEvacThreadClosure : public ThreadClosure {
 private:
   OopClosure* const _oops;
-public:
-  explicit ShenandoahConcurrentEvacThreadClosure(OopClosure* oops) : _oops(oops) {}
 
-  void do_thread(Thread* thread) override {
-    JavaThread* const jt = JavaThread::cast(thread);
-    StackWatermarkSet::finish_processing(jt, _oops, StackWatermarkKind::gc);
-    if (GENERATIONAL) {
-      ShenandoahThreadLocalData::enable_plab_promotions(thread);
-    }
-  }
+public:
+  ShenandoahConcurrentEvacThreadClosure(OopClosure* oops);
+  void do_thread(Thread* thread);
 };
 
-template<bool GENERATIONAL>
+ShenandoahConcurrentEvacThreadClosure::ShenandoahConcurrentEvacThreadClosure(OopClosure* oops) :
+  _oops(oops) {
+}
+
+void ShenandoahConcurrentEvacThreadClosure::do_thread(Thread* thread) {
+  JavaThread* const jt = JavaThread::cast(thread);
+  StackWatermarkSet::finish_processing(jt, _oops, StackWatermarkKind::gc);
+  ShenandoahThreadLocalData::enable_plab_promotions(thread);
+}
+
 class ShenandoahConcurrentEvacUpdateThreadTask : public WorkerTask {
 private:
   ShenandoahJavaThreadsIterator _java_threads;
 
 public:
-  explicit ShenandoahConcurrentEvacUpdateThreadTask(uint n_workers) :
+  ShenandoahConcurrentEvacUpdateThreadTask(uint n_workers) :
     WorkerTask("Shenandoah Evacuate/Update Concurrent Thread Roots"),
     _java_threads(ShenandoahPhaseTimings::conc_thread_roots, n_workers) {
   }
 
-  void work(uint worker_id) override {
-    if (GENERATIONAL) {
-      Thread* worker_thread = Thread::current();
-      ShenandoahThreadLocalData::enable_plab_promotions(worker_thread);
-    }
+  void work(uint worker_id) {
+    Thread* worker_thread = Thread::current();
+    ShenandoahThreadLocalData::enable_plab_promotions(worker_thread);
 
     // ShenandoahEvacOOMScope has to be setup by ShenandoahContextEvacuateUpdateRootsClosure.
     // Otherwise, may deadlock with watermark lock
     ShenandoahContextEvacuateUpdateRootsClosure oops_cl;
-    ShenandoahConcurrentEvacThreadClosure<GENERATIONAL> thr_cl(&oops_cl);
+    ShenandoahConcurrentEvacThreadClosure thr_cl(&oops_cl);
     _java_threads.threads_do(&thr_cl, worker_id);
   }
 };
@@ -815,13 +889,8 @@ void ShenandoahConcurrentGC::op_thread_roots() {
   ShenandoahHeap* const heap = ShenandoahHeap::heap();
   assert(heap->is_evacuation_in_progress(), "Checked by caller");
   ShenandoahGCWorkerPhase worker_phase(ShenandoahPhaseTimings::conc_thread_roots);
-  if (heap->mode()->is_generational()) {
-    ShenandoahConcurrentEvacUpdateThreadTask<true> task(heap->workers()->active_workers());
-    heap->workers()->run_task(&task);
-  } else {
-    ShenandoahConcurrentEvacUpdateThreadTask<false> task(heap->workers()->active_workers());
-    heap->workers()->run_task(&task);
-  }
+  ShenandoahConcurrentEvacUpdateThreadTask task(heap->workers()->active_workers());
+  heap->workers()->run_task(&task);
 }
 
 void ShenandoahConcurrentGC::op_weak_refs() {
@@ -1199,8 +1268,39 @@ void ShenandoahConcurrentGC::op_final_roots() {
       heap->old_generation()->transfer_pointers_from_satb();
     }
 
-    ShenandoahGenerationalHeap::heap()->update_region_ages();
+    ShenandoahMarkingContext *ctx = heap->complete_marking_context();
+    for (size_t i = 0; i < heap->num_regions(); i++) {
+      ShenandoahHeapRegion *r = heap->get_region(i);
+      if (r->is_active() && r->is_young()) {
+        HeapWord* tams = ctx->top_at_mark_start(r);
+        HeapWord* top = r->top();
+        if (top > tams) {
+          r->reset_age();
+        } else if (ShenandoahGenerationalHeap::heap()->is_aging_cycle()) {
+          r->increment_age();
+        }
+      }
+    }
   }
+}
+
+void ShenandoahConcurrentGC::entry_global_coalesce_and_fill() {
+  ShenandoahHeap* const heap = ShenandoahHeap::heap();
+
+  const char* msg = "Coalescing and filling old regions in global collect";
+  ShenandoahConcurrentPhase gc_phase(msg, ShenandoahPhaseTimings::conc_coalesce_and_fill);
+
+  TraceCollectorStats tcs(heap->monitoring_support()->concurrent_collection_counters());
+  EventMark em("%s", msg);
+  ShenandoahWorkerScope scope(heap->workers(),
+                              ShenandoahWorkerPolicy::calc_workers_for_conc_marking(),
+                              "concurrent coalesce and fill");
+
+  op_global_coalesce_and_fill();
+}
+
+void ShenandoahConcurrentGC::op_global_coalesce_and_fill() {
+  ShenandoahGenerationalHeap::heap()->coalesce_and_fill_old_regions(true);
 }
 
 void ShenandoahConcurrentGC::op_cleanup_complete() {

--- a/src/hotspot/share/gc/shenandoah/shenandoahConcurrentGC.hpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahConcurrentGC.hpp
@@ -104,7 +104,7 @@ private:
   void entry_evacuate();
   void entry_update_thread_roots();
   void entry_updaterefs();
-
+  void entry_global_coalesce_and_fill();
   void entry_cleanup_complete();
 
   // Actual work for the phases
@@ -124,7 +124,7 @@ private:
   void op_update_thread_roots();
   void op_final_updaterefs();
   void op_final_roots();
-
+  void op_global_coalesce_and_fill();
   void op_cleanup_complete();
 
 protected:
@@ -132,8 +132,6 @@ protected:
 
 private:
   void start_mark();
-
-  static bool has_in_place_promotions(ShenandoahHeap* heap) ;
 
   // Messages for GC trace events, they have to be immortal for
   // passing around the logging/tracing systems

--- a/src/hotspot/share/gc/shenandoah/shenandoahDegeneratedGC.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahDegeneratedGC.cpp
@@ -164,15 +164,15 @@ void ShenandoahDegenGC::op_degenerated() {
           // we will rescan the roots on this safepoint.
           heap->old_generation()->transfer_pointers_from_satb();
         }
+      }
 
-        if (_degen_point == ShenandoahDegenPoint::_degenerated_roots) {
-          // We only need this if the concurrent cycle has already swapped the card tables.
-          // Marking will use the 'read' table, but interesting pointers may have been
-          // recorded in the 'write' table in the time between the cancelled concurrent cycle
-          // and this degenerated cycle. These pointers need to be included the 'read' table
-          // used to scan the remembered set during the STW mark which follows here.
-          _generation->merge_write_table();
-        }
+      if (_degen_point == ShenandoahDegenPoint::_degenerated_roots) {
+        // We only need this if the concurrent cycle has already swapped the card tables.
+        // Marking will use the 'read' table, but interesting pointers may have been
+        // recorded in the 'write' table in the time between the cancelled concurrent cycle
+        // and this degenerated cycle. These pointers need to be included the 'read' table
+        // used to scan the remembered set during the STW mark which follows here.
+        _generation->merge_write_table();
       }
 
       op_reset();
@@ -280,15 +280,36 @@ void ShenandoahDegenGC::op_degenerated() {
       // In above case, update roots should disarm them
       ShenandoahCodeRoots::disarm_nmethods();
 
-      op_cleanup_complete();
-
-      if (heap->mode()->is_generational()) {
-        ShenandoahGenerationalHeap::heap()->complete_degenerated_cycle();
+      if (heap->mode()->is_generational() && heap->is_concurrent_old_mark_in_progress()) {
+        // This is still necessary for degenerated cycles because the degeneration point may occur
+        // after final mark of the young generation. See ShenandoahConcurrentGC::op_final_updaterefs for
+        // a more detailed explanation.
+        heap->old_generation()->transfer_pointers_from_satb();
       }
 
+      op_cleanup_complete();
+      // We defer generation resizing actions until after cset regions have been recycled.
+      if (heap->mode()->is_generational()) {
+        auto result = ShenandoahGenerationalHeap::heap()->balance_generations();
+        LogTarget(Info, gc, ergo) lt;
+        if (lt.is_enabled()) {
+          LogStream ls(lt);
+          result.print_on("Degenerated GC", &ls);
+        }
+      }
       break;
     default:
       ShouldNotReachHere();
+  }
+
+  if (heap->mode()->is_generational()) {
+    // In case degeneration interrupted concurrent evacuation or update references, we need to clean up transient state.
+    // Otherwise, these actions have no effect.
+    ShenandoahGenerationalHeap::heap()->reset_generation_reserves();
+
+    if (!ShenandoahGenerationalHeap::heap()->old_generation()->is_parseable()) {
+      op_global_coalesce_and_fill();
+    }
   }
 
   if (ShenandoahVerify) {
@@ -380,6 +401,11 @@ void ShenandoahDegenGC::op_prepare_evacuation() {
 
 void ShenandoahDegenGC::op_cleanup_early() {
   ShenandoahHeap::heap()->recycle_trash();
+}
+
+void ShenandoahDegenGC::op_global_coalesce_and_fill() {
+  ShenandoahGCPhase phase(ShenandoahPhaseTimings::degen_gc_coalesce_and_fill);
+  ShenandoahGenerationalHeap::heap()->coalesce_and_fill_old_regions(false);
 }
 
 void ShenandoahDegenGC::op_evacuate() {

--- a/src/hotspot/share/gc/shenandoah/shenandoahDegeneratedGC.hpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahDegeneratedGC.hpp
@@ -58,6 +58,9 @@ private:
   void op_update_roots();
   void op_cleanup_complete();
 
+  // This will rebuild card offsets, which is necessary if classes were unloaded
+  void op_global_coalesce_and_fill();
+
   // Fail handling
   void op_degenerated_futile();
   void op_degenerated_fail();

--- a/src/hotspot/share/gc/shenandoah/shenandoahGenerationalHeap.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahGenerationalHeap.cpp
@@ -33,17 +33,14 @@
 #include "gc/shenandoah/shenandoahHeapRegion.hpp"
 #include "gc/shenandoah/shenandoahInitLogger.hpp"
 #include "gc/shenandoah/shenandoahMemoryPool.hpp"
-#include "gc/shenandoah/shenandoahMonitoringSupport.hpp"
 #include "gc/shenandoah/shenandoahOldGeneration.hpp"
 #include "gc/shenandoah/shenandoahOopClosures.inline.hpp"
 #include "gc/shenandoah/shenandoahPhaseTimings.hpp"
 #include "gc/shenandoah/shenandoahRegulatorThread.hpp"
 #include "gc/shenandoah/shenandoahScanRemembered.inline.hpp"
-#include "gc/shenandoah/shenandoahWorkerPolicy.hpp"
 #include "gc/shenandoah/shenandoahYoungGeneration.hpp"
 #include "gc/shenandoah/shenandoahUtils.hpp"
 #include "logging/log.hpp"
-#include "utilities/events.hpp"
 
 
 class ShenandoahGenerationalInitLogger : public ShenandoahInitLogger {
@@ -945,88 +942,5 @@ void ShenandoahGenerationalHeap::update_heap_references(bool concurrent) {
   if (ShenandoahEnableCardStats) { // generational check proxy
     assert(card_scan() != nullptr, "Card table must exist when card stats are enabled");
     card_scan()->log_card_stats(nworkers, CARD_STAT_UPDATE_REFS);
-  }
-}
-
-void ShenandoahGenerationalHeap::complete_degenerated_cycle() {
-  shenandoah_assert_heaplocked_or_safepoint();
-  if (is_concurrent_old_mark_in_progress()) {
-    // This is still necessary for degenerated cycles because the degeneration point may occur
-    // after final mark of the young generation. See ShenandoahConcurrentGC::op_final_updaterefs for
-    // a more detailed explanation.
-    old_generation()->transfer_pointers_from_satb();
-  }
-
-  // We defer generation resizing actions until after cset regions have been recycled.
-  TransferResult result = balance_generations();
-  LogTarget(Info, gc, ergo) lt;
-  if (lt.is_enabled()) {
-    LogStream ls(lt);
-    result.print_on("Degenerated GC", &ls);
-  }
-
-  // In case degeneration interrupted concurrent evacuation or update references, we need to clean up
-  // transient state. Otherwise, these actions have no effect.
-  reset_generation_reserves();
-
-  if (!old_generation()->is_parseable()) {
-    ShenandoahGCPhase phase(ShenandoahPhaseTimings::degen_gc_coalesce_and_fill);
-    coalesce_and_fill_old_regions(false);
-  }
-}
-
-void ShenandoahGenerationalHeap::complete_concurrent_cycle() {
-  if (!old_generation()->is_parseable()) {
-    // Class unloading may render the card offsets unusable, so we must rebuild them before
-    // the next remembered set scan. We _could_ let the control thread do this sometime after
-    // the global cycle has completed and before the next young collection, but under memory
-    // pressure the control thread may not have the time (that is, because it's running back
-    // to back GCs). In that scenario, we would have to make the old regions parsable before
-    // we could start a young collection. This could delay the start of the young cycle and
-    // throw off the heuristics.
-    entry_global_coalesce_and_fill();
-  }
-
-  TransferResult result;
-  {
-    ShenandoahHeapLocker locker(lock());
-
-    result = balance_generations();
-    reset_generation_reserves();
-  }
-
-  LogTarget(Info, gc, ergo) lt;
-  if (lt.is_enabled()) {
-    LogStream ls(lt);
-    result.print_on("Concurrent GC", &ls);
-  }
-}
-
-void ShenandoahGenerationalHeap::entry_global_coalesce_and_fill() {
-  const char* msg = "Coalescing and filling old regions";
-  ShenandoahConcurrentPhase gc_phase(msg, ShenandoahPhaseTimings::conc_coalesce_and_fill);
-
-  TraceCollectorStats tcs(monitoring_support()->concurrent_collection_counters());
-  EventMark em("%s", msg);
-  ShenandoahWorkerScope scope(workers(),
-                              ShenandoahWorkerPolicy::calc_workers_for_conc_marking(),
-                              "concurrent coalesce and fill");
-
-  coalesce_and_fill_old_regions(true);
-}
-
-void ShenandoahGenerationalHeap::update_region_ages() {
-  ShenandoahMarkingContext *ctx = complete_marking_context();
-  for (size_t i = 0; i < num_regions(); i++) {
-    ShenandoahHeapRegion *r = get_region(i);
-    if (r->is_active() && r->is_young()) {
-      HeapWord* tams = ctx->top_at_mark_start(r);
-      HeapWord* top = r->top();
-      if (top > tams) {
-        r->reset_age();
-      } else if (is_aging_cycle()) {
-        r->increment_age();
-      }
-    }
   }
 }

--- a/src/hotspot/share/gc/shenandoah/shenandoahGenerationalHeap.hpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahGenerationalHeap.hpp
@@ -50,10 +50,6 @@ public:
     return _is_aging_cycle.is_set();
   }
 
-  // Ages regions that haven't been used for allocations in the current cycle.
-  // Resets ages for regions that have been used for allocations.
-  void update_region_ages();
-
   oop evacuate_object(oop p, Thread* thread) override;
   oop try_evacuate_object(oop p, Thread* thread, ShenandoahHeapRegion* from_region, ShenandoahAffiliation target_gen);
 
@@ -66,7 +62,6 @@ public:
   // ---------- Update References
   //
   void update_heap_references(bool concurrent) override;
-
 private:
   HeapWord* allocate_from_plab(Thread* thread, size_t size, bool is_promotion);
   HeapWord* allocate_from_plab_slow(Thread* thread, size_t size, bool is_promotion);
@@ -108,15 +103,11 @@ public:
   // Transfers surplus old regions to young, or takes regions from young to satisfy old region deficit
   TransferResult balance_generations();
 
-  // Balances generations, coalesces and fills old regions if necessary
-  void complete_degenerated_cycle();
-  void complete_concurrent_cycle();
+  // Makes old regions parsable
+  void coalesce_and_fill_old_regions(bool concurrent);
+
 private:
   void initialize_controller() override;
-  void entry_global_coalesce_and_fill();
-
-  // Makes old regions parsable. This will also rebuild card offsets, which is necessary if classes were unloaded
-  void coalesce_and_fill_old_regions(bool concurrent);
 
   ShenandoahRegulatorThread* _regulator_thread;
 


### PR DESCRIPTION
This reverts commit 8f808276edfb163c14223f642f12dc6faddc49c6. This commit is breaking in stress test pipelines. I'm backing it out while it is debugged.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed (1 review required, with at least 1 [Committer](https://openjdk.org/bylaws#committer))

### Issue
 * [JDK-8332824](https://bugs.openjdk.org/browse/JDK-8332824): GenShen: Temporarily revert recent changes to GC helpers (**Task** - P4)


### Reviewers
 * [Kelvin Nilsen](https://openjdk.org/census#kdnilsen) (@kdnilsen - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/shenandoah.git pull/437/head:pull/437` \
`$ git checkout pull/437`

Update a local copy of the PR: \
`$ git checkout pull/437` \
`$ git pull https://git.openjdk.org/shenandoah.git pull/437/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 437`

View PR using the GUI difftool: \
`$ git pr show -t 437`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/shenandoah/pull/437.diff">https://git.openjdk.org/shenandoah/pull/437.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/shenandoah/pull/437#issuecomment-2127127836)