### PR TITLE
8342564: GenShen: Only reference young/old generation names in generational mode

### DIFF
--- a/src/hotspot/share/gc/shenandoah/shenandoahHeap.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahHeap.cpp
@@ -573,8 +573,12 @@ void ShenandoahHeap::print_on(outputStream* st) const {
 
   st->print("Status: ");
   if (has_forwarded_objects())                 st->print("has forwarded objects, ");
-  if (is_concurrent_old_mark_in_progress())    st->print("old marking, ");
-  if (is_concurrent_young_mark_in_progress())  st->print("young marking, ");
+  if (!mode()->is_generational()) {
+    if (is_concurrent_mark_in_progress())      st->print("marking,");
+  } else {
+    if (is_concurrent_old_mark_in_progress())    st->print("old marking, ");
+    if (is_concurrent_young_mark_in_progress())  st->print("young marking, ");
+  }
   if (is_evacuation_in_progress())             st->print("evacuating, ");
   if (is_update_refs_in_progress())            st->print("updating refs, ");
   if (is_degenerated_gc_in_progress())         st->print("degenerated gc, ");


### PR DESCRIPTION
When printing the heap, only reference young/old marking when running in generational mode.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed (1 review required, with at least 1 [Committer](https://openjdk.org/bylaws#committer))

### Issue
 * [JDK-8342564](https://bugs.openjdk.org/browse/JDK-8342564): GenShen: Only reference young/old generation names in generational mode (**Task** - P4)


### Reviewers
 * [Xiaolong Peng](https://openjdk.org/census#xpeng) (@pengxiaolong - no project role)
 * [Y. Srinivas Ramakrishna](https://openjdk.org/census#ysr) (@ysramakrishna - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/shenandoah.git pull/518/head:pull/518` \
`$ git checkout pull/518`

Update a local copy of the PR: \
`$ git checkout pull/518` \
`$ git pull https://git.openjdk.org/shenandoah.git pull/518/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 518`

View PR using the GUI difftool: \
`$ git pr show -t 518`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/shenandoah/pull/518.diff">https://git.openjdk.org/shenandoah/pull/518.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/shenandoah/pull/518#issuecomment-2420668311)