### PR TITLE
8338780: GenShen: Fix up some comments

### DIFF
--- a/src/hotspot/share/gc/shenandoah/heuristics/shenandoahAdaptiveHeuristics.hpp
+++ b/src/hotspot/share/gc/shenandoah/heuristics/shenandoahAdaptiveHeuristics.hpp
@@ -140,6 +140,10 @@ protected:
   // source of feedback to adjust trigger parameters.
   TruncatedSeq _available;
 
+  // A conservative minimum threshold of free space that we'll try to maintain when possible.
+  // For example, we might trigger a concurrent gc if we are likely to drop below
+  // this threshold, or we might consider this when dynamically resizing generations
+  // in the generational case. Controlled by global flag ShenandoahMinFreeThreshold.
   size_t min_free_threshold();
 };
 

--- a/src/hotspot/share/gc/shenandoah/heuristics/shenandoahGlobalHeuristics.cpp
+++ b/src/hotspot/share/gc/shenandoah/heuristics/shenandoahGlobalHeuristics.cpp
@@ -40,29 +40,14 @@ ShenandoahGlobalHeuristics::ShenandoahGlobalHeuristics(ShenandoahGlobalGeneratio
 void ShenandoahGlobalHeuristics::choose_collection_set_from_regiondata(ShenandoahCollectionSet* cset,
                                                                        RegionData* data, size_t size,
                                                                        size_t actual_free) {
-  // The logic for cset selection in adaptive is as follows:
+  // See comments in ShenandoahAdaptiveHeuristics::choose_collection_set_from_regiondata():
+  // we do the same here, but with the following adjustments for generational mode:
   //
-  //   1. We cannot get cset larger than available free space. Otherwise we guarantee OOME
-  //      during evacuation, and thus guarantee full GC. In practice, we also want to let
-  //      application to allocate something. This is why we limit CSet to some fraction of
-  //      available space. In non-overloaded heap, max_cset would contain all plausible candidates
-  //      over garbage threshold.
-  //
-  //   2. We should not get cset too low so that free threshold would not be met right
-  //      after the cycle. Otherwise we get back-to-back cycles for no reason if heap is
-  //      too fragmented. In non-overloaded non-fragmented heap min_garbage would be around zero.
-  //
-  // Therefore, we start by sorting the regions by garbage. Then we unconditionally add the best candidates
-  // before we meet min_garbage. Then we add all candidates that fit with a garbage threshold before
-  // we hit max_cset. When max_cset is hit, we terminate the cset selection. Note that in this scheme,
-  // ShenandoahGarbageThreshold is the soft threshold which would be ignored until min_garbage is hit.
-
-  // In generational mode, the sort order within the data array is not strictly descending amounts of garbage.  In
-  // particular, regions that have reached tenure age will be sorted into this array before younger regions that contain
-  // more garbage.  This represents one of the reasons why we keep looking at regions even after we decide, for example,
-  // to exclude one of the regions because it might require evacuation of too much live data.
-
-
+  // In generational mode, the sort order within the data array is not strictly descending amounts
+  // of garbage. In particular, regions that have reached tenure age will be sorted into this
+  // array before younger regions that typically contain more garbage. This is one reason why,
+  // for example, we continue examining regions even after rejecting a region that has
+  // more live data than we can evacuate.
 
   // Better select garbage-first regions
   QuickSort::sort<RegionData>(data, (int) size, compare_by_garbage);
@@ -127,7 +112,8 @@ void ShenandoahGlobalHeuristics::choose_global_collection_set(ShenandoahCollecti
   for (size_t idx = 0; idx < size; idx++) {
     ShenandoahHeapRegion* r = data[idx]._region;
     if (cset->is_preselected(r->index())) {
-      fatal("There should be no preselected regions during GLOBAL GC");
+      assert(false, "There should be no preselected regions during GLOBAL GC");
+      // It isn't fatal, we just ignore it.
       continue;
     }
     bool add_region = false;

--- a/src/hotspot/share/gc/shenandoah/heuristics/shenandoahGlobalHeuristics.cpp
+++ b/src/hotspot/share/gc/shenandoah/heuristics/shenandoahGlobalHeuristics.cpp
@@ -53,9 +53,10 @@ void ShenandoahGlobalHeuristics::choose_collection_set_from_regiondata(Shenandoa
   QuickSort::sort<RegionData>(data, (int) size, compare_by_garbage);
 
   size_t cur_young_garbage = add_preselected_regions_to_collection_set(cset, data, size);
-  // TODO: If the following assert triggers, then we'll want to check if there are no preselected regions
-  // and may be go back and look at `add_preselected` logic and whether this is needed.
-  assert(cur_young_garbage > 0, "Error: was there any point in executing the above?");
+  // TODO: If the following assert triggers, then we'll want to check if there are
+  // situations where `add_preselected` would be needed. Otherwise, we'll assert there are
+  // never any preslected regions at this point. (Why aren't there?)
+  assert(cur_young_garbage == 0, "Error: we sometimes do add preselected regions here?");
 
   choose_global_collection_set(cset, data, size, actual_free, cur_young_garbage);
 

--- a/src/hotspot/share/gc/shenandoah/heuristics/shenandoahGlobalHeuristics.cpp
+++ b/src/hotspot/share/gc/shenandoah/heuristics/shenandoahGlobalHeuristics.cpp
@@ -53,6 +53,9 @@ void ShenandoahGlobalHeuristics::choose_collection_set_from_regiondata(Shenandoa
   QuickSort::sort<RegionData>(data, (int) size, compare_by_garbage);
 
   size_t cur_young_garbage = add_preselected_regions_to_collection_set(cset, data, size);
+  // TODO: If the following assert triggers, then we'll want to check if there are no preselected regions
+  // and may be go back and look at `add_preselected` logic and whether this is needed.
+  assert(cur_young_garbage > 0, "Error: was there any point in executing the above?");
 
   choose_global_collection_set(cset, data, size, actual_free, cur_young_garbage);
 


### PR DESCRIPTION
/issue JDK-8338780

In https://github.com/openjdk/jdk/pull/20395 Aleksey provided some suggestions for improving various comments. This ticket gathers together several of those changes. Additionally, there was a resulting simplification in the collection set construction for the global gc case as a result of the review & ensuing discussion.

**Testing:** 
- [x] GHA
- [x] SPECjbb w/GenShen
- [x] jtreg:tier1
- [x] jtreg:hotspot_gc (one test fails with OOM in master as well as current branch; will investigate that separately)
- [x] Codepipeline testing

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed (1 review required, with at least 1 [Committer](https://openjdk.org/bylaws#committer))

### Issue
 * [JDK-8338780](https://bugs.openjdk.org/browse/JDK-8338780): GenShen: Fix up some comments (**Task** - P4)


### Reviewers
 * [Kelvin Nilsen](https://openjdk.org/census#kdnilsen) (@kdnilsen - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/shenandoah.git pull/484/head:pull/484` \
`$ git checkout pull/484`

Update a local copy of the PR: \
`$ git checkout pull/484` \
`$ git pull https://git.openjdk.org/shenandoah.git pull/484/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 484`

View PR using the GUI difftool: \
`$ git pr show -t 484`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/shenandoah/pull/484.diff">https://git.openjdk.org/shenandoah/pull/484.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/shenandoah/pull/484#issuecomment-2305281088)