### PR TITLE
8339695: GenShen: Concurrent reset performance has regressed

### DIFF
--- a/src/hotspot/share/gc/shenandoah/shenandoahGeneration.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahGeneration.cpp
@@ -43,10 +43,10 @@
 
 
 class ShenandoahResetUpdateRegionStateClosure : public ShenandoahHeapRegionClosure {
- private:
+private:
   ShenandoahHeap* _heap;
   ShenandoahMarkingContext* const _ctx;
- public:
+public:
   ShenandoahResetUpdateRegionStateClosure() :
     _heap(ShenandoahHeap::heap()),
     _ctx(_heap->marking_context()) {}
@@ -64,11 +64,11 @@ class ShenandoahResetUpdateRegionStateClosure : public ShenandoahHeapRegionClosu
 };
 
 class ShenandoahResetBitmapTask : public WorkerTask {
- private:
-    ShenandoahRegionIterator _regions;
-    ShenandoahGeneration* _generation;
+private:
+  ShenandoahRegionIterator _regions;
+  ShenandoahGeneration* _generation;
 
- public:
+public:
   ShenandoahResetBitmapTask(ShenandoahGeneration* generation) :
     WorkerTask("Shenandoah Reset Bitmap"), _generation(generation) {}
 
@@ -88,9 +88,9 @@ class ShenandoahResetBitmapTask : public WorkerTask {
 // Copy the write-version of the card-table into the read-version, clearing the
 // write-copy.
 class ShenandoahMergeWriteTable: public ShenandoahHeapRegionClosure {
- private:
+private:
   ShenandoahScanRemembered* _scanner;
- public:
+public:
   ShenandoahMergeWriteTable(ShenandoahScanRemembered* scanner) : _scanner(scanner) {}
 
   void heap_region_do(ShenandoahHeapRegion* r) override {
@@ -104,9 +104,9 @@ class ShenandoahMergeWriteTable: public ShenandoahHeapRegionClosure {
 };
 
 class ShenandoahCopyWriteCardTableToRead: public ShenandoahHeapRegionClosure {
- private:
+private:
   ShenandoahScanRemembered* _scanner;
- public:
+public:
   ShenandoahCopyWriteCardTableToRead(ShenandoahScanRemembered* scanner) : _scanner(scanner) {}
 
   void heap_region_do(ShenandoahHeapRegion* region) override {

--- a/src/hotspot/share/gc/shenandoah/shenandoahGeneration.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahGeneration.cpp
@@ -52,10 +52,6 @@ class ShenandoahResetUpdateRegionStateClosure : public ShenandoahHeapRegionClosu
     _ctx(_heap->marking_context()) {}
 
   void heap_region_do(ShenandoahHeapRegion* r) override {
-    if (_heap->is_bitmap_slice_committed(r)) {
-      _ctx->clear_bitmap(r);
-    }
-
     if (r->is_active()) {
       // Reset live data and set TAMS optimistically. We would recheck these under the pause
       // anyway to capture any updates that happened since now.
@@ -227,8 +223,8 @@ void ShenandoahGeneration::merge_write_table() {
 }
 
 void ShenandoahGeneration::prepare_gc() {
-  // Invalidate the marking context
-  set_mark_incomplete();
+
+  reset_mark_bitmap();
 
   // Capture Top At Mark Start for this generation (typically young) and reset mark bitmap.
   ShenandoahResetUpdateRegionStateClosure cl;


### PR DESCRIPTION
A misguided optimization inadvertently increased the time to perform the concurrent reset phase of the GC cycle. This "optimization" has been reverted and the time for the phase has returned to normal.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed (1 review required, with at least 1 [Committer](https://openjdk.org/bylaws#committer))

### Issue
 * [JDK-8339695](https://bugs.openjdk.org/browse/JDK-8339695): GenShen: Concurrent reset performance has regressed (**Bug** - P4)


### Reviewers
 * [Aleksey Shipilev](https://openjdk.org/census#shade) (@shipilev - Committer) ⚠️ Review applies to [bd14ca61](https://git.openjdk.org/shenandoah/pull/495/files/bd14ca613c50f4a80ef09b54d7a5ef01a737f7db)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/shenandoah.git pull/495/head:pull/495` \
`$ git checkout pull/495`

Update a local copy of the PR: \
`$ git checkout pull/495` \
`$ git pull https://git.openjdk.org/shenandoah.git pull/495/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 495`

View PR using the GUI difftool: \
`$ git pr show -t 495`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/shenandoah/pull/495.diff">https://git.openjdk.org/shenandoah/pull/495.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/shenandoah/pull/495#issuecomment-2334720080)