### PR TITLE
8332913: GenShen: Restore shared update refs iterator

### DIFF
--- a/src/hotspot/share/gc/shenandoah/shenandoahConcurrentGC.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahConcurrentGC.cpp
@@ -1200,6 +1200,7 @@ void ShenandoahConcurrentGC::op_update_thread_roots() {
 void ShenandoahConcurrentGC::op_final_updaterefs() {
   ShenandoahHeap* const heap = ShenandoahHeap::heap();
   assert(ShenandoahSafepoint::is_at_shenandoah_safepoint(), "must be at safepoint");
+  assert(!heap->_update_refs_iterator.has_next(), "Should have finished update references");
 
   heap->finish_concurrent_roots();
 

--- a/src/hotspot/share/gc/shenandoah/shenandoahGenerationalHeap.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahGenerationalHeap.cpp
@@ -937,6 +937,9 @@ void ShenandoahGenerationalHeap::update_heap_references(bool concurrent) {
     workers()->run_task(&task);
   }
 
-  assert(card_scan() != nullptr, "Card table must exist when card stats are enabled");
-  card_scan()->log_card_stats(nworkers, CARD_STAT_UPDATE_REFS);
+  if (ShenandoahEnableCardStats) {
+    // Only do this if we are collecting card stats
+    assert(card_scan() != nullptr, "Card table must exist when card stats are enabled");
+    card_scan()->log_card_stats(nworkers, CARD_STAT_UPDATE_REFS);
+  }
 }

--- a/src/hotspot/share/gc/shenandoah/shenandoahGenerationalHeap.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahGenerationalHeap.cpp
@@ -927,20 +927,16 @@ private:
 
 void ShenandoahGenerationalHeap::update_heap_references(bool concurrent) {
   assert(!is_full_gc_in_progress(), "Only for concurrent and degenerated GC");
-  uint nworkers = workers()->active_workers();
+  const uint nworkers = workers()->active_workers();
   ShenandoahRegionChunkIterator work_list(nworkers);
-  ShenandoahRegionIterator update_refs_iterator(this);
   if (concurrent) {
-    ShenandoahGenerationalUpdateHeapRefsTask<true> task(&update_refs_iterator, &work_list);
+    ShenandoahGenerationalUpdateHeapRefsTask<true> task(&_update_refs_iterator, &work_list);
     workers()->run_task(&task);
   } else {
-    ShenandoahGenerationalUpdateHeapRefsTask<false> task(&update_refs_iterator, &work_list);
+    ShenandoahGenerationalUpdateHeapRefsTask<false> task(&_update_refs_iterator, &work_list);
     workers()->run_task(&task);
   }
-  assert(cancelled_gc() || !update_refs_iterator.has_next(), "Should have finished update references");
 
-  if (ShenandoahEnableCardStats) { // generational check proxy
-    assert(card_scan() != nullptr, "Card table must exist when card stats are enabled");
-    card_scan()->log_card_stats(nworkers, CARD_STAT_UPDATE_REFS);
-  }
+  assert(card_scan() != nullptr, "Card table must exist when card stats are enabled");
+  card_scan()->log_card_stats(nworkers, CARD_STAT_UPDATE_REFS);
 }

--- a/src/hotspot/share/gc/shenandoah/shenandoahHeap.hpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahHeap.hpp
@@ -436,6 +436,12 @@ public:
   // Returns true if the soft maximum heap has been changed using management APIs.
   bool check_soft_max_changed();
 
+protected:
+  // This is shared between shConcurrentGC and shDegenerateGC so that degenerated
+  // GC can resume update refs from where the concurrent GC was cancelled. It is
+  // also used in shGenerationalHeap, which uses a different closure for update refs.
+  ShenandoahRegionIterator _update_refs_iterator;
+
 private:
   // GC support
   // Evacuation


### PR DESCRIPTION
Turns out, this iterator is shared between concurrent and degenerated GC cycles. It should not have been made into a local variable.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed (1 review required, with at least 1 [Committer](https://openjdk.org/bylaws#committer))

### Issue
 * [JDK-8332913](https://bugs.openjdk.org/browse/JDK-8332913): GenShen: Restore shared update refs iterator (**Task** - P4)


### Reviewers
 * [Y. Srinivas Ramakrishna](https://openjdk.org/census#ysr) (@ysramakrishna - Committer) ⚠️ Review applies to [6fdc1691](https://git.openjdk.org/shenandoah/pull/439/files/6fdc1691b862eaf5da2adb23299e608c465432c4)
 * [Kelvin Nilsen](https://openjdk.org/census#kdnilsen) (@kdnilsen - Committer) ⚠️ Review applies to [6fdc1691](https://git.openjdk.org/shenandoah/pull/439/files/6fdc1691b862eaf5da2adb23299e608c465432c4)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/shenandoah.git pull/439/head:pull/439` \
`$ git checkout pull/439`

Update a local copy of the PR: \
`$ git checkout pull/439` \
`$ git pull https://git.openjdk.org/shenandoah.git pull/439/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 439`

View PR using the GUI difftool: \
`$ git pr show -t 439`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/shenandoah/pull/439.diff">https://git.openjdk.org/shenandoah/pull/439.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/shenandoah/pull/439#issuecomment-2130096245)