### PR TITLE
8342255: GenShen: Remove unnecessary enum initial values

### DIFF
--- a/src/hotspot/share/gc/shenandoah/shenandoahCardStats.hpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahCardStats.hpp
@@ -29,21 +29,21 @@
 #include "gc/shenandoah/shenandoahNumberSeq.hpp"
 
 enum CardStatType {
-  DIRTY_RUN           = 0,
-  CLEAN_RUN           = 1,
-  DIRTY_CARDS         = 2,
-  CLEAN_CARDS         = 3,
-  MAX_DIRTY_RUN       = 4,
-  MAX_CLEAN_RUN       = 5,
-  DIRTY_SCAN_OBJS     = 6,
-  ALTERNATIONS        = 7,
-  MAX_CARD_STAT_TYPE  = 8
+  DIRTY_RUN,
+  CLEAN_RUN,
+  DIRTY_CARDS,
+  CLEAN_CARDS,
+  MAX_DIRTY_RUN,
+  MAX_CLEAN_RUN,
+  DIRTY_SCAN_OBJS,
+  ALTERNATIONS,
+  MAX_CARD_STAT_TYPE
 };
 
 enum CardStatLogType {
-  CARD_STAT_SCAN_RS       = 0,
-  CARD_STAT_UPDATE_REFS   = 1,
-  MAX_CARD_STAT_LOG_TYPE  = 2
+  CARD_STAT_SCAN_RS,
+  CARD_STAT_UPDATE_REFS,
+  MAX_CARD_STAT_LOG_TYPE
 };
 
 class ShenandoahCardStats: public CHeapObj<mtGC> {


### PR DESCRIPTION
C++ does not require explicit initial values for enumeration members.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed (1 review required, with at least 1 [Committer](https://openjdk.org/bylaws#committer))

### Issue
 * [JDK-8342255](https://bugs.openjdk.org/browse/JDK-8342255): GenShen: Remove unnecessary enum initial values (**Task** - P4)


### Reviewers
 * [Y. Srinivas Ramakrishna](https://openjdk.org/census#ysr) (@ysramakrishna - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/shenandoah.git pull/514/head:pull/514` \
`$ git checkout pull/514`

Update a local copy of the PR: \
`$ git checkout pull/514` \
`$ git pull https://git.openjdk.org/shenandoah.git pull/514/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 514`

View PR using the GUI difftool: \
`$ git pr show -t 514`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/shenandoah/pull/514.diff">https://git.openjdk.org/shenandoah/pull/514.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/shenandoah/pull/514#issuecomment-2415117165)