### PR TITLE
8339094: Shenandoah: Fix up test output from ShenandoahNumberSeqTest

### DIFF
--- a/test/hotspot/gtest/gc/shenandoah/test_shenandoahNumberSeq.cpp
+++ b/test/hotspot/gtest/gc/shenandoah/test_shenandoahNumberSeq.cpp
@@ -55,9 +55,9 @@ class ShenandoahNumberSeqTest: public ::testing::Test {
   void print(HdrSeq& seq, const char* msg) {
     std::cout << "[";
     for (int i = 0; i <= 100; i += 10) {
-      std::cout << "\t" << seq.percentile(i);
+      std::cout << "\t p" << i << ":" << seq.percentile(i);
     }
-    std::cout << " ] : " << msg << "\n";
+    std::cout << "\t] : " << msg << "\n";
   }
 };
 


### PR DESCRIPTION
/issue JDK-8339094

Shenandoah: Fix up test output from ShenandoahNumberSeqTest

Trivial change: added percentile labels on distribution; slightly adjusted format for readability.

**Testing:**
- [x] make test TEST="gtest:BasicShenandoahNumberSeqTest gtest:ShenandoahNumberSeqMergeTest" w/fastdebug & release

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed (1 review required, with at least 1 [Committer](https://openjdk.org/bylaws#committer))

### Issue
 * [JDK-8339094](https://bugs.openjdk.org/browse/JDK-8339094): Shenandoah: Fix up test output from ShenandoahNumberSeqTest (**Task** - P4)


### Reviewers
 * [William Kemper](https://openjdk.org/census#wkemper) (@earthling-amzn - Committer)
 * [Kelvin Nilsen](https://openjdk.org/census#kdnilsen) (@kdnilsen - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/shenandoah.git pull/487/head:pull/487` \
`$ git checkout pull/487`

Update a local copy of the PR: \
`$ git checkout pull/487` \
`$ git pull https://git.openjdk.org/shenandoah.git pull/487/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 487`

View PR using the GUI difftool: \
`$ git pr show -t 487`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/shenandoah/pull/487.diff">https://git.openjdk.org/shenandoah/pull/487.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/shenandoah/pull/487#issuecomment-2313036111)