### PR TITLE
8334491: GenShen: Revert changes to Shenandoah defaults

### DIFF
--- a/src/hotspot/share/gc/shenandoah/shenandoah_globals.hpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoah_globals.hpp
@@ -219,7 +219,7 @@
           "cases. In percents of (soft) max heap size.")                    \
           range(0,100)                                                      \
                                                                             \
-  product(uintx, ShenandoahLearningSteps, 10, EXPERIMENTAL,                 \
+  product(uintx, ShenandoahLearningSteps, 5, EXPERIMENTAL,                  \
           "The number of cycles some heuristics take to collect in order "  \
           "to learn application and GC performance.")                       \
           range(0,100)                                                      \
@@ -253,7 +253,7 @@
           "the heuristic is to allocation spikes. Decreasing this number "  \
           "increases the sensitivity. ")                                    \
                                                                             \
-  product(double, ShenandoahAdaptiveDecayFactor, 0.1, EXPERIMENTAL,         \
+  product(double, ShenandoahAdaptiveDecayFactor, 0.5, EXPERIMENTAL,         \
           "The decay factor (alpha) used for values in the weighted "       \
           "moving average of cycle time and allocation rate. "              \
           "Larger values give more weight to recent values.")               \


### PR DESCRIPTION
On the genshen branch, we have changed the adaptive heuristics decay factor to 0.1 and increased the learning cycles to 10. Testing with the original defaults of 0.5 and 5 (respectively) shows modest performance improvements in specjbb and extremem.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed (1 review required, with at least 1 [Committer](https://openjdk.org/bylaws#committer))

### Issue
 * [JDK-8334491](https://bugs.openjdk.org/browse/JDK-8334491): GenShen: Revert changes to Shenandoah defaults (**Task** - P4)


### Reviewers
 * [Kelvin Nilsen](https://openjdk.org/census#kdnilsen) (@kdnilsen - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/shenandoah.git pull/450/head:pull/450` \
`$ git checkout pull/450`

Update a local copy of the PR: \
`$ git checkout pull/450` \
`$ git pull https://git.openjdk.org/shenandoah.git pull/450/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 450`

View PR using the GUI difftool: \
`$ git pr show -t 450`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/shenandoah/pull/450.diff">https://git.openjdk.org/shenandoah/pull/450.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/shenandoah/pull/450#issuecomment-2176690106)