### PR TITLE
8341485: GenShen: Make evac tracker a non-product feature and confine it to generational mode

### DIFF
--- a/src/hotspot/share/gc/shenandoah/shenandoahEvacTracker.hpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahEvacTracker.hpp
@@ -39,7 +39,7 @@ private:
   AgeTable* _age_table;
 
  public:
-  ShenandoahEvacuationStats(bool generational);
+  ShenandoahEvacuationStats();
 
   AgeTable* age_table() const;
 
@@ -59,16 +59,12 @@ struct ShenandoahCycleStats {
 
 class ShenandoahEvacuationTracker : public CHeapObj<mtGC> {
 private:
-  bool _generational;
 
   ShenandoahEvacuationStats _workers_global;
   ShenandoahEvacuationStats _mutators_global;
 
 public:
-  ShenandoahEvacuationTracker(bool generational) :
-   _generational(generational),
-   _workers_global(generational),
-   _mutators_global(generational) {}
+  ShenandoahEvacuationTracker() = default;
 
   void begin_evacuation(Thread* thread, size_t bytes);
   void end_evacuation(Thread* thread, size_t bytes);
@@ -76,8 +72,8 @@ public:
 
   void print_global_on(outputStream* st);
   void print_evacuations_on(outputStream* st,
-                                   ShenandoahEvacuationStats* workers,
-                                   ShenandoahEvacuationStats* mutators);
+                            ShenandoahEvacuationStats* workers,
+                            ShenandoahEvacuationStats* mutators);
 
   ShenandoahCycleStats flush_cycle_to_global();
 };

--- a/src/hotspot/share/gc/shenandoah/shenandoahGenerationalControlThread.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahGenerationalControlThread.cpp
@@ -34,6 +34,7 @@
 #include "gc/shenandoah/shenandoahFreeSet.hpp"
 #include "gc/shenandoah/shenandoahFullGC.hpp"
 #include "gc/shenandoah/shenandoahGeneration.hpp"
+#include "gc/shenandoah/shenandoahGenerationalHeap.hpp"
 #include "gc/shenandoah/shenandoahOldGC.hpp"
 #include "gc/shenandoah/shenandoahOldGeneration.hpp"
 #include "gc/shenandoah/shenandoahHeap.inline.hpp"
@@ -337,7 +338,7 @@ void ShenandoahGenerationalControlThread::run_service() {
   }
 }
 
-void ShenandoahGenerationalControlThread::process_phase_timings(const ShenandoahHeap* heap) {
+void ShenandoahGenerationalControlThread::process_phase_timings(const ShenandoahGenerationalHeap* heap) {
   // Commit worker statistics to cycle data
   heap->phase_timings()->flush_par_workers_to_cycle();
   if (ShenandoahPacing) {
@@ -391,9 +392,9 @@ void ShenandoahGenerationalControlThread::process_phase_timings(const Shenandoah
 //      |        v                                   v       |
 //      +--->  Global Degen +--------------------> Full <----+
 //
-void ShenandoahGenerationalControlThread::service_concurrent_normal_cycle(ShenandoahHeap* heap,
-                                                              const ShenandoahGenerationType generation,
-                                                              GCCause::Cause cause) {
+void ShenandoahGenerationalControlThread::service_concurrent_normal_cycle(ShenandoahGenerationalHeap* heap,
+                                                                          const ShenandoahGenerationType generation,
+                                                                          GCCause::Cause cause) {
   GCIdMark gc_id_mark;
   switch (generation) {
     case YOUNG: {
@@ -421,7 +422,7 @@ void ShenandoahGenerationalControlThread::service_concurrent_normal_cycle(Shenan
   }
 }
 
-void ShenandoahGenerationalControlThread::service_concurrent_old_cycle(ShenandoahHeap* heap, GCCause::Cause &cause) {
+void ShenandoahGenerationalControlThread::service_concurrent_old_cycle(ShenandoahGenerationalHeap* heap, GCCause::Cause &cause) {
   ShenandoahOldGeneration* old_generation = heap->old_generation();
   ShenandoahYoungGeneration* young_generation = heap->young_generation();
   ShenandoahOldGeneration::State original_state = old_generation->state();

--- a/src/hotspot/share/gc/shenandoah/shenandoahGenerationalControlThread.hpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahGenerationalControlThread.hpp
@@ -28,12 +28,15 @@
 
 #include "gc/shared/gcCause.hpp"
 #include "gc/shenandoah/shenandoahController.hpp"
+#include "gc/shenandoah/shenandoahGenerationType.hpp"
 #include "gc/shenandoah/shenandoahGC.hpp"
-#include "gc/shenandoah/shenandoahHeap.hpp"
 #include "gc/shenandoah/shenandoahPadding.hpp"
 #include "gc/shenandoah/shenandoahSharedVariables.hpp"
 
 class ShenandoahOldGeneration;
+class ShenandoahGeneration;
+class ShenandoahGenerationalHeap;
+class ShenandoahHeap;
 
 class ShenandoahGenerationalControlThread: public ShenandoahController {
   friend class VMStructs;
@@ -101,13 +104,13 @@ private:
   // Returns true if the old generation marking was interrupted to allow a young cycle.
   bool preempt_old_marking(ShenandoahGenerationType generation);
 
-  void process_phase_timings(const ShenandoahHeap* heap);
+  void process_phase_timings(const ShenandoahGenerationalHeap* heap);
 
-  void service_concurrent_normal_cycle(ShenandoahHeap* heap,
+  void service_concurrent_normal_cycle(ShenandoahGenerationalHeap* heap,
                                        ShenandoahGenerationType generation,
                                        GCCause::Cause cause);
 
-  void service_concurrent_old_cycle(ShenandoahHeap* heap,
+  void service_concurrent_old_cycle(ShenandoahGenerationalHeap* heap,
                                     GCCause::Cause &cause);
 
   void set_gc_mode(GCMode new_mode);

--- a/src/hotspot/share/gc/shenandoah/shenandoahGenerationalHeap.hpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahGenerationalHeap.hpp
@@ -53,6 +53,8 @@ public:
   }
 
   void print_init_logger() const override;
+  void print_tracing_info() const override;
+
   size_t unsafe_max_tlab_alloc(Thread *thread) const override;
 
 private:
@@ -62,6 +64,8 @@ private:
   ShenandoahSharedFlag  _is_aging_cycle;
   // Age census used for adapting tenuring threshold
   ShenandoahAgeCensus* _age_census;
+  // Used primarily to look for failed evacuation attempts.
+  ShenandoahEvacuationTracker*  _evac_tracker;
 
 public:
   void set_aging_cycle(bool cond) {
@@ -77,11 +81,15 @@ public:
     return _age_census;
   }
 
+  ShenandoahEvacuationTracker* evac_tracker() const {
+    return _evac_tracker;
+  }
+
   // Ages regions that haven't been used for allocations in the current cycle.
   // Resets ages for regions that have been used for allocations.
   void update_region_ages(ShenandoahMarkingContext* ctx);
 
-  oop evacuate_object(oop p, Thread* thread);
+  oop evacuate_object(oop p, Thread* thread) override;
   oop try_evacuate_object(oop p, Thread* thread, ShenandoahHeapRegion* from_region, ShenandoahAffiliation target_gen);
   void evacuate_collection_set(bool concurrent) override;
   void promote_regions_in_place(bool concurrent);

--- a/src/hotspot/share/gc/shenandoah/shenandoahGenerationalHeap.hpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahGenerationalHeap.hpp
@@ -81,7 +81,7 @@ public:
   // Resets ages for regions that have been used for allocations.
   void update_region_ages(ShenandoahMarkingContext* ctx);
 
-  oop evacuate_object(oop p, Thread* thread) override;
+  oop evacuate_object(oop p, Thread* thread);
   oop try_evacuate_object(oop p, Thread* thread, ShenandoahHeapRegion* from_region, ShenandoahAffiliation target_gen);
   void evacuate_collection_set(bool concurrent) override;
   void promote_regions_in_place(bool concurrent);

--- a/src/hotspot/share/gc/shenandoah/shenandoahHeap.hpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahHeap.hpp
@@ -762,7 +762,7 @@ public:
 
   // Evacuates or promotes object src. Returns the evacuated object, either evacuated
   // by this thread, or by some other thread.
-  virtual oop evacuate_object(oop src, Thread* thread);
+  oop evacuate_object(oop src, Thread* thread);
 
   // Call before/after evacuation.
   inline void enter_evacuation(Thread* t);

--- a/src/hotspot/share/gc/shenandoah/shenandoahHeap.hpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahHeap.hpp
@@ -509,7 +509,6 @@ private:
   ShenandoahVerifier*        _verifier;
 
   ShenandoahPhaseTimings*       _phase_timings;
-  ShenandoahEvacuationTracker*  _evac_tracker;
   ShenandoahMmuTracker          _mmu_tracker;
 
 public:
@@ -534,7 +533,6 @@ public:
   ShenandoahPacer*           pacer()             const { return _pacer;             }
 
   ShenandoahPhaseTimings*      phase_timings()   const { return _phase_timings;     }
-  ShenandoahEvacuationTracker* evac_tracker()    const { return _evac_tracker;      }
 
   ShenandoahEvacOOMHandler* oom_evac_handler() { return &_oom_evac_handler; }
 
@@ -762,7 +760,7 @@ public:
 
   // Evacuates or promotes object src. Returns the evacuated object, either evacuated
   // by this thread, or by some other thread.
-  oop evacuate_object(oop src, Thread* thread);
+  virtual oop evacuate_object(oop src, Thread* thread);
 
   // Call before/after evacuation.
   inline void enter_evacuation(Thread* t);

--- a/src/hotspot/share/gc/shenandoah/shenandoahThreadLocalData.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahThreadLocalData.cpp
@@ -45,7 +45,10 @@ ShenandoahThreadLocalData::ShenandoahThreadLocalData() :
   _plab_promoted(0),
   _plab_allows_promotion(true),
   _plab_retries_enabled(true),
-  _evacuation_stats(new ShenandoahEvacuationStats()) {
+  _evacuation_stats(nullptr) {
+  if (ShenandoahHeap::heap()->mode()->is_generational()) {
+    _evacuation_stats = new ShenandoahEvacuationStats();
+  }
 }
 
 ShenandoahThreadLocalData::~ShenandoahThreadLocalData() {

--- a/src/hotspot/share/gc/shenandoah/shenandoahThreadLocalData.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahThreadLocalData.cpp
@@ -45,9 +45,7 @@ ShenandoahThreadLocalData::ShenandoahThreadLocalData() :
   _plab_promoted(0),
   _plab_allows_promotion(true),
   _plab_retries_enabled(true),
-  _evacuation_stats(nullptr) {
-  bool gen_mode = ShenandoahHeap::heap()->mode()->is_generational();
-  _evacuation_stats = new ShenandoahEvacuationStats(gen_mode);
+  _evacuation_stats(new ShenandoahEvacuationStats()) {
 }
 
 ShenandoahThreadLocalData::~ShenandoahThreadLocalData() {

--- a/src/hotspot/share/gc/shenandoah/shenandoahThreadLocalData.hpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahThreadLocalData.hpp
@@ -152,6 +152,7 @@ public:
   }
 
   static ShenandoahEvacuationStats* evacuation_stats(Thread* thread) {
+    shenandoah_assert_generational();
     return data(thread)->_evacuation_stats;
   }
 


### PR DESCRIPTION
During the course of development of the generational mode, we added a feature to keep track of which threads were evacuating objects and how many evacuations lost the race. The instrumentation added unwarranted overhead. This change makes this instrumentation a non-product feature for the generational mode and removes it entirely from the non-generational modes.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed (1 review required, with at least 1 [Committer](https://openjdk.org/bylaws#committer))

### Issue
 * [JDK-8341485](https://bugs.openjdk.org/browse/JDK-8341485): GenShen: Make evac tracker a non-product feature and confine it to generational mode (**Task** - P4)


### Reviewers
 * [Kelvin Nilsen](https://openjdk.org/census#kdnilsen) (@kdnilsen - Committer)
 * [Y. Srinivas Ramakrishna](https://openjdk.org/census#ysr) (@ysramakrishna - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/shenandoah.git pull/506/head:pull/506` \
`$ git checkout pull/506`

Update a local copy of the PR: \
`$ git checkout pull/506` \
`$ git pull https://git.openjdk.org/shenandoah.git pull/506/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 506`

View PR using the GUI difftool: \
`$ git pr show -t 506`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/shenandoah/pull/506.diff">https://git.openjdk.org/shenandoah/pull/506.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/shenandoah/pull/506#issuecomment-2392056277)