### PR TITLE
8340137: GenShen: Reset mark bitmaps when a region is recycled

### DIFF
--- a/src/hotspot/share/gc/shenandoah/shenandoahHeapRegion.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahHeapRegion.cpp
@@ -576,6 +576,10 @@ void ShenandoahHeapRegion::recycle() {
   reset_alloc_metadata();
 
   heap->marking_context()->reset_top_at_mark_start(this);
+  if (heap->is_bitmap_slice_committed(this)) {
+    heap->marking_context()->clear_bitmap(this);
+  }
+
   set_update_watermark(bottom());
 
   make_empty();


### PR DESCRIPTION
Historically, the concurrent reset phase has reset bitmaps for _all_ committed regions. In the generational mode, however, we wish to reset bitmaps for only the generation being collected. This action was recently made to [exclude](https://bugs.openjdk.org/browse/JDK-8332082) [free](https://github.com/openjdk/shenandoah/pull/496/files#diff-21f0a6cd0f9698d813b88d4265dd2b8686a836966789d23de509cd1b9e936ae1R52) regions. This broke an assert for regions that became committed (active) after concurrent reset. To address this, we can reset bitmaps for a region when it is recycled (resets still happen for active regions during concurrent reset).

## Testing
GHA, internal pipelines

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed (1 review required, with at least 1 [Committer](https://openjdk.org/bylaws#committer))

### Issue
 * [JDK-8340137](https://bugs.openjdk.org/browse/JDK-8340137): GenShen: Reset mark bitmaps when a region is recycled (**Bug** - P3)


### Reviewers
 * [Kelvin Nilsen](https://openjdk.org/census#kdnilsen) (@kdnilsen - Committer)
 * [Y. Srinivas Ramakrishna](https://openjdk.org/census#ysr) (@ysramakrishna - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/shenandoah.git pull/500/head:pull/500` \
`$ git checkout pull/500`

Update a local copy of the PR: \
`$ git checkout pull/500` \
`$ git pull https://git.openjdk.org/shenandoah.git pull/500/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 500`

View PR using the GUI difftool: \
`$ git pr show -t 500`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/shenandoah/pull/500.diff">https://git.openjdk.org/shenandoah/pull/500.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/shenandoah/pull/500#issuecomment-2349688253)