### PR TITLE
8338763: GenShen: Global GC should not swap remembered sets for the verifier

### DIFF
--- a/src/hotspot/share/gc/shenandoah/shenandoahConcurrentGC.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahConcurrentGC.cpp
@@ -599,10 +599,7 @@ void ShenandoahConcurrentGC::op_init_mark() {
 
   if (heap->mode()->is_generational()) {
     if (_generation->is_young()) {
-      // The current implementation of swap_remembered_set() copies the write-card-table
-      // to the read-card-table. The remembered sets are also swapped for GLOBAL collections
-      // so that the verifier works with the correct copy of the card table when verifying.
-      // TODO: This path should not really depend on ShenandoahVerify.
+      // The current implementation of swap_remembered_set() copies the write-card-table to the read-card-table.
       ShenandoahGCPhase phase(ShenandoahPhaseTimings::init_swap_rset);
       _generation->swap_remembered_set();
     }

--- a/src/hotspot/share/gc/shenandoah/shenandoahConcurrentGC.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahConcurrentGC.cpp
@@ -598,7 +598,7 @@ void ShenandoahConcurrentGC::op_init_mark() {
 
 
   if (heap->mode()->is_generational()) {
-    if (_generation->is_young() || (_generation->is_global() && ShenandoahVerify)) {
+    if (_generation->is_young()) {
       // The current implementation of swap_remembered_set() copies the write-card-table
       // to the read-card-table. The remembered sets are also swapped for GLOBAL collections
       // so that the verifier works with the correct copy of the card table when verifying.

--- a/src/hotspot/share/gc/shenandoah/shenandoahDegeneratedGC.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahDegeneratedGC.cpp
@@ -133,10 +133,8 @@ void ShenandoahDegenGC::op_degenerated() {
       heap->set_unload_classes(_generation->heuristics()->can_unload_classes() &&
                                 (!heap->mode()->is_generational() || _generation->is_global()));
 
-      if (heap->mode()->is_generational() &&
-            (_generation->is_young() || (_generation->is_global() && ShenandoahVerify))) {
-        // Swap remembered sets for young, or if the verifier will run during a global collect
-        // TODO: This path should not depend on ShenandoahVerify
+      if (heap->mode()->is_generational() && _generation->is_young()) {
+        // Swap remembered sets for young
         _generation->swap_remembered_set();
       }
 


### PR DESCRIPTION
It seems that subsequent improvements to remembered set verification have made this change unnecessary.

## Testing
GHA, internal pipelines and local dacapo runs

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed (1 review required, with at least 1 [Committer](https://openjdk.org/bylaws#committer))

### Issue
 * [JDK-8338763](https://bugs.openjdk.org/browse/JDK-8338763): GenShen: Global GC should not swap remembered sets for the verifier (**Task** - P4)


### Reviewers
 * [Kelvin Nilsen](https://openjdk.org/census#kdnilsen) (@kdnilsen - Committer) ⚠️ Review applies to [d52cdcc6](https://git.openjdk.org/shenandoah/pull/485/files/d52cdcc671af94ae19344a5c3a91f8c5c7d1289e)
 * [Y. Srinivas Ramakrishna](https://openjdk.org/census#ysr) (@ysramakrishna - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/shenandoah.git pull/485/head:pull/485` \
`$ git checkout pull/485`

Update a local copy of the PR: \
`$ git checkout pull/485` \
`$ git pull https://git.openjdk.org/shenandoah.git pull/485/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 485`

View PR using the GUI difftool: \
`$ git pr show -t 485`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/shenandoah/pull/485.diff">https://git.openjdk.org/shenandoah/pull/485.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/shenandoah/pull/485#issuecomment-2305444411)