### PR TITLE
8342927: GenShen: Guarantee slices of time for coalesce and filling

### DIFF
--- a/src/hotspot/share/gc/shenandoah/shenandoah_globals.hpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoah_globals.hpp
@@ -557,12 +557,12 @@
           "Log cumulative card stats every so many remembered set or "      \
           "update refs scans")                                              \
                                                                             \
-  product(uintx, ShenandoahMinimumOldTimeMs, 100, EXPERIMENTAL,         \
-         "Minimum amount of time in milliseconds to run old marking "       \
+  product(uintx, ShenandoahMinimumOldTimeMs, 100, EXPERIMENTAL,             \
+         "Minimum amount of time in milliseconds to run old collections "   \
          "before a young collection is allowed to run. This is intended "   \
          "to prevent starvation of the old collector. Setting this to "     \
          "0 will allow back to back young collections to run during old "   \
-         "marking.")                                                        \
+         "collections.")                                                    \
   // end of GC_SHENANDOAH_FLAGS
 
 #endif // SHARE_GC_SHENANDOAH_SHENANDOAH_GLOBALS_HPP

--- a/src/hotspot/share/gc/shenandoah/shenandoah_globals.hpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoah_globals.hpp
@@ -557,7 +557,7 @@
           "Log cumulative card stats every so many remembered set or "      \
           "update refs scans")                                              \
                                                                             \
-  product(uintx, ShenandoahMinimumOldMarkTimeMs, 100, EXPERIMENTAL,         \
+  product(uintx, ShenandoahMinimumOldTimeMs, 100, EXPERIMENTAL,         \
          "Minimum amount of time in milliseconds to run old marking "       \
          "before a young collection is allowed to run. This is intended "   \
          "to prevent starvation of the old collector. Setting this to "     \


### PR DESCRIPTION
By design, young collections may preempt old collections. However, in some cases, this leads to starvation of old collection cycles. When old generation collections cannot make progress, the system continues to get "backed up" until an eventual degenerated or full GC cleans out the old generation. Genshen already has a mechanism to guarantee progress for old marking. It should be extended to also provide for coalescing and filling.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed (1 review required, with at least 1 [Committer](https://openjdk.org/bylaws#committer))

### Issue
 * [JDK-8342927](https://bugs.openjdk.org/browse/JDK-8342927): GenShen: Guarantee slices of time for coalesce and filling (**Task** - P4)


### Reviewers
 * [Kelvin Nilsen](https://openjdk.org/census#kdnilsen) (@kdnilsen - Committer) ⚠️ Review applies to [e3ee59ba](https://git.openjdk.org/shenandoah/pull/526/files/e3ee59bae2b555931f4f51035916c9af5f67b1af)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/shenandoah.git pull/526/head:pull/526` \
`$ git checkout pull/526`

Update a local copy of the PR: \
`$ git checkout pull/526` \
`$ git pull https://git.openjdk.org/shenandoah.git pull/526/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 526`

View PR using the GUI difftool: \
`$ git pr show -t 526`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/shenandoah/pull/526.diff">https://git.openjdk.org/shenandoah/pull/526.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/shenandoah/pull/526#issuecomment-2433859972)