### PR TITLE
8338881: GenShen: Use explicit third temp register for post barrier

### DIFF
--- a/src/hotspot/cpu/aarch64/gc/shenandoah/shenandoahBarrierSetAssembler_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/gc/shenandoah/shenandoahBarrierSetAssembler_aarch64.cpp
@@ -419,7 +419,7 @@ void ShenandoahBarrierSetAssembler::store_at(MacroAssembler* masm, DecoratorSet 
   BarrierSetAssembler::store_at(masm, decorators, type, Address(tmp3, 0), val, noreg, noreg, noreg);
 
   bool in_heap = (decorators & IN_HEAP) != 0;
-  bool needs_post_barrier = val != noreg && in_heap && ShenandoahCardBarrier;
+  bool needs_post_barrier = (val != noreg) && in_heap && ShenandoahCardBarrier;
   if (needs_post_barrier) {
     store_check(masm, tmp3);
   }

--- a/src/hotspot/cpu/aarch64/gc/shenandoah/shenandoahBarrierSetAssembler_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/gc/shenandoah/shenandoahBarrierSetAssembler_aarch64.cpp
@@ -416,21 +416,13 @@ void ShenandoahBarrierSetAssembler::store_at(MacroAssembler* masm, DecoratorSet 
                                val != noreg /* tosca_live */,
                                false /* expand_call */);
 
-  if (val == noreg) {
-    BarrierSetAssembler::store_at(masm, decorators, type, Address(tmp3, 0), noreg, noreg, noreg, noreg);
-  } else {
-    // Barrier needs uncompressed oop for region cross check.
-    Register new_val = val;
-    if (UseCompressedOops) {
-      new_val = rscratch2;
-      __ mov(new_val, val);
-    }
-    BarrierSetAssembler::store_at(masm, decorators, type, Address(tmp3, 0), val, noreg, noreg, noreg);
-    if (ShenandoahCardBarrier) {
-      store_check(masm, r3);
-    }
-  }
+  BarrierSetAssembler::store_at(masm, decorators, type, Address(tmp3, 0), val, noreg, noreg, noreg);
 
+  bool in_heap = (decorators & IN_HEAP) != 0;
+  bool needs_post_barrier = val != noreg && in_heap && ShenandoahCardBarrier;
+  if (needs_post_barrier) {
+    store_check(masm, tmp3);
+  }
 }
 
 void ShenandoahBarrierSetAssembler::try_resolve_jobject_in_native(MacroAssembler* masm, Register jni_env,


### PR DESCRIPTION
* Use register given as `tmp3` argument instead of "out of the blue" `r3`
* Simplify logic for post barrier call

## Testing
GHA, internal pipelines

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed (1 review required, with at least 1 [Committer](https://openjdk.org/bylaws#committer))

### Issue
 * [JDK-8338881](https://bugs.openjdk.org/browse/JDK-8338881): GenShen: Use explicit third temp register for post barrier (**Task** - P4)


### Reviewers
 * [Aleksey Shipilev](https://openjdk.org/census#shade) (@shipilev - Committer) ⚠️ Review applies to [fa7dc0c4](https://git.openjdk.org/shenandoah/pull/486/files/fa7dc0c43bcf7ec88b01b74d3016cb6262d59ebe)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/shenandoah.git pull/486/head:pull/486` \
`$ git checkout pull/486`

Update a local copy of the PR: \
`$ git checkout pull/486` \
`$ git pull https://git.openjdk.org/shenandoah.git pull/486/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 486`

View PR using the GUI difftool: \
`$ git pr show -t 486`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/shenandoah/pull/486.diff">https://git.openjdk.org/shenandoah/pull/486.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/shenandoah/pull/486#issuecomment-2307490312)