### PR TITLE
8335932: GenShen: Fix old heuristic unit test

### DIFF
--- a/test/hotspot/gtest/gc/shenandoah/test_shenandoahOldHeuristic.cpp
+++ b/test/hotspot/gtest/gc/shenandoah/test_shenandoahOldHeuristic.cpp
@@ -82,12 +82,17 @@ class ShenandoahOldHeuristicTest : public ::testing::Test {
     _heap = ShenandoahHeap::heap();
     _heuristics = _heap->old_generation()->heuristics();
     _collection_set = _heap->collection_set();
-    ShenandoahHeapLocker locker(_heap->lock());
+    _heap->lock()->lock(false);
     ShenandoahResetRegions reset;
     _heap->heap_region_iterate(&reset);
-    _heap->old_generation()->set_evacuation_reserve(_heap->old_generation()->soft_max_capacity() / 4);
+    _heap->old_generation()->set_capacity(ShenandoahHeapRegion::region_size_bytes() * 10);
+    _heap->old_generation()->set_evacuation_reserve(ShenandoahHeapRegion::region_size_bytes() * 4);
     _heuristics->abandon_collection_candidates();
     _collection_set->clear();
+  }
+
+  ~ShenandoahOldHeuristicTest() override {
+    _heap->lock()->unlock();
   }
 
   ShenandoahOldGeneration::State old_generation_state() {
@@ -95,7 +100,6 @@ class ShenandoahOldHeuristicTest : public ::testing::Test {
   }
 
   size_t make_garbage(size_t region_idx, size_t garbage_bytes) {
-    ShenandoahHeapLocker locker(_heap->lock());
     ShenandoahHeapRegion* region = _heap->get_region(region_idx);
     region->set_affiliation(OLD_GENERATION);
     region->make_regular_allocation(OLD_GENERATION);
@@ -106,7 +110,7 @@ class ShenandoahOldHeuristicTest : public ::testing::Test {
   }
 
   size_t create_too_much_garbage_for_one_mixed_evacuation() {
-    size_t garbage_target = _heap->old_generation()->soft_max_capacity() / 2;
+    size_t garbage_target = _heap->old_generation()->max_capacity() / 2;
     size_t garbage_total = 0;
     size_t region_idx = 0;
     while (garbage_total < garbage_target && region_idx < _heap->num_regions()) {
@@ -116,14 +120,12 @@ class ShenandoahOldHeuristicTest : public ::testing::Test {
   }
 
   void make_pinned(size_t region_idx) {
-    ShenandoahHeapLocker locker(_heap->lock());
     ShenandoahHeapRegion* region = _heap->get_region(region_idx);
     region->record_pin();
     region->make_pinned();
   }
 
   void make_unpinned(size_t region_idx) {
-    ShenandoahHeapLocker locker(_heap->lock());
     ShenandoahHeapRegion* region = _heap->get_region(region_idx);
     region->record_unpin();
     region->make_unpinned();

--- a/test/hotspot/gtest/gc/shenandoah/test_shenandoahOldHeuristic.cpp
+++ b/test/hotspot/gtest/gc/shenandoah/test_shenandoahOldHeuristic.cpp
@@ -92,6 +92,7 @@ class ShenandoahOldHeuristicTest : public ::testing::Test {
   }
 
   ~ShenandoahOldHeuristicTest() override {
+    SKIP_IF_NOT_SHENANDOAH();
     _heap->lock()->unlock();
   }
 


### PR DESCRIPTION
This isn't really a unit test and it must be run with Shenandoah enabled, but it exercises a hard to reach code path. The test has suffered some bit-rot* of late that needs to be addressed.

\* We no longer set soft-max-capacity on the old generation.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed (1 review required, with at least 1 [Committer](https://openjdk.org/bylaws#committer))

### Issue
 * [JDK-8335932](https://bugs.openjdk.org/browse/JDK-8335932): GenShen: Fix old heuristic unit test (**Bug** - P4)


### Reviewers
 * [Kelvin Nilsen](https://openjdk.org/census#kdnilsen) (@kdnilsen - Committer) ⚠️ Review applies to [4e7e2b38](https://git.openjdk.org/shenandoah/pull/458/files/4e7e2b380b9ae99726daa9c6b70f81152c434ba4)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/shenandoah.git pull/458/head:pull/458` \
`$ git checkout pull/458`

Update a local copy of the PR: \
`$ git checkout pull/458` \
`$ git pull https://git.openjdk.org/shenandoah.git pull/458/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 458`

View PR using the GUI difftool: \
`$ git pr show -t 458`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/shenandoah/pull/458.diff">https://git.openjdk.org/shenandoah/pull/458.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/shenandoah/pull/458#issuecomment-2215413841)