### PR TITLE
8335347: GenShen: Revert change that has adaptive heuristic ignore abbreviated cycles

### DIFF
--- a/src/hotspot/share/gc/shenandoah/heuristics/shenandoahAdaptiveHeuristics.cpp
+++ b/src/hotspot/share/gc/shenandoah/heuristics/shenandoahAdaptiveHeuristics.cpp
@@ -132,8 +132,8 @@ void ShenandoahAdaptiveHeuristics::record_cycle_start() {
   _allocation_rate.allocation_counter_reset();
 }
 
-void ShenandoahAdaptiveHeuristics::record_success_concurrent(bool abbreviated) {
-  ShenandoahHeuristics::record_success_concurrent(abbreviated);
+void ShenandoahAdaptiveHeuristics::record_success_concurrent() {
+  ShenandoahHeuristics::record_success_concurrent();
 
   size_t available = _space_info->available();
 

--- a/src/hotspot/share/gc/shenandoah/heuristics/shenandoahAdaptiveHeuristics.hpp
+++ b/src/hotspot/share/gc/shenandoah/heuristics/shenandoahAdaptiveHeuristics.hpp
@@ -76,7 +76,7 @@ public:
                                                      size_t actual_free);
 
   void record_cycle_start();
-  void record_success_concurrent(bool abbreviated);
+  void record_success_concurrent();
   void record_success_degenerated();
   void record_success_full();
 

--- a/src/hotspot/share/gc/shenandoah/heuristics/shenandoahHeuristics.cpp
+++ b/src/hotspot/share/gc/shenandoah/heuristics/shenandoahHeuristics.cpp
@@ -220,14 +220,11 @@ void ShenandoahHeuristics::adjust_penalty(intx step) {
          "In range after adjustment: " INTX_FORMAT, _gc_time_penalties);
 }
 
-void ShenandoahHeuristics::record_success_concurrent(bool abbreviated) {
+void ShenandoahHeuristics::record_success_concurrent() {
+  _gc_cycle_time_history->add(elapsed_cycle_time());
   _gc_times_learned++;
 
   adjust_penalty(Concurrent_Adjust);
-
-  if (_gc_times_learned <= ShenandoahLearningSteps || !(abbreviated && ShenandoahAdaptiveIgnoreShortCycles)) {
-    _gc_cycle_time_history->add(elapsed_cycle_time());
-  }
 }
 
 void ShenandoahHeuristics::record_success_degenerated() {

--- a/src/hotspot/share/gc/shenandoah/heuristics/shenandoahHeuristics.hpp
+++ b/src/hotspot/share/gc/shenandoah/heuristics/shenandoahHeuristics.hpp
@@ -141,7 +141,7 @@ public:
 
   virtual bool should_degenerate_cycle();
 
-  virtual void record_success_concurrent(bool abbreviated);
+  virtual void record_success_concurrent();
 
   virtual void record_success_degenerated();
 

--- a/src/hotspot/share/gc/shenandoah/heuristics/shenandoahOldHeuristics.cpp
+++ b/src/hotspot/share/gc/shenandoah/heuristics/shenandoahOldHeuristics.cpp
@@ -685,10 +685,10 @@ bool ShenandoahOldHeuristics::should_start_gc() {
   return this->ShenandoahHeuristics::should_start_gc();
 }
 
-void ShenandoahOldHeuristics::record_success_concurrent(bool abbreviated) {
+void ShenandoahOldHeuristics::record_success_concurrent() {
   // Forget any triggers that occurred while OLD GC was ongoing.  If we really need to start another, it will retrigger.
   clear_triggers();
-  this->ShenandoahHeuristics::record_success_concurrent(abbreviated);
+  this->ShenandoahHeuristics::record_success_concurrent();
 }
 
 void ShenandoahOldHeuristics::record_success_degenerated() {

--- a/src/hotspot/share/gc/shenandoah/heuristics/shenandoahOldHeuristics.hpp
+++ b/src/hotspot/share/gc/shenandoah/heuristics/shenandoahOldHeuristics.hpp
@@ -189,7 +189,7 @@ public:
 
   bool should_start_gc() override;
 
-  void record_success_concurrent(bool abbreviated) override;
+  void record_success_concurrent() override;
 
   void record_success_degenerated() override;
 

--- a/src/hotspot/share/gc/shenandoah/shenandoahControlThread.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahControlThread.cpp
@@ -326,7 +326,7 @@ void ShenandoahControlThread::service_concurrent_normal_cycle(GCCause::Cause cau
   ShenandoahConcurrentGC gc(heap->global_generation(), false);
   if (gc.collect(cause)) {
     // Cycle is complete
-    heap->global_generation()->heuristics()->record_success_concurrent(gc.abbreviated());
+    heap->global_generation()->heuristics()->record_success_concurrent();
     heap->shenandoah_policy()->record_success_concurrent(false, gc.abbreviated());
     heap->log_heap_status("At end of GC");
   } else {

--- a/src/hotspot/share/gc/shenandoah/shenandoahGeneration.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahGeneration.cpp
@@ -1009,6 +1009,6 @@ void ShenandoahGeneration::decrease_capacity(size_t decrement) {
 }
 
 void ShenandoahGeneration::record_success_concurrent(bool abbreviated) {
-  heuristics()->record_success_concurrent(abbreviated);
+  heuristics()->record_success_concurrent();
   ShenandoahHeap::heap()->shenandoah_policy()->record_success_concurrent(is_young(), abbreviated);
 }

--- a/src/hotspot/share/gc/shenandoah/shenandoahOldGeneration.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahOldGeneration.cpp
@@ -618,7 +618,7 @@ ShenandoahHeuristics* ShenandoahOldGeneration::initialize_heuristics(ShenandoahM
 }
 
 void ShenandoahOldGeneration::record_success_concurrent(bool abbreviated) {
-  heuristics()->record_success_concurrent(abbreviated);
+  heuristics()->record_success_concurrent();
   ShenandoahHeap::heap()->shenandoah_policy()->record_success_old();
 }
 

--- a/src/hotspot/share/gc/shenandoah/shenandoah_globals.hpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoah_globals.hpp
@@ -259,16 +259,6 @@
           "Larger values give more weight to recent values.")               \
           range(0,1.0)                                                      \
                                                                             \
-  product(bool, ShenandoahAdaptiveIgnoreShortCycles, true, EXPERIMENTAL,    \
-          "The adaptive heuristic tracks a moving average of cycle "        \
-          "times in order to start a gc before memory is exhausted. "       \
-          "In some cases, Shenandoah may skip the evacuation and update "   \
-          "reference phases, resulting in a shorter cycle. These may skew " \
-          "the average cycle time downward and may cause the heuristic "    \
-          "to wait too long to start a cycle. Disabling this will have "    \
-          "the gc run less often, which will reduce CPU utilization, but"   \
-          "increase the risk of degenerated cycles.")                       \
-                                                                            \
   product(uintx, ShenandoahGuaranteedGCInterval, 5*60*1000, EXPERIMENTAL,   \
           "Many heuristics would guarantee a concurrent GC cycle at "       \
           "least with this interval. This is useful when large idle "       \


### PR DESCRIPTION
Additional performance testing has shown no benefit from this feature. In fact, latency is degraded on the extremem benchmark with this feature enabled.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed (1 review required, with at least 1 [Committer](https://openjdk.org/bylaws#committer))

### Issue
 * [JDK-8335347](https://bugs.openjdk.org/browse/JDK-8335347): GenShen: Revert change that has adaptive heuristic ignore abbreviated cycles (**Bug** - P4)


### Reviewers
 * [Kelvin Nilsen](https://openjdk.org/census#kdnilsen) (@kdnilsen - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/shenandoah.git pull/455/head:pull/455` \
`$ git checkout pull/455`

Update a local copy of the PR: \
`$ git checkout pull/455` \
`$ git pull https://git.openjdk.org/shenandoah.git pull/455/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 455`

View PR using the GUI difftool: \
`$ git pr show -t 455`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/shenandoah/pull/455.diff">https://git.openjdk.org/shenandoah/pull/455.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/shenandoah/pull/455#issuecomment-2197272250)