### PR TITLE
8333825: GenShen: Revert/Remove ShenandoahMaxEvacLABRatio

### DIFF
--- a/src/hotspot/share/gc/shenandoah/shenandoahGenerationalHeap.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahGenerationalHeap.cpp
@@ -90,9 +90,7 @@ size_t ShenandoahGenerationalHeap::calculate_min_plab() {
 
 size_t ShenandoahGenerationalHeap::calculate_max_plab() {
   size_t MaxTLABSizeWords = ShenandoahHeapRegion::max_tlab_size_words();
-  return ((ShenandoahMaxEvacLABRatio > 0)?
-          align_down(MIN2(MaxTLABSizeWords, PLAB::min_size() * ShenandoahMaxEvacLABRatio), CardTable::card_size_in_words()):
-          align_down(MaxTLABSizeWords, CardTable::card_size_in_words()));
+  return align_down(MaxTLABSizeWords, CardTable::card_size_in_words());
 }
 
 // Returns size in bytes
@@ -402,51 +400,50 @@ HeapWord* ShenandoahGenerationalHeap::allocate_from_plab_slow(Thread* thread, si
 
   assert(mode()->is_generational(), "PLABs only relevant to generational GC");
   const size_t plab_min_size = this->plab_min_size();
+  // PLABs must align on size of card table in order to avoid the need for synchronization when registering
+  // newly allocated objects within the card table.
   const size_t min_size = (size > plab_min_size)? align_up(size, CardTable::card_size_in_words()): plab_min_size;
 
-  // Figure out size of new PLAB, looking back at heuristics. Expand aggressively.  PLABs must align on size
-  // of card table in order to avoid the need for synchronization when registering newly allocated objects within
-  // the card table.
+  // Figure out size of new PLAB, using value determined at last refill.
   size_t cur_size = ShenandoahThreadLocalData::plab_size(thread);
   if (cur_size == 0) {
     cur_size = plab_min_size;
   }
 
-  // Limit growth of PLABs to the smaller of ShenandoahMaxEvacLABRatio * the minimum size and ShenandoahHumongousThreshold.
-  // This minimum value is represented by generational_heap->plab_max_size().  Enforcing this limit enables more equitable
-  // distribution of available evacuation budget between the many threads that are coordinating in the evacuation effort.
+  // We'll expand aggressively, doubling at each refill in this epoch, clamping at plab_max_size()
   size_t future_size = MIN2(cur_size * 2, plab_max_size());
-  assert(is_aligned(future_size, CardTable::card_size_in_words()), "Align by design, future_size: " SIZE_FORMAT
-          ", alignment: " SIZE_FORMAT ", cur_size: " SIZE_FORMAT ", max: " SIZE_FORMAT,
+  // Since we start off a card-multiple, and grow by doubling, we should remain a card-multiple
+  assert(is_aligned(future_size, CardTable::card_size_in_words()), "Card multiple by construction, future_size: " SIZE_FORMAT
+          ", card_size: " SIZE_FORMAT ", cur_size: " SIZE_FORMAT ", max: " SIZE_FORMAT,
          future_size, (size_t) CardTable::card_size_in_words(), cur_size, plab_max_size());
 
   // Record new heuristic value even if we take any shortcut. This captures
   // the case when moderately-sized objects always take a shortcut. At some point,
   // heuristics should catch up with them.  Note that the requested cur_size may
   // not be honored, but we remember that this is the preferred size.
+  log_debug(gc, free)("Thread " PTR_FORMAT " Set future PLAB: " SIZE_FORMAT, p2i(thread), future_size);
   ShenandoahThreadLocalData::set_plab_size(thread, future_size);
   if (cur_size < size) {
     // The PLAB to be allocated is still not large enough to hold the object. Fall back to shared allocation.
     // This avoids retiring perfectly good PLABs in order to represent a single large object allocation.
+    log_debug(gc, free)("Thread " PTR_FORMAT " current PLAB size (" SIZE_FORMAT ") is too small for " SIZE_FORMAT, p2i(thread), cur_size, size);
     return nullptr;
   }
 
   // Retire current PLAB, and allocate a new one.
   PLAB* plab = ShenandoahThreadLocalData::plab(thread);
   if (plab->words_remaining() < plab_min_size) {
-    // Retire current PLAB, and allocate a new one.
-    // CAUTION: retire_plab may register the remnant filler object with the remembered set scanner without a lock.  This
-    // is safe iff it is assured that each PLAB is a whole-number multiple of card-mark memory size and each PLAB is
-    // aligned with the start of a card's memory range.
+    // Retire current PLAB. This does appropriate PLAB tracking accounting & book-keeping.
+    // CAUTION: retire_plab may register the remnant filler object with the remembered set scanner without a lock.
+    // This is safe iff each PLAB is card-aligned and is a multiple of card-size, so updates will never
+    // interfere or conflict.
     retire_plab(plab, thread);
 
     size_t actual_size = 0;
-    // allocate_new_plab resets plab_evacuated and plab_promoted and disables promotions if old-gen available is
-    // less than the remaining evacuation need.  It also adjusts plab_preallocated and expend_promoted if appropriate.
     HeapWord* plab_buf = allocate_new_plab(min_size, cur_size, &actual_size);
     if (plab_buf == nullptr) {
       if (min_size == plab_min_size) {
-        // Disable plab promotions for this thread because we cannot even allocate a plab of minimal size.  This allows us
+        // Disable PLAB promotions for this thread because we cannot even allocate a minimal PLAB. This allows us
         // to fail faster on subsequent promotion attempts.
         ShenandoahThreadLocalData::disable_plab_promotions(thread);
       }

--- a/src/hotspot/share/gc/shenandoah/shenandoahHeap.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahHeap.cpp
@@ -920,7 +920,7 @@ HeapWord* ShenandoahHeap::allocate_from_gclab_slow(Thread* thread, size_t size) 
   // Record new heuristic value even if we take any shortcut. This captures
   // the case when moderately-sized objects always take a shortcut. At some point,
   // heuristics should catch up with them.
-  log_debug(gc, free)("Bump up GCLAB size to " SIZE_FORMAT, new_size);
+  log_debug(gc, free)("Set new GCLAB size: " SIZE_FORMAT, new_size);
   ShenandoahThreadLocalData::set_gclab_size(thread, new_size);
 
   if (new_size < size) {

--- a/src/hotspot/share/gc/shenandoah/shenandoahHeap.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahHeap.cpp
@@ -914,20 +914,19 @@ HeapWord* ShenandoahHeap::allocate_from_gclab_slow(Thread* thread, size_t size) 
   // Figure out size of new GCLAB, looking back at heuristics. Expand aggressively.
   size_t new_size = ShenandoahThreadLocalData::gclab_size(thread) * 2;
 
-  // Clamp between ceiling and floor
   new_size = MIN2(new_size, PLAB::max_size());
   new_size = MAX2(new_size, PLAB::min_size());
 
   // Record new heuristic value even if we take any shortcut. This captures
   // the case when moderately-sized objects always take a shortcut. At some point,
   // heuristics should catch up with them.
-  log_debug(gc, free)("Thread " PTR_FORMAT " Set new gclab: " SIZE_FORMAT, p2i(thread), new_size);
+  log_debug(gc, free)("Bump up GCLAB size to " SIZE_FORMAT, new_size);
   ShenandoahThreadLocalData::set_gclab_size(thread, new_size);
 
   if (new_size < size) {
     // New size still does not fit the object. Fall back to shared allocation.
     // This avoids retiring perfectly good GCLABs, when we encounter a large object.
-    log_debug(gc, free)("Thread " PTR_FORMAT " new gclab size (" SIZE_FORMAT ") is too small for " SIZE_FORMAT, p2i(thread), new_size, size);
+    log_debug(gc, free)("New gclab size (" SIZE_FORMAT ") is too small for " SIZE_FORMAT, new_size, size);
     return nullptr;
   }
 

--- a/src/hotspot/share/gc/shenandoah/shenandoah_globals.hpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoah_globals.hpp
@@ -383,26 +383,6 @@
           "failures, which will trigger stop-the-world Full GC passes.")    \
           range(1.0,100.0)                                                  \
                                                                             \
-  product(uintx, ShenandoahMaxEvacLABRatio, 0, EXPERIMENTAL,                \
-          "Potentially, each running thread maintains a PLAB for "          \
-          "evacuating objects into old-gen memory and a GCLAB for "         \
-          "evacuating objects into young-gen memory.  Each time a thread "  \
-          "exhausts its PLAB or GCLAB, a new local buffer is allocated. "   \
-          "By default, the new buffer is twice the size of the previous "   \
-          "buffer.  The sizes are reset to the minimum at the start of "    \
-          "each GC pass.  This parameter limits the growth of evacuation "  \
-          "buffer sizes to its value multiplied by the minimum buffer "     \
-          "size.  A higher value allows evacuation allocations to be more " \
-          "efficient because less synchronization is required by "          \
-          "individual threads.  However, a larger value increases the "     \
-          "likelihood of evacuation failures, leading to long "             \
-          "stop-the-world pauses.  This is because a large value "          \
-          "allows individual threads to consume large percentages of "      \
-          "the total evacuation budget without necessarily effectively "    \
-          "filling their local evacuation buffers with evacuated "          \
-          "objects.  A value of zero means no maximum size is enforced.")   \
-          range(0, 1024)                                                    \
-                                                                            \
   product(bool, ShenandoahEvacReserveOverflow, true, EXPERIMENTAL,          \
           "Allow evacuations to overflow the reserved space. Enabling it "  \
           "will make evacuations more resilient when evacuation "           \


### PR DESCRIPTION
/issue JDK-8333825 GenShen: Revert/Remove ShenandoahMaxEvacLABRatio

ShenandoahMaxEvacLABRatio was intended as an experimental/research option and guardrail to manually bound the ceiling of PLABs used in Shenandoah and GenShen at the time that GenShen's LAB auto-sizing and allocation heuristics were somewhat nascent and immature. There is however a natural upper-bound of the heap region size for these local allocation buffers which prevent runaway growth, and the manual throttle has never had to be used, and the option thus appears somewhat vestigial. Removing it also reduces differences with upstream Shenandoah which should simplify GenShen's upstreaming reviews.

- Removed the option and its uses in Shen and GenShen code
- Adjusted logging to be consistent, and adjusted some comments in GenShen
- Tested with codepipeline, GC tests, and exercised the new log lines

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed (1 review required, with at least 1 [Committer](https://openjdk.org/bylaws#committer))

### Issue
 * [JDK-8333825](https://bugs.openjdk.org/browse/JDK-8333825): GenShen: Revert/Remove ShenandoahMaxEvacLABRatio (**Task** - P4)


### Reviewers
 * [William Kemper](https://openjdk.org/census#wkemper) (@earthling-amzn - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/shenandoah.git pull/446/head:pull/446` \
`$ git checkout pull/446`

Update a local copy of the PR: \
`$ git checkout pull/446` \
`$ git pull https://git.openjdk.org/shenandoah.git pull/446/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 446`

View PR using the GUI difftool: \
`$ git pr show -t 446`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/shenandoah/pull/446.diff">https://git.openjdk.org/shenandoah/pull/446.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/shenandoah/pull/446#issuecomment-2155323862)