### PR TITLE
8342214: GenShen: Reduce code duplication in shFreeSet with iterator abstraction

### DIFF
--- a/src/hotspot/share/gc/shenandoah/shenandoahFreeSet.hpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahFreeSet.hpp
@@ -293,8 +293,7 @@ private:
 
   // Return the address of memory allocated, setting in_new_region to true iff the allocation is taken
   // from a region that was previously empty.  Return nullptr if memory could not be allocated.
-  inline HeapWord* allocate_from_partition_with_affiliation(ShenandoahFreeSetPartitionId which_partition,
-                                                            ShenandoahAffiliation affiliation,
+  inline HeapWord* allocate_from_partition_with_affiliation(ShenandoahAffiliation affiliation,
                                                             ShenandoahAllocRequest& req, bool& in_new_region);
 
   // We re-evaluate the left-to-right allocation bias whenever _alloc_bias_weight is less than zero.  Each time
@@ -336,14 +335,16 @@ private:
   // Update allocation bias and decided whether to allocate from the left or right side of the heap.
   void update_allocation_bias();
 
-  // Search for regions to satisfy allocation request starting from the right, moving to the left.
-  HeapWord* allocate_from_right_to_left(ShenandoahAllocRequest& req, bool& in_new_region);
-
-  // Search for regions to satisfy allocation request starting from the left, moving to the right.
-  HeapWord* allocate_from_left_to_right(ShenandoahAllocRequest& req, bool& in_new_region);
+  // Search for regions to satisfy allocation request using iterator.
+  template<typename Iter>
+  HeapWord* allocate_from_regions(Iter& iterator, ShenandoahAllocRequest &req, bool &in_new_region);
 
   // Handle allocation for collector (for evacuation).
   HeapWord* allocate_for_collector(ShenandoahAllocRequest& req, bool& in_new_region);
+
+  // Search for allocation in region with same affiliation as request, using given iterator.
+  template<typename Iter>
+  HeapWord* allocate_with_affiliation(Iter& iterator, ShenandoahAffiliation affiliation, ShenandoahAllocRequest& req, bool& in_new_region);
 
   // Return true if the respective generation for this request has free regions.
   bool can_allocate_in_new_region(const ShenandoahAllocRequest& req);
@@ -365,7 +366,7 @@ private:
   size_t transfer_empty_regions_from_collector_set_to_mutator_set(ShenandoahFreeSetPartitionId which_collector,
                                                                   size_t max_xfer_regions,
                                                                   size_t& bytes_transferred);
-  size_t transfer_non_empty_regions_from_collector_set_to_mutator_set(ShenandoahFreeSetPartitionId collector_id,
+  size_t transfer_non_empty_regions_from_collector_set_to_mutator_set(ShenandoahFreeSetPartitionId which_collector,
                                                                       size_t max_xfer_regions,
                                                                       size_t& bytes_transferred);
 
@@ -445,7 +446,6 @@ public:
   }
 
   HeapWord* allocate(ShenandoahAllocRequest& req, bool& in_new_region);
-  size_t unsafe_peek_free() const;
 
   /*
    * Internal fragmentation metric: describes how fragmented the heap regions are.


### PR DESCRIPTION
Introduce `ShenandoahLeftRightIterator` and `ShenandoahRightLeftIterator` classes to encapsulate allocation bias to one side of the heap or the other.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed (1 review required, with at least 1 [Committer](https://openjdk.org/bylaws#committer))

### Issue
 * [JDK-8342214](https://bugs.openjdk.org/browse/JDK-8342214): GenShen: Reduce code duplication in shFreeSet with iterator abstraction (**Task** - P4)


### Reviewers
 * [Kelvin Nilsen](https://openjdk.org/census#kdnilsen) (@kdnilsen - Committer)
 * [Y. Srinivas Ramakrishna](https://openjdk.org/census#ysr) (@ysramakrishna - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/shenandoah.git pull/512/head:pull/512` \
`$ git checkout pull/512`

Update a local copy of the PR: \
`$ git checkout pull/512` \
`$ git pull https://git.openjdk.org/shenandoah.git pull/512/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 512`

View PR using the GUI difftool: \
`$ git pr show -t 512`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/shenandoah/pull/512.diff">https://git.openjdk.org/shenandoah/pull/512.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/shenandoah/pull/512#issuecomment-2414731621)