### PR TITLE
8340395: GenShen: Remove unnecessary check on card barrier flag

### DIFF
--- a/src/hotspot/share/gc/shenandoah/shenandoahBarrierSet.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahBarrierSet.cpp
@@ -132,11 +132,10 @@ void ShenandoahBarrierSet::on_thread_detach(Thread *thread) {
       gclab->retire();
     }
 
-    if (ShenandoahCardBarrier) {
-      PLAB* plab = ShenandoahThreadLocalData::plab(thread);
-      if (plab != nullptr) {
-        ShenandoahGenerationalHeap::heap()->retire_plab(plab);
-      }
+    PLAB* plab = ShenandoahThreadLocalData::plab(thread);
+    if (plab != nullptr) {
+      // This will assert if plab is not null in non-generational mode
+      ShenandoahGenerationalHeap::heap()->retire_plab(plab);
     }
 
     // SATB protocol requires to keep alive reachable oops from roots at the beginning of GC


### PR DESCRIPTION
PLABs will only be non-null in the generational mode, so we do not need to check the mode before checking if a PLAB is non-null.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed (1 review required, with at least 1 [Committer](https://openjdk.org/bylaws#committer))

### Issue
 * [JDK-8340395](https://bugs.openjdk.org/browse/JDK-8340395): GenShen: Remove unnecessary check on card barrier flag (**Task** - P4)


### Reviewers
 * [Y. Srinivas Ramakrishna](https://openjdk.org/census#ysr) (@ysramakrishna - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/shenandoah.git pull/501/head:pull/501` \
`$ git checkout pull/501`

Update a local copy of the PR: \
`$ git checkout pull/501` \
`$ git pull https://git.openjdk.org/shenandoah.git pull/501/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 501`

View PR using the GUI difftool: \
`$ git pr show -t 501`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/shenandoah/pull/501.diff">https://git.openjdk.org/shenandoah/pull/501.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/shenandoah/pull/501#issuecomment-2358958373)