### PR TITLE
8341042: GenShen: Reset mark bitmaps for unaffiliated regions when preparing for a cycle

### DIFF
--- a/src/hotspot/share/gc/shenandoah/shenandoahGeneration.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahGeneration.cpp
@@ -77,7 +77,8 @@ public:
     ShenandoahHeap* heap = ShenandoahHeap::heap();
     ShenandoahMarkingContext* const ctx = heap->marking_context();
     while (region != nullptr) {
-      if (_generation->contains(region) && heap->is_bitmap_slice_committed(region)) {
+      bool needs_reset = _generation->contains(region) || !region->is_affiliated();
+      if (needs_reset && heap->is_bitmap_slice_committed(region)) {
         ctx->clear_bitmap(region);
       }
       region = _regions.next();

--- a/src/hotspot/share/gc/shenandoah/shenandoahHeapRegion.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahHeapRegion.cpp
@@ -579,14 +579,9 @@ void ShenandoahHeapRegion::recycle() {
 
   set_top(bottom());
   clear_live_data();
-  heap->marking_context()->clear_bitmap(this);
-
   reset_alloc_metadata();
 
   heap->marking_context()->reset_top_at_mark_start(this);
-  if (heap->is_bitmap_slice_committed(this)) {
-    heap->marking_context()->clear_bitmap(this);
-  }
 
   set_update_watermark(bottom());
 


### PR DESCRIPTION
A recent change to reset unaffiliated bitmaps during the concurrent cleanup phase has caused a performance regression. Likely because concurrent cleanup only uses one thread (at this time). This issue is to revert the regression causing change while we work on a preferred solution.