### PR TITLE
8339127: GenShen: Restore completed mark context assertion during class unloading

### DIFF
--- a/src/hotspot/share/gc/shenandoah/shenandoahUnload.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahUnload.cpp
@@ -51,8 +51,7 @@ private:
 
 public:
   ShenandoahIsUnloadingOopClosure() :
-    // TODO: In non-generational mode, this should still be complete_marking_context()
-    _marking_context(ShenandoahHeap::heap()->marking_context()),
+    _marking_context(ShenandoahHeap::heap()->complete_marking_context()),
     _is_unloading(false) {
   }
 


### PR DESCRIPTION
We only unload classes during a global GC, so it is safe to assert that marking is complete at this point.

### Testing
GHA, internal pipelines

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed (1 review required, with at least 1 [Committer](https://openjdk.org/bylaws#committer))

### Issue
 * [JDK-8339127](https://bugs.openjdk.org/browse/JDK-8339127): GenShen: Restore completed mark context assertion during class unloading (**Task** - P4)


### Reviewers
 * [Kelvin Nilsen](https://openjdk.org/census#kdnilsen) (@kdnilsen - Committer)
 * [Y. Srinivas Ramakrishna](https://openjdk.org/census#ysr) (@ysramakrishna - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/shenandoah.git pull/488/head:pull/488` \
`$ git checkout pull/488`

Update a local copy of the PR: \
`$ git checkout pull/488` \
`$ git pull https://git.openjdk.org/shenandoah.git pull/488/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 488`

View PR using the GUI difftool: \
`$ git pr show -t 488`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/shenandoah/pull/488.diff">https://git.openjdk.org/shenandoah/pull/488.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/shenandoah/pull/488#issuecomment-2313617927)